### PR TITLE
Bug Fix and Typo Fix

### DIFF
--- a/OpenUtau/Core/USTx/UTrack.cs
+++ b/OpenUtau/Core/USTx/UTrack.cs
@@ -12,7 +12,7 @@ namespace OpenUtau.Core.USTx
         public string Comment = string.Empty;
         public USinger Singer;
 
-        public string SingerName { get { if (Singer != null) return Singer.DisplayName; else return "[No Signer]"; } }
+        public string SingerName { get { if (Singer != null) return Singer.DisplayName; else return "[No Singer]"; } }
         public int TrackNo { set; get; }
         public int DisplayTrackNo { get { return TrackNo + 1; } }
         public bool Mute { set; get; }

--- a/OpenUtau/UI/MainWindow.xaml.cs
+++ b/OpenUtau/UI/MainWindow.xaml.cs
@@ -426,20 +426,23 @@ namespace OpenUtau.UI
                 Multiselect = false,
                 CheckFileExists = true
             };
-            if (openFileDialog.ShowDialog() == true) CmdImportAudio(openFileDialog.FileName);
-            var project = DocManager.Inst.Project;
-            var parts = Core.Formats.Midi.Load(openFileDialog.FileName, project);
-
-            DocManager.Inst.StartUndoGroup();
-            foreach (var part in parts)
+            if (openFileDialog.ShowDialog() == true)
             {
-                var track = new UTrack();
-                track.TrackNo = project.Tracks.Count;
-                part.TrackNo = track.TrackNo;
-                DocManager.Inst.ExecuteCmd(new AddTrackCommand(project, track));
-                DocManager.Inst.ExecuteCmd(new AddPartCommand(project, part));
+                CmdImportAudio(openFileDialog.FileName);
+                var project = DocManager.Inst.Project;
+                var parts = Core.Formats.Midi.Load(openFileDialog.FileName, project);
+
+                DocManager.Inst.StartUndoGroup();
+                foreach (var part in parts)
+                {
+                    var track = new UTrack();
+                    track.TrackNo = project.Tracks.Count;
+                    part.TrackNo = track.TrackNo;
+                    DocManager.Inst.ExecuteCmd(new AddTrackCommand(project, track));
+                    DocManager.Inst.ExecuteCmd(new AddPartCommand(project, part));
+                }
+                DocManager.Inst.EndUndoGroup();
             }
-            DocManager.Inst.EndUndoGroup();
         }
 
         private void MenuSingers_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
1. Fix the bug that causes the application to crash when canceling the "Import Midi..." OpenFileDialog.
2. Fix a typo in `UTrack.cs`.