### PR TITLE
Singer character.txt parsing fixes

### DIFF
--- a/OpenUtau/Classic/VoicebankInstaller.cs
+++ b/OpenUtau/Classic/VoicebankInstaller.cs
@@ -96,6 +96,8 @@ namespace OpenUtau.Classic {
                             while (!streamReader.EndOfStream) {
                                 string line = streamReader.ReadLine().Trim();
                                 var s = line.Split(new char[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                                if (s.Length != 2)
+                                    s = line.Split(new string[] { ": " }, StringSplitOptions.RemoveEmptyEntries);
                                 if (s.Length == 2) {
                                     s[0] = s[0].ToLowerInvariant();
                                     if (s[0] == "name") {

--- a/OpenUtau/Classic/VoicebankInstaller.cs
+++ b/OpenUtau/Classic/VoicebankInstaller.cs
@@ -97,7 +97,8 @@ namespace OpenUtau.Classic {
                                 string line = streamReader.ReadLine().Trim();
                                 var s = line.Split(new char[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
                                 if (s.Length != 2)
-                                    s = line.Split(new string[] { ": " }, StringSplitOptions.RemoveEmptyEntries);
+                                    s = line.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+                                Array.ForEach(s, temp => temp.Trim());
                                 if (s.Length == 2) {
                                     s[0] = s[0].ToLowerInvariant();
                                     if (s[0] == "name") {

--- a/OpenUtau/Classic/VoicebankInstaller.cs
+++ b/OpenUtau/Classic/VoicebankInstaller.cs
@@ -106,6 +106,8 @@ namespace OpenUtau.Classic {
                                         voicebank.Image = s[1];
                                     } else if (s[0] == "author") {
                                         voicebank.Author = s[1];
+                                    } else if (s[0] == "created by") {
+                                        voicebank.Author = s[1];
                                     } else if (s[0] == "web") {
                                         voicebank.Web = s[1];
                                     } else {


### PR DESCRIPTION
Some Utau singers, such as the ones at [this site](https://marginalsynth.wixsite.com/utau/) use ": " as a delimiter in their character.txt files rather than "=". For this reason, singers from that site (and potentially other sites) fail to import due to character.txt parsing issues. 

To fix this, I made OpenUtau fall back on attempting to parse using a ": " delimiter if "=" does not work. Now singers from that site load without issue.

I also made it read the "created by" key in character.txt, and set the author information based on that. Now character.txt files that have a "created by" key but no "author" key can still have their author information loaded.

I have successfully tested my changes with [this singer](https://marginalsynth.wixsite.com/utau/sayuri).