### PR TITLE
crash on long envelope & utau pitch extra points

### DIFF
--- a/OpenUtau/Core/Formats/Ust.cs
+++ b/OpenUtau/Core/Formats/Ust.cs
@@ -270,7 +270,7 @@ namespace OpenUtau.Core.Formats {
                 }
                 float p1 = parts[0], p2 = parts[1], p3 = parts[2], v1 = parts[3], v2 = parts[4], v3 = parts[5], v4 = parts[6];
                 if (parts.Length == 11) {
-                    float p4 = parts[8], p5 = parts[9], v5 = parts[11];
+                    float p4 = parts[8], p5 = parts[9], v5 = parts[10];
                 }
                 note.expressions["dec"].value = 100f - v3;
             } catch (Exception e) {
@@ -323,6 +323,8 @@ namespace OpenUtau.Core.Formats {
                 if (!string.IsNullOrWhiteSpace(pbm)) {
                     var m = pbm.Split(new[] { ',' });
                     for (var i = 0; i < m.Count() - 1; i++) {
+                        if (i >= points.Count)
+                            break;
                         switch (m[i]) {
                             case "r":
                                 points[i].shape = PitchPointShape.o;


### PR DESCRIPTION
Invalid Envelope
"E:\Documents\Synths\UST\CVC RUS USTs\представь на мне корону (you should see me in a crown) [Billie Eilish]\p1.ust"
at line 25:
"Envelope=30,0,0,100,100,100,100,%,50,0,100"

Pitch problem note (idk why there are 3 extra shapes, probably utau doesn't delete points correcly):
[#0050]
Length=1387
Lyric=t'i
NoteNum=63
PreUtterance=
Intensity=100
Modulation=0
PBType=5
PitchBend=-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-200,-199,-195,-191,-184,-177,-168,-157,-146,-134,-122,-109,-96,-83,-70,-58,-46,-36,-26,-18,-11,-6,-2,0,0
Envelope=30,575,200,100,100,53,0,%,0,213,72
PBM=,,s,s,
PBS=0
PBW=100
PBStart=-103