### PR TITLE
Fixed and Localization JapaneseCVVCPhonemizer.cs

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
@@ -97,7 +97,6 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             } else if (plainVowels.Contains(currentLyric)) {
                 var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
-
                 // Current note is VV
                 if (vowelLookup.TryGetValue(prevUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
                     currentLyric = $"{vow} {currentLyric}";
@@ -108,72 +107,30 @@ namespace OpenUtau.Plugin.Builtin {
 
                 var nextUnicode = ToUnicodeElements(nextNeighbour?.lyric);
                 var nextLyric = string.Join("", nextUnicode);
-                int Fvcou = 0;
 
                 // Check if next note is a vowel and does not require VC
-                //+Exception detection by avoiding suffix and prefix -surfixとprefixを回避しながら後続母音を決定、母音系統発音の例外も検出
-                
-                for (Fvcou = 0; Fvcou < nextLyric.Length; Fvcou++) {
-                    if (exception.Any(nextLyric.Contains)) {
-                        break;
-                    }
-                    var searchFVF = Convert.ToString(nextLyric.ElementAtOrDefault(Fvcou));
-                    if (searchFVF != string.Empty) {
-                        if (System.Text.RegularExpressions.Regex.IsMatch(searchFVF, @"[\p{IsHiragana}\p{IsKatakana}\p{Ll}\p{Nd}]+")) {
-                            if (plainVowels.Contains(searchFVF)) {
-                                return new Result {
-                                    phonemes = new Phoneme[] {
-                                        new Phoneme() {
-                                            phoneme = currentLyric,
-                                        }
-                                    },
-                                };
+                if (plainVowels.Contains(nextUnicode.FirstOrDefault() ?? string.Empty)) {
+                    return new Result {
+                        phonemes = new Phoneme[] {
+                            new Phoneme() {
+                                phoneme = currentLyric,
                             }
-                        }
-                    }
+                        },
+                    };
                 }
-                
+
                 // Insert VC before next neighbor
                 // Get vowel from current note
 
                 var vowel = "";
-                var vowpre = "";
-                int vcou = 0;
-
-                //+Exclusion extraction of surfix and detail search -surfixを回避しながら本来の母音を検索 
-
-                for (vcou = currentLyric.Length-1; vcou < currentLyric.Length; vcou--) {
-                    var searchvF = Convert.ToString(currentLyric.ElementAtOrDefault(vcou));
-                    if (searchvF != string.Empty) {
-                        if (System.Text.RegularExpressions.Regex.IsMatch(searchvF, @"[\p{IsHiragana}\p{IsKatakana}\p{Ll}\p{Nd}]+")) {
-                            vowpre = string.Concat(vowpre, currentLyric.ElementAtOrDefault(vcou));
-                            break;
-                        }
-                    }
-                }
-
-                if (vowelLookup.TryGetValue(vowpre ?? string.Empty, out var vow)) {
+                if (vowelLookup.TryGetValue(currentUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
                     vowel = vow;
                 }
 
                 // Get consonant from next note
                 var consonant = "";
-                var conpre = "";
-                int cou = 0;
-
-                //Exclusion extraction of prefix and detail search -prefixを回避しながら本来の後続子音を検索
-
-                for (cou = 0; cou < nextLyric.Length; cou++) {
-                    var searchF = Convert.ToString(nextLyric.ElementAtOrDefault(cou));
-                    if (searchF != string.Empty) {
-                        if (System.Text.RegularExpressions.Regex.IsMatch(searchF, @"[\p{IsHiragana}\p{IsKatakana}\p{Ll}\p{Nd}]+")){
-                              conpre = string.Concat(conpre, nextLyric.ElementAtOrDefault(cou));
-                        }
-                    }
-                }
-
-                if (consonantLookup.TryGetValue(conpre ?? string.Empty, out var conmas)){
-                    consonant = conmas;
+                if (consonantLookup.TryGetValue(nextUnicode.FirstOrDefault() ?? string.Empty, out var con)) {
+                    consonant = con;
                 }
 
 
@@ -229,6 +186,3 @@ namespace OpenUtau.Plugin.Builtin {
         }
     }
 }
-
-// JPN_localize_program_arrange_001_@raigeki_denka
-// JPN_localize_program_arrange_002_???


### PR DESCRIPTION
I'm raigeki_denka, who just recently joined the OpenUtau community.
I was very interested in the automatic input of CVVC phonemes, and while remembering the programming I learned a long time ago, I modified it to make it easier for Japanese people to use.
The attached cs file was modified overnight.
I also tested if the changed elements work well.
Please take a look at the comments that describe where you changed.
Since this is my first time using GitHub, I was wondering if it should be listed here, but I can only find it here, so I will post it here.

Roughly change elements
1. Add consonant [ng]
2. Add a string so that a, i, u, e, o correspond to all consonants
3. Fixed checking only the first character, added surfix, prefix detection, and added a function to avoid when VC is generated.
4. Fixed checking only the last character, added surfix, prefix detection, and added a function to avoid when VC is generated.
4. Fixed ゐ (wi) and ゑ (we) being in the "y" line
5. Add "4" to the "r" line
6. Fixed so that single consonants have a smooth connection while avoiding Surfix and Prefix.
7. Exceptional CV using vowel strings so that the appropriate VC is called

JP
1.子音[ng]を追加
2.全ての子音にa,i,u,e,oが対応するように文字列を追加
3.最初の文字しかチェックしない事を修正、surfix、prefixの検出、VC生成時回避するよう機能を追加
4.最後の文字しかチェックしない事を修正、surfix、prefixの検出、VC生成時回避するよう機能を追加
4.ゐ(wi)、ゑ(we)が"y"の行に入っていたのを修正
5."r"の行に"4"を追加
6.SurfixやPrefixを回避しつつ単独子音が滑らかなつながりになるよう修正
7.母音の文字列を使ったCVを例外措置して適切なVCが呼び出されるよう修正