### PR TITLE
fix crash on VoicebankLoader.ParseOto

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -315,7 +315,12 @@ namespace OpenUtau.Classic {
             };
             if (string.IsNullOrEmpty(result.Alias)) {
                 var ext = Path.GetExtension(wav);
-                result.Alias = wav.Replace(ext, "");
+                if (!string.IsNullOrEmpty(ext)) {
+                    result.Alias = wav.Replace(ext, "");
+                }
+                else {
+                    result.Alias = wav;
+                }
             }
             result.Phonetic = result.Alias;
             if (!ParseDouble(parts.Length < 2 ? null : parts[1], out result.Offset)) {


### PR DESCRIPTION
[00:44:16 ERR] Failed to parse
"H:\Program Files (x86)\UTAU\voice\Blue Trey CVC\oto.ini"
at line 2:
"濵濵・wav=,,,,,"
System.ArgumentException: String cannot be of zero length. (Parameter 'oldValue')
   at System.String.Replace(String oldValue, String newValue)
   at OpenUtau.Classic.VoicebankLoader.ParseOto(String line) in H:\External\Github\HeidenBZR\OpenUtau\OpenUtau.Core\Classic\VoicebankLoader.cs:line 318
   at OpenUtau.Classic.VoicebankLoader.ParseOtoSet(Stream stream, String filePath, Encoding encoding) in H:\External\Github\HeidenBZR\OpenUtau\OpenUtau.Core\Classic\VoicebankLoader.cs:line 273