### PR TITLE
fix crash avarar is set but file does not exist

### DIFF
--- a/OpenUtau.Core/Ustx/USinger.cs
+++ b/OpenUtau.Core/Ustx/USinger.cs
@@ -151,16 +151,22 @@ namespace OpenUtau.Core.Ustx {
             Location = Path.GetDirectoryName(voicebank.File);
             if (!string.IsNullOrEmpty(voicebank.Image)) {
                 Avatar = Path.Combine(Location, voicebank.Image);
-                try {
-                    using (var stream = new FileStream(Avatar, FileMode.Open)) {
-                        using (var memoryStream = new MemoryStream()) {
-                            stream.CopyTo(memoryStream);
-                            AvatarData = memoryStream.ToArray();
+                if (File.Exists(Avatar)) {
+                    try {
+                        using (var stream = new FileStream(Avatar, FileMode.Open)) {
+                            using (var memoryStream = new MemoryStream()) {
+                                stream.CopyTo(memoryStream);
+                                AvatarData = memoryStream.ToArray();
+                            }
                         }
+                    } catch (Exception e) {
+                        AvatarData = null;
+                        Log.Error(e, "Failed to load avatar data.");
                     }
-                } catch (Exception e) {
+                }
+                else {
                     AvatarData = null;
-                    Log.Error(e, "Failed to load avatar data.");
+                    Log.Error("Avatar can't be found");
                 }
             }
             if (!string.IsNullOrEmpty(voicebank.Portrait)) {


### PR DESCRIPTION
[00:59:19 ERR] Failed to load avatar data.
System.IO.FileNotFoundException: Could not find file 'H:\Program Files (x86)\UTAU\voice\Gian VCCV old\icon.bmp'.
File name: 'H:\Program Files (x86)\UTAU\voice\Gian VCCV old\icon.bmp'
   at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
   at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode)
   at OpenUtau.Core.Ustx.USinger..ctor(Voicebank voicebank) in H:\External\Github\HeidenBZR\OpenUtau\OpenUtau.Core\Ustx\USinger.cs:line 155