### PR TITLE
Use prevDur only when overlapped

### DIFF
--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -119,7 +119,7 @@ namespace OpenUtau.Core.Ustx {
                     autoPreutter = maxPreutter;
                     autoOverlap *= ratio;
                 }
-                if (autoPreutter > prevDur * 0.9f) {
+                if (autoPreutter > prevDur * 0.9f && overlapped) {
                     float delta = autoPreutter - prevDur * 0.9f;
                     autoPreutter -= delta;
                     autoOverlap -= delta;


### PR DESCRIPTION
Fixes bug where short notes affected next preutterance even when notes were non-adjacent

![preutt bug](https://user-images.githubusercontent.com/26780012/149942284-f32d5bb6-5f52-472e-ad25-eeecdac9b6c5.gif)
