### PR TITLE
Add setting for playhead tracking position

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -95,6 +95,7 @@ namespace OpenUtau.Core.Util {
             public bool ResamplerLogging = false;
             public Dictionary<string, string> SingerPhonemizers = new Dictionary<string, string>();
             public bool PreferPortAudio = false;
+            public double PlayPosMarkerMargin = 0.9;
         }
     }
 }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -160,6 +160,7 @@ Hold Ctrl to select more</system:String>
   <system:String x:Key="prefs.playback.backend">Audio Backend</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>
   <system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>
+  <system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>
   <system:String x:Key="prefs.playback.device">Playback Device</system:String>
   <system:String x:Key="prefs.playback.test">Test</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>

--- a/OpenUtau/Strings/Strings.es-ES.axaml
+++ b/OpenUtau/Strings/Strings.es-ES.axaml
@@ -160,6 +160,7 @@ Hold Ctrl to select more</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <system:String x:Key="prefs.playback.cursorposition">Posición del cursor</system:String>
   <system:String x:Key="prefs.playback.device">Dispositivo de reproducción</system:String>
   <system:String x:Key="prefs.playback.test">Probar</system:String>
   <!--<system:String x:Key="prefs.rendering">Rendering</system:String>-->

--- a/OpenUtau/Strings/Strings.es-MX.axaml
+++ b/OpenUtau/Strings/Strings.es-MX.axaml
@@ -160,6 +160,7 @@ Mantiene Ctrl para seleccionar más</system:String>
   <system:String x:Key="prefs.playback.backend">Backend de Audio</system:String>
   <system:String x:Key="prefs.playback.backend.auto">Escoger Automáticamente</system:String>
   <system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>
+  <system:String x:Key="prefs.playback.cursorposition">Posición del Cursor</system:String>
   <system:String x:Key="prefs.playback.device">Dispositivo de Reproducción</system:String>
   <system:String x:Key="prefs.playback.test">Probar</system:String>
   <system:String x:Key="prefs.rendering">Renderización</system:String>

--- a/OpenUtau/Strings/Strings.fi-FI.axaml
+++ b/OpenUtau/Strings/Strings.fi-FI.axaml
@@ -160,6 +160,7 @@ Aktivoi monivalinta pitämällä Ctrl pohjassa</system:String>
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">Äänentoistolaite</system:String>
   <system:String x:Key="prefs.playback.test">Testaa</system:String>
   <system:String x:Key="prefs.rendering">Renderöi</system:String>

--- a/OpenUtau/Strings/Strings.fr-FR.axaml
+++ b/OpenUtau/Strings/Strings.fr-FR.axaml
@@ -160,6 +160,7 @@ Hold Ctrl to select more</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">Audio de sortie</system:String>
   <!--<system:String x:Key="prefs.playback.test">Test</system:String>-->
   <system:String x:Key="prefs.rendering">Render</system:String>

--- a/OpenUtau/Strings/Strings.id-ID.axaml
+++ b/OpenUtau/Strings/Strings.id-ID.axaml
@@ -160,6 +160,7 @@ Tahan Ctrl untuk memilih lainnya</system:String>
   <!--<system:String x:Key="prefs.playback.backend">Latar Belakang Audio</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Otomatis</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">Perangkat Pemutaran</system:String>
   <system:String x:Key="prefs.playback.test">Tes</system:String>
   <system:String x:Key="prefs.rendering">Merender</system:String>

--- a/OpenUtau/Strings/Strings.it-IT.axaml
+++ b/OpenUtau/Strings/Strings.it-IT.axaml
@@ -160,6 +160,7 @@ Tieni premuto click sinistro + Ctrl per selezionare più note</system:String>
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <system:String x:Key="prefs.playback.cursorposition">Posizione del cursore</system:String>
   <system:String x:Key="prefs.playback.device">Dispositivo audio</system:String>
   <!--<system:String x:Key="prefs.playback.test">Test</system:String>-->
   <system:String x:Key="prefs.rendering">Renderizzazione</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -160,6 +160,7 @@ Ctrl長押しで複数選択</system:String>
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">再生デバイス</system:String>
   <system:String x:Key="prefs.playback.test">再生テスト</system:String>
   <system:String x:Key="prefs.rendering">レンダリング</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -160,6 +160,7 @@ Hold Ctrl to select more</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">재생 장치</system:String>
   <system:String x:Key="prefs.playback.test">테스트</system:String>
   <system:String x:Key="prefs.rendering">렌더링</system:String>

--- a/OpenUtau/Strings/Strings.nl-NL.axaml
+++ b/OpenUtau/Strings/Strings.nl-NL.axaml
@@ -160,6 +160,7 @@ Hold Ctrl to select more</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">Afspeelapparaat</system:String>
   <!--<system:String x:Key="prefs.playback.test">Test</system:String>-->
   <system:String x:Key="prefs.rendering">Renderen</system:String>

--- a/OpenUtau/Strings/Strings.pl-PL.axaml
+++ b/OpenUtau/Strings/Strings.pl-PL.axaml
@@ -160,6 +160,7 @@ Hold Ctrl to select more</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">Użądzenie Odtwarzania</system:String>
   <!--<system:String x:Key="prefs.playback.test">Test</system:String>-->
   <system:String x:Key="prefs.rendering">Renderowanie</system:String>

--- a/OpenUtau/Strings/Strings.pt-BR.axaml
+++ b/OpenUtau/Strings/Strings.pt-BR.axaml
@@ -160,6 +160,7 @@ Segure Ctrl para selecionar mais notas</system:String>
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <system:String x:Key="prefs.playback.cursorposition">Posição do Cursor</system:String>
   <system:String x:Key="prefs.playback.device">Dispositivo de Reprodução</system:String>
   <system:String x:Key="prefs.playback.test">Teste</system:String>
   <system:String x:Key="prefs.rendering">Renderização</system:String>

--- a/OpenUtau/Strings/Strings.vi-VN.axaml
+++ b/OpenUtau/Strings/Strings.vi-VN.axaml
@@ -160,6 +160,7 @@ Nhấn giữ Ctrl để chọn đồng loạt nhiều nốt</system:String>
   <!--<system:String x:Key="prefs.playback.backend">Audio Backend</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.auto">Automatic</system:String>-->
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">Thiết bị phát lại</system:String>
   <system:String x:Key="prefs.playback.test">Nghe thử</system:String>
   <system:String x:Key="prefs.rendering">Render</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -160,6 +160,7 @@
   <system:String x:Key="prefs.playback.backend">音频后端</system:String>
   <system:String x:Key="prefs.playback.backend.auto">自动</system:String>
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <!--<system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>-->
   <system:String x:Key="prefs.playback.device">回放设备</system:String>
   <system:String x:Key="prefs.playback.test">测试</system:String>
   <system:String x:Key="prefs.rendering">渲染</system:String>

--- a/OpenUtau/ViewConstants.cs
+++ b/OpenUtau/ViewConstants.cs
@@ -49,7 +49,5 @@ namespace OpenUtau.App {
         public const int ExpressionHiddenZIndex = 0;
         public const int ExpressionVisibleZIndex = 200;
         public const int ExpressionShadowZIndex = 100;
-
-        public const double PlayPosMarkerMargin = 0.92;
     }
 }

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -433,7 +433,7 @@ namespace OpenUtau.App.ViewModels {
             double playPosX = TickToneToPoint(tick, 0).X;
             double scroll = 0;
             if (!noScroll && playPosX > PlayPosX) {
-                double margin = ViewConstants.PlayPosMarkerMargin * Bounds.Width;
+                double margin = Preferences.Default.PlayPosMarkerMargin * Bounds.Width;
                 if (playPosX > margin) {
                     scroll = playPosX - margin;
                 }

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -25,6 +25,7 @@ namespace OpenUtau.App.ViewModels {
             set => this.RaiseAndSetIfChanged(ref audioOutputDevice, value);
         }
         [Reactive] public int PreferPortAudio { get; set; }
+        [Reactive] public double PlayPosMarkerMargin { get; set; }
         public string AdditionalSingersPath => PathManager.Inst.AdditionalSingersPath;
         public List<int> PrerenderThreadsItems { get; }
         public int PrerenderThreads {
@@ -68,6 +69,7 @@ namespace OpenUtau.App.ViewModels {
                 }
             }
             PreferPortAudio = Preferences.Default.PreferPortAudio ? 1 : 0;
+            PlayPosMarkerMargin = Preferences.Default.PlayPosMarkerMargin;
             PrerenderThreadsItems = Enumerable.Range(1, 16).ToList();
             PrerenderThreads = Preferences.Default.PrerenderThreads;
             ResamplerDrivers.Search();
@@ -118,6 +120,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.PreferPortAudio)
                 .Subscribe(index => {
                     Preferences.Default.PreferPortAudio = index > 0;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.PlayPosMarkerMargin)
+                .Subscribe(playPosMarkerMargin => {
+                    Preferences.Default.PlayPosMarkerMargin = playPosMarkerMargin;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.PrerenderThreads)

--- a/OpenUtau/ViewModels/TracksViewModel.cs
+++ b/OpenUtau/ViewModels/TracksViewModel.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using DynamicData.Binding;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -255,7 +256,7 @@ namespace OpenUtau.App.ViewModels {
             double playPosX = TickTrackToPoint(tick, 0).X;
             double scroll = 0;
             if (!noScroll && playPosX > PlayPosX) {
-                double margin = ViewConstants.PlayPosMarkerMargin * Bounds.Width;
+                double margin = Preferences.Default.PlayPosMarkerMargin * Bounds.Width;
                 if (playPosX > margin) {
                     scroll = playPosX - margin;
                 }

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -28,6 +28,9 @@
               <ComboBoxItem Content="{DynamicResource prefs.playback.backend.port}"/>
             </ComboBox>
             <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.note.restart}"/>
+            <TextBlock Margin="0,4,0,0" Text="{DynamicResource prefs.playback.cursorposition}" />
+            <Slider Value="{Binding PlayPosMarkerMargin}" Minimum="0" Maximum="1"
+                    TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"/>
           </StackPanel>
         </HeaderedContentControl>
         <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.paths}">


### PR DESCRIPTION
This PR adds a setting in the preferences dialog to allow the user to change the position at which the playhead will be tracked during playback.