### PR TITLE
Add .rudb to meta file list to support an old engine RUCE

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankFiles.cs
+++ b/OpenUtau.Core/Classic/VoicebankFiles.cs
@@ -49,6 +49,7 @@ namespace OpenUtau.Classic {
                 Tuple.Create(source + ".frc", sourceTemp + ".frc"),
                 Tuple.Create(source + ".pmk", sourceTemp + ".pmk"),
                 Tuple.Create(source + ".vs4ufrq", sourceTemp + ".vs4ufrq"),
+                Tuple.Create(noExt + ".rudb", tempNoExt + ".rudb"),
             };
         }
 


### PR DESCRIPTION
RUCE is an old UTAU engine, a part of Rocaloid project (now discontinued). It uses its own intermediate sound model file with *.rudb extension. Adding rudb files to meta file list, and then RUCE will work in OpenUTAU.