### PR TITLE
Add an option to move back cursor on pausing

### DIFF
--- a/OpenUtau.Core/PlaybackManager.cs
+++ b/OpenUtau.Core/PlaybackManager.cs
@@ -59,6 +59,7 @@ namespace OpenUtau.Core {
         List<Fader> faders;
         MasterAdapter masterMix;
         double startMs;
+        public int StartTick => DocManager.Inst.Project.MillisecondToTick(startMs);
         CancellationTokenSource renderCancellation;
 
         public Audio.IAudioOutput AudioOutput { get; set; } = new Audio.DummyAudioOutput();

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -97,6 +97,7 @@ namespace OpenUtau.Core.Util {
             public Dictionary<string, string> SingerPhonemizers = new Dictionary<string, string>();
             public bool PreferPortAudio = false;
             public double PlayPosMarkerMargin = 0.9;
+            public int LockStartTime = 0;
             public int PlaybackAutoScroll = 1;
         }
     }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -174,6 +174,9 @@ Hold Ctrl to select more</system:String>
   <system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>
   <system:String x:Key="prefs.playback.cursorposition">Cursor Position</system:String>
   <system:String x:Key="prefs.playback.device">Playback Device</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime">On Pausing</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime.off">Do nothing</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime.on">Move cursor back to where you started playing</system:String>
   <system:String x:Key="prefs.playback.test">Test</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -166,6 +166,9 @@
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">播放标记位置</system:String>
   <system:String x:Key="prefs.playback.device">回放设备</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime">暂停时</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime.off">什么都不做</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime.on">将播放标记移回开始播放处</system:String>
   <system:String x:Key="prefs.playback.test">测试</system:String>
   <system:String x:Key="prefs.rendering">渲染</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">相位修正</system:String>

--- a/OpenUtau/ViewModels/PlaybackViewModel.cs
+++ b/OpenUtau/ViewModels/PlaybackViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using ReactiveUI;
 
 namespace OpenUtau.App.ViewModels {
@@ -26,7 +27,12 @@ namespace OpenUtau.App.ViewModels {
             DocManager.Inst.ExecuteCmd(new SeekPlayPosTickNotification(Project.EndTick));
         }
         public bool PlayOrPause() {
-            return PlaybackManager.Inst.PlayOrPause();
+            var ret = PlaybackManager.Inst.PlayOrPause();
+            var lockStartTime = Convert.ToBoolean(Preferences.Default.LockStartTime);
+            if (!PlaybackManager.Inst.Playing && lockStartTime) {
+                DocManager.Inst.ExecuteCmd(new SeekPlayPosTickNotification(PlaybackManager.Inst.StartTick));
+            }
+            return ret;
         }
         public void Pause() {
             PlaybackManager.Inst.PausePlayback();

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -27,6 +27,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int PreferPortAudio { get; set; }
         [Reactive] public int PlaybackAutoScroll { get; set; }
         [Reactive] public double PlayPosMarkerMargin { get; set; }
+        [Reactive] public int LockStartTime { get; set; }
         public string AdditionalSingersPath => PathManager.Inst.AdditionalSingersPath;
         [Reactive] public int InstallToAdditionalSingersPath { get; set; }
         public List<IResampler>? Resamplers { get; }
@@ -63,6 +64,7 @@ namespace OpenUtau.App.ViewModels {
             PreferPortAudio = Preferences.Default.PreferPortAudio ? 1 : 0;
             PlaybackAutoScroll = Preferences.Default.PlaybackAutoScroll;
             PlayPosMarkerMargin = Preferences.Default.PlayPosMarkerMargin;
+            LockStartTime = Preferences.Default.LockStartTime;
             InstallToAdditionalSingersPath = Preferences.Default.InstallToAdditionalSingersPath ? 1 : 0;
             Classic.Resamplers.Search();
             Resamplers = Classic.Resamplers.GetResamplers();
@@ -117,6 +119,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.PlayPosMarkerMargin)
                 .Subscribe(playPosMarkerMargin => {
                     Preferences.Default.PlayPosMarkerMargin = playPosMarkerMargin;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.LockStartTime)
+                .Subscribe(lockStartTime => {
+                    Preferences.Default.LockStartTime = lockStartTime;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.InstallToAdditionalSingersPath)

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -33,6 +33,11 @@
                 <ComboBoxItem Content="{DynamicResource prefs.off}"/>
                 <ComboBoxItem Content="{DynamicResource prefs.on}"/>
             </ComboBox>
+            <TextBlock Text="{DynamicResource prefs.playback.lockstarttime}"/>
+            <ComboBox HorizontalAlignment="Stretch" SelectedIndex="{Binding LockStartTime}">
+                <ComboBoxItem Content="{DynamicResource prefs.playback.lockstarttime.off}"/>
+                <ComboBoxItem Content="{DynamicResource prefs.playback.lockstarttime.on}"/>
+            </ComboBox>
             <Grid ColumnDefinitions="Auto,8,20,8,*" Margin="0,4,0,0">
               <TextBlock Grid.Column="0" Text="{DynamicResource prefs.playback.cursorposition}"/>
               <TextBlock Grid.Column="2">


### PR DESCRIPTION
Closes #114

---

One thing to notice is that `PlaybackManager` is at present not good at seeking to a new position. User experience would be better if the `Task` or the `RenderEngine` created in `PlaybackManager.Render` could be reused after seeking. I'll create a seperate issue later to track this.