### PR TITLE
Use b@ instead of bV

### DIFF
--- a/OpenUtau.Plugin.Builtin/TetoEnglishPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/TetoEnglishPhonemizer.cs
@@ -6,8 +6,8 @@ using OpenUtau.Api;
 using Serilog;
 
 namespace OpenUtau.Plugin.Builtin {
-    [Phonemizer("English Delta Phonemizer", "EN DELTA", "nago & Heiden.BZR")]
-    public class EnglishDeltaPhonemizer : SyllableBasedPhonemizer {
+    [Phonemizer("Teto English Phonemizer", "EN Teto", "nago & Heiden.BZR")]
+    public class TetoEnglishPhonemizer : SyllableBasedPhonemizer {
 
         private readonly string[] vowels = "a,A,@,{,V,O,aU,aI,E,3,eI,I,i,oU,OI,U,u".Split(",");
         private readonly string[] consonants = "b,tS,d,D,f,g,h,dZ,k,l,m,n,N,p,r,s,S,t,T,v,w,j,z,Z".Split(",");
@@ -204,6 +204,14 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             }
             return phonemes;
+        }
+
+        protected override string ValidateAlias(string alias) {
+            if (alias == "- bV" || alias == "bV" || alias == "V b" || alias == "V b-") {
+                return alias.Replace('V', '@');
+            } else {
+                return base.ValidateAlias(alias);
+            }
         }
     }
 }


### PR DESCRIPTION
Teto English lacks the `bVbVb` sample and all associated OTO entries, so it's replaced with the corresponding phonemes from `b@b@b`.