### PR TITLE
Add note defaults & presets

### DIFF
--- a/OpenUtau.Core/Commands/ExpCommands.cs
+++ b/OpenUtau.Core/Commands/ExpCommands.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 
 namespace OpenUtau.Core {
     public abstract class ExpCommand : UCommand {
@@ -175,8 +176,10 @@ namespace OpenUtau.Core {
             Note = note;
             oldPitch = note.pitch;
             newPitch = new UPitch();
-            newPitch.AddPoint(new PitchPoint(-40, 0));
-            newPitch.AddPoint(new PitchPoint(40, 0));
+            int start = NotePresets.Default.DefaultPortamento.PortamentoStart;
+            int length = NotePresets.Default.DefaultPortamento.PortamentoLength;
+            newPitch.AddPoint(new PitchPoint(start, 0));
+            newPitch.AddPoint(new PitchPoint(start + length, 0));
         }
         public override string ToString() => "Reset pitch points";
         public override void Execute() => Note.pitch = newPitch;

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 
 namespace OpenUtau.Core.Editing {
     public class AddTailNote : BatchEdit {
@@ -115,7 +116,7 @@ namespace OpenUtau.Core.Editing {
         private string name;
 
         public ClearVibratos() {
-            name = "pianoroll.menu.notes.reset.vibratos";
+            name = "pianoroll.menu.notes.clear.vibratos";
         }
 
         public void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager) {
@@ -123,6 +124,34 @@ namespace OpenUtau.Core.Editing {
             docManager.StartUndoGroup(true);
             foreach (var note in notes) {
                 if (note.vibrato.length > 0) {
+                    docManager.ExecuteCmd(new VibratoLengthCommand(part, note, 0));
+                }
+            }
+            docManager.EndUndoGroup();
+        }
+    }
+
+    public class ResetVibratos : BatchEdit {
+        public virtual string Name => name;
+
+        private string name;
+
+        public ResetVibratos() {
+            name = "pianoroll.menu.notes.reset.vibratos";
+        }
+
+        public void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager) {
+            var notes = selectedNotes.Count > 0 ? selectedNotes : part.notes.ToList();
+            docManager.StartUndoGroup(true);
+            foreach (var note in notes) {
+                docManager.ExecuteCmd(new VibratoPeriodCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoPeriod));
+                docManager.ExecuteCmd(new VibratoDepthCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoDepth));
+                docManager.ExecuteCmd(new VibratoFadeInCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoIn));
+                docManager.ExecuteCmd(new VibratoFadeOutCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoOut));
+                docManager.ExecuteCmd(new VibratoShiftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoShift));
+                if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) {
+                    docManager.ExecuteCmd(new VibratoLengthCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoLength));
+                } else {
                     docManager.ExecuteCmd(new VibratoLengthCommand(part, note, 0));
                 }
             }

--- a/OpenUtau.Core/Format/Midi.cs
+++ b/OpenUtau.Core/Format/Midi.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using NAudio.Midi;
 
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 
 namespace OpenUtau.Core.Format
 {
@@ -31,6 +32,7 @@ namespace OpenUtau.Core.Format
                             _e.NoteNumber,
                             (int)_e.AbsoluteTime * project.resolution / midi.DeltaTicksPerQuarterNote,
                             _e.NoteLength * project.resolution / midi.DeltaTicksPerQuarterNote);
+                        if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) note.vibrato.length = NotePresets.Default.DefaultVibrato.VibratoLength;
                         parts[e.Channel].notes.Add(note);
                     }
                 foreach (var pair in parts)

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Text.RegularExpressions;
 using OpenUtau.Api;
+using OpenUtau.Core.Util;
 using YamlDotNet.Serialization;
 
 namespace OpenUtau.Core.Ustx {
@@ -13,7 +14,7 @@ namespace OpenUtau.Core.Ustx {
         public int position;
         public int duration;
         public int tone;
-        public string lyric = "a";
+        public string lyric = NotePresets.Default.DefaultLyric;
         public UPitch pitch;
         public UVibrato vibrato;
 
@@ -198,15 +199,15 @@ namespace OpenUtau.Core.Ustx {
         // Vibrato percentage of note length.
         float _length;
         // Period in milliseconds.
-        float _period = 175f;
+        float _period = NotePresets.Default.DefaultVibrato.VibratoPeriod;
         // Depth in cents (1 semitone = 100 cents).
-        float _depth = 25f;
+        float _depth = NotePresets.Default.DefaultVibrato.VibratoDepth;
         // Fade-in percentage of vibrato length.
-        float _in = 10f;
+        float _in = NotePresets.Default.DefaultVibrato.VibratoIn;
         // Fade-out percentage of vibrato length.
-        float _out = 10f;
+        float _out = NotePresets.Default.DefaultVibrato.VibratoOut;
         // Shift percentage of period length.
-        float _shift;
+        float _shift = NotePresets.Default.DefaultVibrato.VibratoShift;
         float _drift;
 
         public float length { get => _length; set => _length = Math.Max(0, Math.Min(100, value)); }

--- a/OpenUtau.Core/Ustx/UProject.cs
+++ b/OpenUtau.Core/Ustx/UProject.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenUtau.Core.Util;
 using YamlDotNet.Serialization;
 
 namespace OpenUtau.Core.Ustx {
@@ -43,8 +44,10 @@ namespace OpenUtau.Core.Ustx {
 
         public UNote CreateNote() {
             UNote note = UNote.Create();
-            note.pitch.AddPoint(new PitchPoint(-40, 0));
-            note.pitch.AddPoint(new PitchPoint(40, 0));
+            int start = NotePresets.Default.DefaultPortamento.PortamentoStart;
+            int length = NotePresets.Default.DefaultPortamento.PortamentoLength;
+            note.pitch.AddPoint(new PitchPoint(start, 0));
+            note.pitch.AddPoint(new PitchPoint(start + length, 0));
             return note;
         }
 

--- a/OpenUtau.Core/Util/NotePresets.cs
+++ b/OpenUtau.Core/Util/NotePresets.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+using Serilog;
+
+namespace OpenUtau.Core.Util {
+    public static class NotePresets {
+        public static SerializableNotePresets Default;
+
+        static NotePresets() {
+            Load();
+        }
+
+        public static void Save() {
+            try {
+                File.WriteAllText(PathManager.Inst.NotePresetsFilePath,
+                    JsonConvert.SerializeObject(Default, Formatting.Indented),
+                    Encoding.UTF8);
+            } catch (Exception e) {
+                Log.Error(e, "Failed to save note presets.");
+            }
+        }
+
+        private static void Load() {
+            try {
+                if (File.Exists(PathManager.Inst.NotePresetsFilePath)) {
+                    Default = JsonConvert.DeserializeObject<SerializableNotePresets>(
+                        File.ReadAllText(PathManager.Inst.NotePresetsFilePath, Encoding.UTF8));
+                } else {
+                    Reset();
+                }
+            } catch (Exception e) {
+                Log.Error(e, "Failed to load prefs.");
+                Default = new SerializableNotePresets();
+            }
+        }
+
+        public static void Reset() {
+            Default = new SerializableNotePresets();
+            Default.PortamentoPresets.AddRange(new List<PortamentoPreset> {
+                new PortamentoPreset("Standard", 80, -40),
+                new PortamentoPreset("Fast", 50, -25),
+                new PortamentoPreset("Slow", 120, -60),
+                new PortamentoPreset("Snap", 2, -1),
+            });
+            Default.VibratoPresets.AddRange(new List<VibratoPreset> {
+                new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0),
+                new VibratoPreset("UTAU Default", 65, 180, 35, 20, 20, 0),
+                new VibratoPreset("UTAU Strong", 65, 210, 55, 25, 25, 0),
+                new VibratoPreset("UTAU Weak", 65, 165, 20, 25, 25, 0)
+            });
+
+            Save();
+        }
+
+        [Serializable]
+        public class SerializableNotePresets {
+            public string DefaultLyric = "a";
+            public PortamentoPreset DefaultPortamento = new PortamentoPreset("Standard", 80, -40);
+            public List<PortamentoPreset> PortamentoPresets = new List<PortamentoPreset> { };
+            public VibratoPreset DefaultVibrato = new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0);
+            public List<VibratoPreset> VibratoPresets = new List<VibratoPreset> { };
+            public bool AutoVibratoToggle = false;
+            public int AutoVibratoNoteDuration = 481;
+        }
+
+        public class PortamentoPreset {
+            public string Name = "Default";
+            public int PortamentoLength = 80;
+            public int PortamentoStart = -40;
+
+            public PortamentoPreset (string name, int length, int start) {
+                Name = name;
+                PortamentoLength = length;
+                PortamentoStart = start;
+            }
+
+            public override string ToString() => Name;
+        }
+
+        public class VibratoPreset {
+            public string Name = "Default";
+            public float VibratoLength = 75;
+            public float VibratoPeriod = 175;
+            public float VibratoDepth = 25;
+            public float VibratoIn = 10;
+            public float VibratoOut = 10;
+            public float VibratoShift = 0;
+
+            public VibratoPreset(string name, float length, float period, float depth, float fadein, float fadeout, float shift) {
+                Name = name;
+                VibratoLength = length;
+                VibratoPeriod = period;
+                VibratoDepth = depth;
+                VibratoIn = fadein;
+                VibratoOut = fadeout;
+                VibratoShift = shift;
+            }
+
+            public override string ToString() => Name;
+        }
+
+    }
+}

--- a/OpenUtau.Core/Util/PathManager.cs
+++ b/OpenUtau.Core/Util/PathManager.cs
@@ -53,6 +53,7 @@ namespace OpenUtau.Core {
         public string TemplatesPath => Path.Combine(HomePath, "Templates");
         public string LogFilePath => Path.Combine(HomePath, "Logs", "log.txt");
         public string PrefsFilePath => Path.Combine(HomePath, "prefs.json");
+        public string NotePresetsFilePath => Path.Combine(HomePath, "notepresets.json");
         public string CachePath => Path.Combine(HomePath, "Cache");
 
         public string GetPartSavePath(string projectPath, int partNo) {

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -99,6 +99,30 @@
   <system:String x:Key="menu.tools.singer.installadv">Install Singer (Advanced)...</system:String>
   <system:String x:Key="menu.tools.singers">Singers...</system:String>
 
+  <system:String x:Key="notedefaults.lyric">Lyric</system:String>
+  <system:String x:Key="notedefaults.lyric.defaultlyric">Default Lyric</system:String>
+  <system:String x:Key="notedefaults.portamento">Portamento</system:String>
+  <system:String x:Key="notedefaults.portamento.length">Length</system:String>
+  <system:String x:Key="notedefaults.portamento.start">Start</system:String>
+  <system:String x:Key="notedefaults.preset">Preset</system:String>
+  <system:String x:Key="notedefaults.preset.remove">Remove</system:String>
+  <system:String x:Key="notedefaults.preset.remove.tooltip">Removes last applied preset.</system:String>
+  <system:String x:Key="notedefaults.preset.save">Save</system:String>
+  <system:String x:Key="notedefaults.preset.save.tooltip">Save current settings to a new preset.</system:String>
+  <system:String x:Key="notedefaults.preset.namenew">New Preset Name</system:String>
+  <system:String x:Key="notedefaults.reset">Reset All Settings</system:String>
+  <system:String x:Key="notedefaults.reset.tooltip">Reset every setting to default values.
+Warning: this option removes custom presets.</system:String>
+  <system:String x:Key="notedefaults.vibrato">Vibrato</system:String>
+  <system:String x:Key="notedefaults.vibrato.length">Length</system:String>
+  <system:String x:Key="notedefaults.vibrato.period">Period</system:String>
+  <system:String x:Key="notedefaults.vibrato.depth">Depth</system:String>
+  <system:String x:Key="notedefaults.vibrato.in">Fade In</system:String>
+  <system:String x:Key="notedefaults.vibrato.out">Fade Out</system:String>
+  <system:String x:Key="notedefaults.vibrato.shift">Shift</system:String>
+  <system:String x:Key="notedefaults.vibrato.autotoggle">Automatic Vibrato by Length</system:String>
+  <system:String x:Key="notedefaults.vibrato.autominlength">Minimum Length</system:String>
+
   <system:String x:Key="oto.alias">Alias</system:String>
   <system:String x:Key="oto.color">Color</system:String>
   <system:String x:Key="oto.consonant">Consonant</system:String>
@@ -119,9 +143,11 @@
   <system:String x:Key="pianoroll.menu.lyrics.removelettersuffix">Remove Letter Suffix</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">Remove Tone Suffix</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">Romaji to Hiragana</system:String>
+  <system:String x:Key="pianoroll.menu.notedefaults">Note Defaults</system:String>
   <system:String x:Key="pianoroll.menu.notes">Notes</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtaildash">Add tail "-"</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtailrest">Add tail "R"</system:String>
+  <system:String x:Key="pianoroll.menu.notes.clear.vibratos">Clear vibratos</system:String>
   <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">Load Rendered Pitch</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize15">Quantize to 1/128</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize30">Quantize to 1/64</system:String>

--- a/OpenUtau/ViewModels/NoteDefaultsViewModel.cs
+++ b/OpenUtau/ViewModels/NoteDefaultsViewModel.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.RegularExpressions;
+using Avalonia;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+using OpenUtau.Audio;
+using OpenUtau.Classic;
+using OpenUtau.Core;
+using OpenUtau.App.Views;
+using OpenUtau.Core.Util;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace OpenUtau.App.ViewModels {
+    class NoteDefaultsViewModel : ViewModelBase {
+
+        [Reactive] public string DefaultLyric { get; set; }
+        [Reactive] public int CurrentPortamentoLength { get; set; }
+        [Reactive] public int CurrentPortamentoStart { get; set; }
+        [Reactive] public float CurrentVibratoLength { get; set; }
+        [Reactive] public float CurrentVibratoPeriod { get; set; }
+        [Reactive] public float CurrentVibratoDepth { get; set; }
+        [Reactive] public float CurrentVibratoIn { get; set; }
+        [Reactive] public float CurrentVibratoOut { get; set; }
+        [Reactive] public float CurrentVibratoShift { get; set; }
+        [Reactive] public float AutoVibratoNoteLength { get; set; }
+        [Reactive] public bool AutoVibratoToggle { get; set; }
+        public List<NotePresets.PortamentoPreset>? PortamentoPresets { get; }
+        public NotePresets.PortamentoPreset? ApplyPortamentoPreset {
+            get => appliedPortamentoPreset;
+            set => this.RaiseAndSetIfChanged(ref appliedPortamentoPreset, value);
+        }
+        public List<NotePresets.VibratoPreset>? VibratoPresets { get; }
+        public NotePresets.VibratoPreset? ApplyVibratoPreset {
+            get => appliedVibratoPreset;
+            set => this.RaiseAndSetIfChanged(ref appliedVibratoPreset, value);
+        }
+
+        private NotePresets.PortamentoPreset? appliedPortamentoPreset = NotePresets.Default.DefaultPortamento;
+        private NotePresets.VibratoPreset? appliedVibratoPreset = NotePresets.Default.DefaultVibrato;
+
+        public bool IsPortamentoApplied => appliedPortamentoPreset != null;
+        public bool IsVibratoApplied => appliedVibratoPreset != null;
+        public NoteDefaultsViewModel() {
+            DefaultLyric = NotePresets.Default.DefaultLyric;
+            CurrentPortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+            CurrentPortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+            CurrentVibratoLength = NotePresets.Default.DefaultVibrato.VibratoLength;
+            CurrentVibratoPeriod = NotePresets.Default.DefaultVibrato.VibratoPeriod;
+            CurrentVibratoDepth = NotePresets.Default.DefaultVibrato.VibratoDepth;
+            CurrentVibratoIn = NotePresets.Default.DefaultVibrato.VibratoIn;
+            CurrentVibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
+            CurrentVibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
+            AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
+            AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
+            PortamentoPresets = NotePresets.Default.PortamentoPresets;
+            VibratoPresets = NotePresets.Default.VibratoPresets;
+
+            this.WhenAnyValue(vm => vm.DefaultLyric)
+                    .Subscribe(defaultLyric => {
+                        NotePresets.Default.DefaultLyric = defaultLyric;
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.CurrentPortamentoLength)
+                    .Subscribe(portamentoLength => {
+                        NotePresets.Default.DefaultPortamento.PortamentoLength = portamentoLength;
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.CurrentPortamentoStart)
+                    .Subscribe(portamentoStart => {
+                        NotePresets.Default.DefaultPortamento.PortamentoStart = portamentoStart;
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.CurrentVibratoLength)
+                    .Subscribe(vibratoLength => {
+                        NotePresets.Default.DefaultVibrato.VibratoLength = Math.Max(0, Math.Min(100, vibratoLength));
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.CurrentVibratoPeriod)
+                    .Subscribe(vibratoPeriod => {
+                        NotePresets.Default.DefaultVibrato.VibratoPeriod = Math.Max(5, Math.Min(500, vibratoPeriod));
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.CurrentVibratoDepth)
+                    .Subscribe(vibratoDepth => {
+                        NotePresets.Default.DefaultVibrato.VibratoDepth = Math.Max(5, Math.Min(200, vibratoDepth));
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.CurrentVibratoIn)
+                    .Subscribe(vibratoIn => {
+                        NotePresets.Default.DefaultVibrato.VibratoIn = Math.Max(0, Math.Min(100, vibratoIn));
+                        CurrentVibratoOut = (float)Math.Round(Math.Min(NotePresets.Default.DefaultVibrato.VibratoOut, 100 - NotePresets.Default.DefaultVibrato.VibratoIn), 1);
+                        NotePresets.Default.DefaultVibrato.VibratoOut = CurrentVibratoOut;
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.CurrentVibratoOut)
+                    .Subscribe(vibratoOut => {
+                        NotePresets.Default.DefaultVibrato.VibratoOut = Math.Max(0, Math.Min(100, vibratoOut));
+                        CurrentVibratoIn = (float)Math.Round(Math.Min(NotePresets.Default.DefaultVibrato.VibratoIn, 100 - NotePresets.Default.DefaultVibrato.VibratoOut), 1);
+                        NotePresets.Default.DefaultVibrato.VibratoIn = CurrentVibratoIn;
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.CurrentVibratoShift)
+                    .Subscribe(vibratoShift => {
+                        NotePresets.Default.DefaultVibrato.VibratoShift = Math.Max(0, Math.Min(100, vibratoShift));
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.AutoVibratoToggle)
+                    .Subscribe(autoVibratoToggle => {
+                        NotePresets.Default.AutoVibratoToggle = autoVibratoToggle;
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.AutoVibratoNoteLength)
+                    .Subscribe(autoVibratoNoteLength => {
+                        NotePresets.Default.AutoVibratoNoteDuration = (int) Math.Max(10, autoVibratoNoteLength);
+                        NotePresets.Save();
+                    });
+            this.WhenAnyValue(vm => vm.ApplyPortamentoPreset)
+                .WhereNotNull()
+                .Subscribe(portamentoPreset => {
+                    if (portamentoPreset != null) {
+                        CurrentPortamentoLength = portamentoPreset.PortamentoLength;
+                        CurrentPortamentoStart = portamentoPreset.PortamentoStart;
+                        NotePresets.Default.DefaultPortamento.PortamentoLength = CurrentPortamentoLength;
+                        NotePresets.Default.DefaultPortamento.PortamentoStart = CurrentPortamentoStart;
+                        NotePresets.Save();
+                    }
+                });
+            this.WhenAnyValue(vm => vm.ApplyVibratoPreset)
+                .WhereNotNull()
+                .Subscribe(vibratoPreset => {
+                    if (vibratoPreset != null) {
+                        CurrentVibratoLength = Math.Max(0, Math.Min(100, vibratoPreset.VibratoLength));
+                        CurrentVibratoPeriod = Math.Max(5, Math.Min(500, vibratoPreset.VibratoPeriod));
+                        CurrentVibratoDepth = Math.Max(5, Math.Min(200, vibratoPreset.VibratoDepth));
+                        CurrentVibratoIn = Math.Max(0, Math.Min(100, vibratoPreset.VibratoIn));
+                        CurrentVibratoOut = Math.Max(0, Math.Min(100, vibratoPreset.VibratoOut));
+                        CurrentVibratoShift = Math.Max(0, Math.Min(100, vibratoPreset.VibratoShift));
+                        NotePresets.Default.DefaultVibrato.VibratoLength = CurrentVibratoLength;
+                        NotePresets.Default.DefaultVibrato.VibratoPeriod = CurrentVibratoPeriod;
+                        NotePresets.Default.DefaultVibrato.VibratoDepth = CurrentVibratoDepth;
+                        NotePresets.Default.DefaultVibrato.VibratoIn = CurrentVibratoIn;
+                        NotePresets.Default.DefaultVibrato.VibratoOut = CurrentVibratoOut;
+                        NotePresets.Default.DefaultVibrato.VibratoShift = CurrentVibratoShift;
+                        NotePresets.Save();
+                    }
+                });
+        }
+
+        public void SavePortamentoPreset(string name) {
+            if (string.IsNullOrEmpty(name)) {
+                return;
+            }
+            NotePresets.Default.PortamentoPresets.Add(new NotePresets.PortamentoPreset(name, CurrentPortamentoLength, CurrentPortamentoStart));
+            NotePresets.Save();
+        }
+
+        public void RemoveAppliedPortamentoPreset() {
+            if (appliedPortamentoPreset == null) {
+                return;
+            }
+            NotePresets.Default.PortamentoPresets.Remove(appliedPortamentoPreset);
+            NotePresets.Save();
+        }
+
+        public void SaveVibratoPreset(string name) {
+            if (string.IsNullOrEmpty(name)) {
+                return;
+            }
+            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, CurrentVibratoLength, CurrentVibratoPeriod, CurrentVibratoDepth, CurrentVibratoIn, CurrentVibratoOut, CurrentVibratoShift));
+            NotePresets.Save();
+        }
+
+        public void RemoveAppliedVibratoPreset() {
+            if (appliedVibratoPreset == null) {
+                return;
+            }
+            NotePresets.Default.VibratoPresets.Remove(appliedVibratoPreset);
+            NotePresets.Save();
+        }
+
+        public void ResetSettings() {
+            DefaultLyric = NotePresets.Default.DefaultLyric;
+            CurrentPortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+            CurrentPortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+            CurrentVibratoLength = NotePresets.Default.DefaultVibrato.VibratoLength;
+            CurrentVibratoPeriod = NotePresets.Default.DefaultVibrato.VibratoPeriod;
+            CurrentVibratoDepth = NotePresets.Default.DefaultVibrato.VibratoDepth;
+            CurrentVibratoIn = NotePresets.Default.DefaultVibrato.VibratoIn;
+            CurrentVibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
+            CurrentVibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
+            AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
+            AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
+        }
+    }
+}

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -458,7 +458,7 @@ namespace OpenUtau.App.ViewModels {
         public void ToggleVibrato(UNote note) {
             var vibrato = note.vibrato;
             DocManager.Inst.StartUndoGroup();
-            DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, vibrato.length == 0 ? 75f : 0));
+            DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, vibrato.length == 0 ? NotePresets.Default.DefaultVibrato.VibratoLength : 0));
             DocManager.Inst.EndUndoGroup();
         }
 

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -135,6 +135,7 @@ namespace OpenUtau.App.ViewModels {
                 new ResetPitchBends(),
                 new ResetAllExpressions(),
                 new ClearVibratos(),
+                new ResetVibratos(),
                 new ClearTimings(),
             }.Select(edit => new MenuItemViewModel() {
                 Header = ThemeManager.GetString(edit.Name),

--- a/OpenUtau/Views/NoteDefaultsDialog.axaml
+++ b/OpenUtau/Views/NoteDefaultsDialog.axaml
@@ -1,0 +1,123 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:OpenUtau.App.ViewModels"
+        mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="470"
+        x:Class="OpenUtau.App.Views.NoteDefaultsDialog"
+        Title="{DynamicResource notedefaults.caption}"
+        WindowStartupLocation="CenterScreen"
+        MinWidth="600" MinHeight="470" Width="600" Height="470"
+        ExtendClientAreaToDecorationsHint="False">
+  <Window.Resources>
+    <vm:CultureNameConverter x:Key="cultureNameConverter"/>
+  </Window.Resources>
+  <Design.DataContext>
+  </Design.DataContext>
+  <Grid Margin="{Binding $parent.WindowDecorationMargin}">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
+      <StackPanel Margin="5">
+          <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.lyric}">
+              <StackPanel>
+                  <Grid ColumnDefinitions="173,20,*">
+                      <Label Content="{DynamicResource notedefaults.lyric.defaultlyric}"/>
+                      <TextBox Grid.Column="2" Text="{Binding DefaultLyric}" />
+                  </Grid>
+              </StackPanel>
+          </HeaderedContentControl>
+          <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.portamento}">
+              <StackPanel>
+                  <Grid ColumnDefinitions="173,20,*,20,80,20,80">
+                      <Label Content="{DynamicResource notedefaults.preset}"/>
+                      <ComboBox Grid.Column="2" Items="{Binding PortamentoPresets}"
+                      SelectedItem="{Binding ApplyPortamentoPreset}" HorizontalAlignment="Stretch"/>
+                      <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.save}"
+                      HorizontalAlignment="Stretch" Click="OnSavePortamentoPreset"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
+                      <Button Grid.Column="6" Content="{DynamicResource notedefaults.preset.remove}"
+                      HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedPortamentoPreset}"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
+                  </Grid>
+                  <Grid ColumnDefinitions="180,20,50,20,*">
+                      <Label Content="{DynamicResource notedefaults.portamento.length}"/>
+                      <TextBox Grid.Column="2" Text="{Binding CurrentPortamentoLength}" />
+                      <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentPortamentoLength}" Minimum="2" Maximum="320"
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
+                  </Grid>
+                  <Grid ColumnDefinitions="180,20,50,20,*">
+                      <Label Content="{DynamicResource notedefaults.portamento.start}"/>
+                      <TextBox Grid.Column="2" Text="{Binding CurrentPortamentoStart}" />
+                      <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentPortamentoStart}" Minimum="-200" Maximum="200"
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
+                  </Grid>
+              </StackPanel>
+          </HeaderedContentControl>
+          <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.vibrato}">
+              <StackPanel>
+                  <Grid ColumnDefinitions="173,20,*,20,80,20,80">
+                      <Label Content="{DynamicResource notedefaults.preset}"/>
+                      <ComboBox Grid.Column="2" Items="{Binding VibratoPresets}"
+                      SelectedItem="{Binding ApplyVibratoPreset}" HorizontalAlignment="Stretch" />
+                      <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.save}"
+                      HorizontalAlignment="Stretch" Click="OnSaveVibratoPreset"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
+                      <Button Grid.Column="6" Content="{DynamicResource notedefaults.preset.remove}"
+                      HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedVibratoPreset}"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
+                  </Grid>
+                  <Grid ColumnDefinitions="180,20,50,20,*">
+                      <Label Content="{DynamicResource notedefaults.vibrato.length}"/>
+                      <TextBox Grid.Column="2" Text="{Binding CurrentVibratoLength}" />
+                      <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoLength}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                  </Grid>
+                  <Grid ColumnDefinitions="180,20,50,20,*">
+                      <Label Content="{DynamicResource notedefaults.vibrato.period}"/>
+                      <TextBox Grid.Column="2" Text="{Binding CurrentVibratoPeriod}" />
+                      <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoPeriod}" Minimum="5" Maximum="500"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                  </Grid>
+                  <Grid ColumnDefinitions="180,20,50,20,*">
+                      <Label Content="{DynamicResource notedefaults.vibrato.depth}"/>
+                      <TextBox Grid.Column="2" Text="{Binding CurrentVibratoDepth}" />
+                      <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoDepth}" Minimum="5" Maximum="200"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                  </Grid>
+                  <Grid ColumnDefinitions="*,20,*">
+                      <Grid Grid.Column="0" ColumnDefinitions="70,10,40,20,*">
+                          <Label Content="{DynamicResource notedefaults.vibrato.in}"/>
+                          <TextBox Grid.Column="2" Text="{Binding CurrentVibratoIn}" />
+                          <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoIn}" Minimum="0" Maximum="100"
+                          TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                      </Grid>
+                      <Grid Grid.Column="2" ColumnDefinitions="70,10,40,20,*">
+                          <Label Content="{DynamicResource notedefaults.vibrato.out}"/>
+                          <TextBox Grid.Column="2" Text="{Binding CurrentVibratoOut}" />
+                          <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoOut}" Minimum="0" Maximum="100"
+                          TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                      </Grid>
+                  </Grid>
+                  <Grid ColumnDefinitions="180,20,50,20,*">
+                      <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
+                      <TextBox Grid.Column="2" Text="{Binding CurrentVibratoShift}" />
+                      <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoShift}" Minimum="1" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                  </Grid>
+                  <Grid ColumnDefinitions="173,20,*">
+                      <Label Content="{DynamicResource notedefaults.vibrato.autotoggle}"/>
+                      <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>
+                  </Grid>
+                  <Grid ColumnDefinitions="180,20,50,20,*">
+                      <Label Content="{DynamicResource notedefaults.vibrato.autominlength}"/>
+                      <TextBox Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Text="{Binding AutoVibratoNoteLength}" />
+                      <Slider Grid.Column="4" Classes="fader" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" Minimum="10" Maximum="1920"
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
+                  </Grid>
+              </StackPanel>
+          </HeaderedContentControl>
+          <Button Grid.Column="4" Content="{DynamicResource notedefaults.reset}"
+          HorizontalAlignment="Stretch" Click="OnReset" ToolTip.Tip="{DynamicResource notedefaults.reset.tooltip}" />
+      </StackPanel>
+    </ScrollViewer>
+  </Grid>
+</Window>

--- a/OpenUtau/Views/NoteDefaultsDialog.axaml.cs
+++ b/OpenUtau/Views/NoteDefaultsDialog.axaml.cs
@@ -1,0 +1,53 @@
+﻿using System.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using OpenUtau.App.ViewModels;
+using OpenUtau.Core.Util;
+
+namespace OpenUtau.App.Views {
+    public partial class NoteDefaultsDialog : Window {
+        internal readonly NoteDefaultsViewModel ViewModel;
+        public NoteDefaultsDialog() {
+            InitializeComponent();
+#if DEBUG
+            this.AttachDevTools();
+#endif
+            DataContext = ViewModel = new NoteDefaultsViewModel();
+        }
+
+        private void InitializeComponent() {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        void OnSavePortamentoPreset(object sender, RoutedEventArgs e) {
+            var dialog = new TypeInDialog() {
+                Title = ThemeManager.GetString("notedefaults.preset.namenew"),
+                onFinish = name => ViewModel.SavePortamentoPreset(name),
+            };
+            dialog.ShowDialog(this);
+        }
+
+        void OnRemovePortamentoPreset(object sender, RoutedEventArgs e) {
+            ViewModel.RemoveAppliedPortamentoPreset();
+        }
+
+        void OnSaveVibratoPreset(object sender, RoutedEventArgs e) {
+            var dialog = new TypeInDialog() {
+                Title = ThemeManager.GetString("notedefaults.preset.namenew"),
+                onFinish = name => ViewModel.SaveVibratoPreset(name),
+            };
+            dialog.ShowDialog(this);
+        }
+
+        void OnRemoveVibratoPreset(object sender, RoutedEventArgs e) {
+            ViewModel.RemoveAppliedVibratoPreset();
+        }
+
+        void OnReset(object sender, RoutedEventArgs e) {
+            NotePresets.Reset();
+            ViewModel.ResetSettings();
+        }
+    }
+}

--- a/OpenUtau/Views/NoteEditStates.cs
+++ b/OpenUtau/Views/NoteEditStates.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using OpenUtau.App.Controls;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
+using OpenUtau.Core.Util;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.App.Views {
@@ -242,6 +243,8 @@ namespace OpenUtau.App.Views {
             }
             if (deltaDuration != 0) {
                 DocManager.Inst.ExecuteCmd(new ResizeNoteCommand(notesVm.Part, note, deltaDuration));
+                if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(notesVm.Part, note, NotePresets.Default.DefaultVibrato.VibratoLength));
+                else DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(notesVm.Part, note, 0));
             }
             valueTip.UpdateValueTip(note.duration.ToString());
         }

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -335,6 +335,7 @@
                 </MenuItem.DataTemplates>
               </MenuItem>
               <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.lyrics.edit}" Click="OnMenuEditLyrics"/>
+              <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.notedefaults}" Click="OnMenuNoteDefaults"/>
             </Menu>
           </Border>
         </Border>

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -107,6 +107,14 @@ namespace OpenUtau.App.Views {
             dialog.ShowDialog(this);
         }
 
+        void OnMenuNoteDefaults(object sender, RoutedEventArgs args) {
+            var dialog = new NoteDefaultsDialog();
+            dialog.ShowDialog(this);
+            if (dialog.Position.Y < 0) {
+                dialog.Position = dialog.Position.WithY(0);
+            }
+        }
+
         public void OnExpButtonClick(object sender, RoutedEventArgs args) {
             var dialog = new ExpressionsDialog() {
                 DataContext = new ExpressionsViewModel(),


### PR DESCRIPTION
Added a window for default notes settings - lyric, portamento and vibrato.
- Portamento settings include start and length;
- Vibrato settings include length, period, depth, fade in and out, and shift, as well as toggle for automatic vibrato and minimum note duration for adding it;
- Portamento and vibrato have presets, which user can add or remove;
- Default settings and presets are saved in a file separate from preferences;
- Batch edit previously named "Reset vibratos" is now named "Clear vibratos" and current "Reset..." applies all the default values;
Small bug which I wasn't able to fix: preset dropdown lists don't update after adding or removing presets, the window needs to be reopened for changes to be seen.