### PR TITLE
Fix links on index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,18 +13,18 @@ Open singing synthesis platform / Open source UTAU successor
 
 ### Getting Started
 
-[Getting Started](./Getting-Started)
+[Getting Started](https://github.com/stakira/OpenUtau/wiki/Getting-Started)
 
-[FAQ](./FAQ)
+[FAQ](https://github.com/stakira/OpenUtau/wiki/FAQ)
 
 [中文使用说明](https://opensynth.miraheze.org/wiki/OpenUTAU/%E4%BD%BF%E7%94%A8%E6%96%B9%E6%B3%95)
 
 ### Documentation
 
-[Phonemizers](./Phonemizers)
+[Phonemizers](https://github.com/stakira/OpenUtau/wiki/Phonemizers)
 
-[Resamplers](./Resamplers)
+[Resamplers](https://github.com/stakira/OpenUtau/wiki/Resamplers)
 
-[Legacy Plugins](./Legacy-Plugins)
+[Legacy Plugins](https://github.com/stakira/OpenUtau/wiki/Legacy-Plugins)
 
-[NNSVS](./Status-of-ENUNU-NNSVS-Support)
+[NNSVS](https://github.com/stakira/OpenUtau/wiki/Status-of-ENUNU-NNSVS-Support)


### PR DESCRIPTION
Links previously went to openutau.com/`LinkName` because of it being set up like `.LinkName` for the link.