### PR TITLE
Added "Spanish to Japanese Phonemizer" + vowel ending support for ENtoJA Phonemizer + ES-SYL Phonemizer simplifications

### DIFF
--- a/OpenUtau.Plugin.Builtin/ENtoJAPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENtoJAPhonemizer.cs
@@ -393,6 +393,10 @@ namespace OpenUtau.Plugin.Builtin {
                 }
                 prevV = WanaKana.ToRomaji(solo).Last<char>().ToString();
             }
+            
+            if (ending.IsEndingV) {
+                TryAddPhoneme(phonemes, ending.tone, $"{prevV} R", $"{prevV} -", $"{prevV}-");
+            }
 
             return phonemes;
         }

--- a/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
@@ -14,7 +14,7 @@ namespace OpenUtau.Plugin.Builtin {
         ///</summary>
         protected override string[] GetVowels() => vowels;
         private static readonly string[] vowels =
-            "a i u e o N".Split();
+            "a i u e o".Split();
         protected override string[] GetConsonants() => consonants;
         private static readonly string[] consonants =
             "b by ch d dy f g gy h hh hy j k ky l ly m my n ny p py r ry rr rry s sh t ty ts w y z".Split();

--- a/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
@@ -1,0 +1,573 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenUtau.Api;
+using WanaKanaNet;
+
+namespace OpenUtau.Plugin.Builtin {
+    [Phonemizer("Spanish to Japanese Phonemizer", "ES to JA", "Lotte V")]
+    public class EStoJAPhonemizer : SyllableBasedPhonemizer {
+        /// <summary>
+        /// Phonemizer for using Japanese banks for Spanish songs.
+        /// Closely based on TUBS' English To Japanese Phonemizer; it has many of the same functions, just tweaked for Spanish.
+        /// This phonemizer always uses seseo, because the Japanese "z" is very different from the Spanish "z".
+        ///</summary>
+        protected override string[] GetVowels() => vowels;
+        private static readonly string[] vowels =
+            "a i u e o N".Split();
+        protected override string[] GetConsonants() => consonants;
+        private static readonly string[] consonants =
+            "b by ch d dy f g gy h hh hy j k ky l ly m my n ny p py r ry rr rry s sh t ty ts w y z".Split();
+        protected override string GetDictionaryName() => "cmudict_es.txt";
+        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryPhonemesReplacement;
+        private static readonly Dictionary<string, string> dictionaryPhonemesReplacement = new Dictionary<string, string> {
+            { "a", "a" },
+            { "b", "b" },
+            { "ch", "ch" },
+            { "d", "d" },
+            { "e", "e" },
+            { "f", "f" },
+            { "g", "g" },
+            { "h", "h" },
+            { "hh", "hh" },
+            { "i", "i" },
+            { "I", "y" },
+            { "ll", "j" },
+            { "k", "k" },
+            { "l", "l" },
+            { "m", "m" },
+            { "n", "n" },
+            { "gn", "ny" },
+            { "o", "o" },
+            { "p", "p" },
+            { "r", "r" },
+            { "rr", "rr" },
+            { "s", "s" },
+            { "t", "t" },
+            { "u", "u" },
+            { "U", "w" },
+            { "w", "w" },
+            { "y", "y" },
+            { "z", "s" },
+        };
+
+        private Dictionary<string, string> StartingConsonant => startingConsonant;
+        private static readonly Dictionary<string, string> startingConsonant = new Dictionary<string, string> {
+            { "", "" },
+            { "b", "b" },
+            { "by", "by" },
+            { "bw", "bw" },
+            { "ch", "ch" },
+            { "chw", "chw" },
+            { "d", "d" },
+            { "dy", "dy" },
+            { "dw", "dw" },
+            { "f", "f" },
+            { "fy", "fy" },
+            { "fw", "fw" },
+            { "g", "g" },
+            { "gy", "gy" },
+            { "gw", "gw" },
+            { "h", "h" },
+            { "hy", "hy" },
+            { "hw", "hw" },
+            { "j", "j" },
+            { "jw", "jw" },
+            { "k", "k" },
+            { "ky", "ky" },
+            { "kw", "kw" },
+            { "l", "r" },
+            { "ly", "ry" },
+            { "lw", "rw" },
+            { "m", "m" },
+            { "my", "my" },
+            { "mw", "mw" },
+            { "n", "n" },
+            { "ny", "ny" },
+            { "nw", "nw" },
+            { "p", "p" },
+            { "py", "py" },
+            { "pw", "pw" },
+            { "r", "r" },
+            { "rw", "rw" },
+            { "rr", "rr" },
+            { "rry", "rry" },
+            { "rrw", "rrw" },
+            { "s", "s" },
+            { "sy", "sy" },
+            { "sw", "sw" },
+            { "t", "t" },
+            { "ty", "ty" },
+            { "tw", "tw" },
+            { "w", "w" },
+            { "y", "y" },
+        };
+
+        private Dictionary<string, string> SoloConsonant => soloConsonant;
+        private static readonly Dictionary<string, string> soloConsonant = new Dictionary<string, string> {
+            { "b", "ぶ" },
+            { "by", "び" },
+            { "bu", "ぶ" },
+            { "ch", "ちゅ" },
+            { "chw", "ちゅ" },
+            { "d", "ど" },
+            { "dy", "でぃ" },
+            { "dw", "どぅ" },
+            { "f", "ふ" },
+            { "fy", "ふぃ" },
+            { "g", "ぐ" },
+            { "gy", "ぎ" },
+            { "gw", "ぐ" },
+            { "h", "ほ" },
+            { "hy", "ひ" },
+            { "hw", "ほ" },
+            { "hh", "息" },
+            { "I", "い" },
+            { "j", "じゅ" },
+            { "jw", "じゅ" },
+            { "k", "く" },
+            { "ky", "き" },
+            { "kw", "く" },
+            { "l", "る" },
+            { "ly", "り" },
+            { "lw", "る" },
+            { "m", "ん" },
+            { "my", "み" },
+            { "mw", "む" },
+            { "n", "ん" },
+            { "ny", "に" },
+            { "nw", "ぬ" },
+            { "p", "ぷ" },
+            { "py", "ぴ" },
+            { "pw", "ぷ" },
+            { "r", "る" },
+            { "ry", "り" },
+            { "rw", "る" },
+            { "rr", "る" },
+            { "rry", "り" },
+            { "rrw", "る" },
+            { "s", "す" },
+            { "sy", "すぃ" },
+            { "sw", "す" },
+            { "t", "と" },
+            { "ty", "てぃ" },
+            { "tw", "とぅ" },
+            { "U", "う" },
+            { "w", "う" },
+            { "y", "い" },
+        };
+
+        private readonly string[] SpecialClusters = "ky kw gy gw sy sw jw ty tw chw dy dw ny nw hy hw by bw py pw my mw ry rw rry rrw ly lw".Split();
+
+        private Dictionary<string, string> AltCv => altCv;
+        private static readonly Dictionary<string, string> altCv = new Dictionary<string, string> {
+            {"kwa", "kula" },
+            {"kwi", "kuli" },
+            {"kwe", "kule" },
+            {"kwo", "kulo" },
+            {"gwa", "gula" },
+            {"gwi", "guli" },
+            {"gwe", "gule" },
+            {"gwo", "gulo" },
+            {"si", "suli" },
+            {"sya", "sulya" },
+            {"syu", "sulyu" },
+            {"sye", "sulile" },
+            {"syo", "sulyo" },
+            {"swa", "sula" },
+            {"swi", "sui" },
+            {"swe", "sule" },
+            {"swo", "sulo" },
+            {"ti", "teli" },
+            {"tya", "telya" },
+            {"tyu", "telyu" },
+            {"tye", "tele" },
+            {"tyo", "telyo" },
+            {"tu", "tolu" },
+            {"di", "deli" },
+            {"dya", "delya" },
+            {"dyu", "delyu" },
+            {"dye", "dele" },
+            {"dyo", "delyo" },
+            {"du", "dolu" },
+            {"nwa", "nula" },
+            {"nwi", "nuli" },
+            {"nwe", "nule" },
+            {"nwo", "nulo" },
+            {"hwa", "hola" },
+            {"hwi", "holi" },
+            {"hwe", "hole" },
+            {"hwo", "holo" },
+            {"bwa", "bula" },
+            {"bwi", "buli" },
+            {"bwe", "bule" },
+            {"bwo", "bulo" },
+            {"pwa", "pula" },
+            {"pwi", "puli" },
+            {"pwe", "pule" },
+            {"pwo", "pulo" },
+            {"hu", "holu" },
+            {"mwa", "mula" },
+            {"mwi", "muli" },
+            {"mwe", "mule" },
+            {"mwo", "mulo" },
+            {"yi", "i" },
+            {"rwa", "rula" },
+            {"rwi", "ruli" },
+            {"rwe", "rule" },
+            {"rwo", "rulo" },
+            {"wu", "u" },
+            {"wi", "uli" },
+            {"we", "ule" },
+            {"wo", "ulo" }, 
+        };
+
+        private Dictionary<string, string> ConditionalAlt => conditionalAlt;
+        private static readonly Dictionary<string, string> conditionalAlt = new Dictionary<string, string> {
+            {"uli", "wi" },
+            {"ule", "we" },
+            {"ulo", "wo"},
+        };
+
+        private Dictionary<string, string[]> ExtraCv => extraCv;
+        private static readonly Dictionary<string, string[]> extraCv = new Dictionary<string, string[]> {
+            {"rr", new [] { "ru", "ru", "ru" } },
+            {"rra", new [] { "ra", "ra", "ra" } },
+            {"rri", new [] { "ri", "ri", "ri" } },
+            {"rru", new [] { "ru", "ru", "ru" } },
+            {"rre", new [] { "re", "re", "re" } },
+            {"rro", new [] { "ro", "ro", "ro" } },
+            {"rrya", new [] { "ri", "ri", "rya" } },
+            {"rryu", new [] { "ri", "ri", "ryu" } },
+            {"rrye", new [] { "ri", "ri", "rye" } },
+            {"rryo", new [] { "ri", "ri", "ryo" } },
+            {"rrwa", new [] { "ru", "ru", "rula" } },
+            {"rrwi", new [] { "ru", "ru", "ruli" } },
+            {"rrwe", new [] { "ru", "ru", "rule" } },
+            {"rrwo", new [] { "ru", "ru", "rulo" } },
+            {"kye", new [] { "ki", "e" } },
+            {"kwa", new [] { "ku", "wa" } },
+            {"kwi", new [] { "ku", "uli" } },
+            {"kwe", new [] { "ku", "ule" } },
+            {"kwo", new [] { "ku", "ulo" } },
+            {"gye", new [] { "gi", "e" } },
+            {"gwa", new [] { "gu", "wa" } },
+            {"gwi", new [] { "gu", "uli" } },
+            {"gwe", new [] { "gu", "ule" } },
+            {"gwo", new [] { "gu", "ulo" } },
+            {"suli", new [] { "se", "i" } },
+            {"sulya", new [] { "suli", "ya" } },
+            {"sulyu", new [] { "suli", "yu" } },
+            {"sulile", new [] { "suli", "ye" } },
+            {"sulyo", new [] { "suli", "yo" } },
+            {"sula", new [] { "su", "wa" } },
+            {"sui", new [] { "su", "uli" } },
+            {"sule", new [] { "su", "ule" } },
+            {"sulo", new [] { "su", "ulo" } }, 
+            {"je", new [] { "ji", "e" } },
+            {"jwa", new [] { "ju", "wa" } },
+            {"jwi", new [] { "ju", "uli" } },
+            {"jwe", new [] { "ju", "ule" } },
+            {"jwo", new [] { "ju", "ulo" } },
+            {"teli", new [] { "te", "i" } },
+            {"telya", new [] { "teli", "ya" } },
+            {"telyu", new [] { "teli", "yu" } },
+            {"tele", new [] { "telile" } },
+            {"telile", new [] { "teli", "ye" } },
+            {"telyo", new [] { "teli", "yo" } },
+            {"tolu", new [] { "to", "u" } },
+            {"twa", new [] { "tolu", "wa" } },
+            {"twi", new [] { "tolu", "uli" } },
+            {"twe", new [] { "tolu", "ule" } },
+            {"two", new [] { "tolu", "ulo" } },
+            {"che", new [] { "chi", "e" } },
+            {"chwa", new [] { "chu", "wa" } },
+            {"chwi", new [] { "chu", "uli" } },
+            {"chwe", new [] { "chu", "ule" } },
+            {"chwo", new [] { "chu", "ulo" } },
+            {"deli", new [] { "de", "i" } },
+            {"delya", new [] { "deli", "ya" } },
+            {"delyu", new [] { "deli", "yu" } },
+            {"dele", new [] { "delile" } },
+            {"delile", new [] { "deli", "ye" } },
+            {"delyo", new [] { "deli", "yo" } },
+            {"dolu", new [] { "do", "u" } },
+            {"dwa", new [] { "dolu", "wa" } },
+            {"dwi", new [] { "dolu", "uli" } },
+            {"dwe", new [] { "dolu", "ule" } },
+            {"dwo", new [] { "dolu", "ulo" } },
+            {"nye", new [] { "ni", "e" } },
+            {"nula", new [] { "nu", "wa" } },
+            {"nuli", new [] { "nu", "uli" } },
+            {"nule", new [] { "nu", "ule" } },
+            {"nulo", new [] { "nu", "ulo" } },
+            {"hye", new [] { "hi", "e" } },
+            {"holu", new [] { "ho", "u" } },
+            {"fa", new [] { "fu", "a" } },
+            {"fi", new [] { "fu", "i" } },
+            {"fe", new [] { "fu", "e" } },
+            {"fo", new [] { "fu", "o" } },
+            {"fwa", new [] { "fu", "wa" } },
+            {"fwi", new [] { "fu", "uli" } },
+            {"fwe", new [] { "fu", "ule" } },
+            {"fwo", new [] { "fu", "ulo" } },
+            {"fya", new [] { "fi", "ya" } },
+            {"fyu", new [] { "fi", "yu" } },
+            {"fye", new [] { "fi", "ye" } },
+            {"fyo", new [] { "fi", "yo" } },
+            {"bye", new [] { "bi", "e" } },
+            {"bula", new [] { "bu", "wa" } },
+            {"buli", new [] { "bu", "uli" } },
+            {"bule", new [] { "bu", "ule" } },
+            {"bulo", new [] { "bu", "ulo" } },
+            {"pye", new [] { "pi", "e" } },
+            {"pula", new [] { "pu", "wa" } },
+            {"puli", new [] { "pu", "uli" } },
+            {"pule", new [] { "pu", "ule" } },
+            {"pulo", new [] { "pu", "ulo" } },
+            {"mye", new [] { "mi", "e" } },
+            {"mula", new [] { "mu", "wa" } },
+            {"muli", new [] { "mu", "uli" } },
+            {"mule", new [] { "mu", "ule" } },
+            {"mulo", new [] { "mu", "ulo" } },
+            {"ye", new [] { "i", "e" } },
+            {"rye", new [] { "ri", "e" } },
+            {"rula", new [] { "ru", "wa" } },
+            {"ruli", new [] { "ru", "uli" } },
+            {"rule", new [] { "ru", "ule" } },
+            {"rulo", new [] { "ru", "ulo" } },
+            {"uli", new [] { "u", "i" } },
+            {"ule", new [] { "u", "e" } },
+            {"ulo", new [] { "u", "o" } },
+        };
+
+        private readonly string[] affricates = "ch j".Split();
+
+        protected override List<string> ProcessSyllable(Syllable syllable) {
+            // Skip processing if this note extends the prevous syllable
+            if (CanMakeAliasExtension(syllable)) {
+                return new List<string> { null };
+            }
+
+            var prevV = syllable.prevV;
+            var cc = syllable.cc;
+            var v = syllable.v;
+            var phonemes = new List<string>();
+            var usingVC = false;
+
+            if (prevV.Length == 0) {
+                prevV = "-";
+            }
+
+            // Check CCs for special clusters
+            var adjustedCC = new List<string>();
+            for (var i = 0; i < cc.Length; i++) {
+                if (i == cc.Length - 1) {
+                    adjustedCC.Add(cc[i]);
+                } else {
+                    if (cc[i] == cc[i + 1]) {
+                        adjustedCC.Add(cc[i]);
+                        i++;
+                        continue;
+                    }
+                    var diphone = $"{cc[i]}{cc[i + 1]}";
+                    if (SpecialClusters.Contains(diphone)) {
+                        adjustedCC.Add(diphone);
+                        i++;
+                    } else {
+                        adjustedCC.Add(cc[i]);
+                    }
+                }
+            }
+            cc = adjustedCC.ToArray();
+
+            // Separate CCs and main CV
+            var finalCons = "";
+            if (cc.Length > 0) {
+                finalCons = cc[cc.Length - 1];
+
+                var start = 0;
+                (var hasVc, var vcPhonemes) = HasVc(prevV, cc[0], syllable.tone, cc.Length);
+                usingVC = hasVc;
+                phonemes.AddRange(vcPhonemes);
+
+                if (usingVC) {
+                    start = 1;
+                }
+
+                for (var i = start; i < cc.Length - 1; i++) {
+                    var cons = SoloConsonant[cc[i]];
+                    if (!usingVC) {
+                        cons = TryVcv(prevV, cons, syllable.tone);
+                    } else {
+                        usingVC = false;
+                    }
+                    if (HasOto(cons, syllable.tone)) {
+                        phonemes.Add(cons);
+                    } else if (ConditionalAlt.ContainsKey(cons)) {
+                        cons = ConditionalAlt[cons];
+                        phonemes.Add(TryVcv(prevV, cons, syllable.tone));
+                    }
+                    prevV = WanaKana.ToRomaji(cons).Last<char>().ToString();
+                }
+            }
+
+            // Convert to hiragana
+            var cv = $"{StartingConsonant[finalCons]}{v}";
+            cv = AltCv.ContainsKey(cv) ? AltCv[cv] : cv;
+            var hiragana = ToHiragana(cv);
+            if (!usingVC) {
+                hiragana = TryVcv(prevV, hiragana, syllable.vowelTone);
+            } else {
+                hiragana = FixCv(hiragana, syllable.vowelTone);
+            }
+
+            // Check for nonstandard CV
+            var split = false;
+            if (HasOto(hiragana, syllable.vowelTone)) {
+                phonemes.Add(hiragana);
+            } else if (ConditionalAlt.ContainsKey(cv)) {
+                cv = ConditionalAlt[cv];
+                hiragana = TryVcv(prevV, ToHiragana(cv), syllable.vowelTone);
+                if (HasOto(hiragana, syllable.vowelTone)) {
+                    phonemes.Add(hiragana);
+                } else {
+                    split = true;
+                }
+            } else {
+                split = true;
+            }
+
+            // Handle nonstandard CV
+            if (split && ExtraCv.ContainsKey(cv)) {
+                var splitCv = ExtraCv[cv];
+                for (var i = 0; i < splitCv.Length; i++) {
+                    if (splitCv[i] != prevV) {
+                        var converted = ToHiragana(splitCv[i]);
+                        phonemes.Add(TryVcv(prevV, converted, syllable.vowelTone));
+                        prevV = splitCv[i].Last<char>().ToString();
+                    }
+                }
+            }
+
+            return phonemes;
+        }
+
+        protected override List<string> ProcessEnding(Ending ending) {
+            var prevV = ending.prevV;
+            var cc = ending.cc;
+            var phonemes = new List<string>();
+
+            // Check CCs for special clusters
+            var adjustedCC = new List<string>();
+            for (var i = 0; i < cc.Length; i++) {
+                if (i == cc.Length - 1) {
+                    adjustedCC.Add(cc[i]);
+                } else {
+                    if (cc[i] == cc[i + 1]) {
+                        adjustedCC.Add(cc[i]);
+                        i++;
+                        continue;
+                    }
+                    var diphone = $"{cc[i]}{cc[i + 1]}";
+                    if (SpecialClusters.Contains(diphone)) {
+                        adjustedCC.Add(diphone);
+                        i++;
+                    } else {
+                        adjustedCC.Add(cc[i]);
+                    }
+                }
+            }
+            cc = adjustedCC.ToArray();
+
+            var usingVC = false;
+            // Convert to hiragana
+            for (var i = 0; i < cc.Length; i++) {
+                var symbol = cc[i];
+
+                if (i == 0) {
+                    (var hasVc, var vcPhonemes) = HasVc(prevV, symbol, ending.tone, cc.Length + 1);
+                    usingVC = hasVc;
+                    phonemes.AddRange(vcPhonemes);
+                    if (usingVC) {
+                        continue;
+                    }
+                }
+
+                var solo = SoloConsonant[symbol];
+                if (!usingVC) {
+                    solo = TryVcv(prevV, solo, ending.tone);
+                } else {
+                    usingVC = false;
+                    solo = FixCv(solo, ending.tone);
+                }
+
+                if (HasOto(solo, ending.tone)) {
+                    phonemes.Add(solo);
+                } else if (ConditionalAlt.ContainsKey(solo)) {
+                    solo = ConditionalAlt[solo];
+                    if (!usingVC) {
+                        solo = TryVcv(prevV, solo, ending.tone);
+                    } else {
+                        solo = FixCv(solo, ending.tone);
+                    }
+                    phonemes.Add(solo);
+                }
+                prevV = WanaKana.ToRomaji(solo).Last<char>().ToString();
+            }
+
+            if (ending.IsEndingV) {
+                TryAddPhoneme(phonemes, ending.tone, $"{prevV} R", $"{prevV} -", $"{prevV}-");
+            }
+
+            return phonemes;
+        }
+
+        private (bool, string[]) HasVc(string vowel, string cons, int tone, int cc) {
+            if (vowel == "" || vowel == "-") {
+                return (false, new string[0]);
+            }
+
+            var phonemes = new List<string>();
+            if (cons == "rr") {
+                cons = "r";
+            } else if (cons == "rry") {
+                cons = "ry";
+            } else if (cons == "l") {
+                cons = "r";
+            } else if (cons == "ly") {
+                cons = "ry";
+            }
+
+            var vc = $"{vowel} {cons}";
+            var altVc = $"{vowel} {cons[0]}";
+
+            if (HasOto(vc, tone)) {
+                phonemes.Add(vc);
+            } else if (HasOto(altVc, tone)) {
+                phonemes.Add(altVc);
+            }
+
+            if (affricates.Contains(cons) && cc > 1) {
+                phonemes.Add(FixCv(SoloConsonant[cons], tone));
+            }
+
+            return (phonemes.Count > 0, phonemes.ToArray());
+        }
+
+        private string TryVcv(string vowel, string cv, int tone) {
+            var vcv = $"{vowel} {cv}";
+            return HasOto(vcv, tone) ? vcv : FixCv(cv, tone);
+        }
+
+        private string FixCv(string cv, int tone) {
+            var alt = $"- {cv}";
+            return HasOto(cv, tone) ? cv : HasOto(alt, tone) ? alt : cv;
+        }
+        private string ToHiragana(string romaji) {
+            var hiragana = WanaKana.ToHiragana(romaji);
+            hiragana = hiragana.Replace("ゔ", "ヴ");
+            return hiragana;
+        }
+    }
+}

--- a/OpenUtau.Plugin.Builtin/SpanishSyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SpanishSyllableBasedPhonemizer.cs
@@ -31,12 +31,13 @@ namespace OpenUtau.Plugin.Builtin {
         private readonly string[] longConsonants = "b,ch,d,dz,g,h,s,sh,k,p,rr,t,ts,z,l,m,n".Split(',');
         private readonly string[] burstConsonants = "b,ch,d,dz,g,j,k,p,r,t,ts".Split(',');
         private readonly string[] notClusters = "dz,hh,ll,nh,sh,zz,zh".Split(',');
-        private readonly string[] specialClusters = "by,dy,fy,gy,hy,jy,ky,ly,my,py,ry,rry,sy,ty,vy,zy,bw,chw,dw,fw,gw,hw,jw,kw,lw,llw,mw,nw,pw,rw,rrw,sw,tw,vw,zw,bl,fl,gl,kl,pl,br,dr,fr,gr,kr,pr,tr,si".Split(',');
+        private readonly string[] specialClusters = "by,dy,fy,gy,hy,jy,ky,ly,my,py,ry,rry,sy,ty,vy,zy,bw,chw,dw,fw,gw,hw,jw,kw,lw,llw,mw,nw,pw,rw,rrw,sw,tw,vw,zw,bl,fl,gl,kl,pl,br,dr,fr,gr,kr,pr,tr".Split(',');
 
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "cmudict_es.txt";
         protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
+
         protected override List<string> ProcessSyllable(Syllable syllable){
             string prevV = syllable.prevV;
             string[] cc = syllable.cc;
@@ -296,27 +297,17 @@ namespace OpenUtau.Plugin.Builtin {
             string v = ending.prevV;
 
             var phonemes = new List<string>();
-            var vr = $"{v} -";
-            if (ending.IsEndingV && HasOto(vr, ending.tone)) {   // ending V
-                phonemes.Add(vr);
+            if (ending.IsEndingV) {   // ending V
+                TryAddPhoneme(phonemes, ending.tone, $"{v} R", $"{v} -", $"{v}-");
             } else if (ending.IsEndingVCWithOneConsonant) {   // ending VC
-                var vcr = $"{v} {cc[0]}-";
-                var vc1 = $"{v} {cc[0]}";
-                var vc2 = $"{v}{cc[0]}";
                 var vrr = $"{v}rr";
                 if (cc[0] == "r" && HasOto(vrr, ending.tone)) {
                     phonemes.Add(vrr);
-                } else if (HasOto(vcr, ending.tone)) {   // applies ending VC
-                    phonemes.Add(vcr);
-                } else if (!HasOto(vcr, ending.tone) && (HasOto(vc1, ending.tone))) {   // if no ending VC, then regular VC
-                    phonemes.Add(vc1);
+                } else {   // applies ending VC
+                    TryAddPhoneme(phonemes, ending.tone, $"{v} {cc[0]}-", $"{v}{cc[0]}-", $"{v} {cc[0]}", $"{v}{cc[0]}", $"{cc[0]}");
                     if (burstConsonants.Contains(cc[0])) {
                         TryAddPhoneme(phonemes, ending.tone, cc[0]);
                     }
-                } else if (!HasOto(vc1, ending.tone) && HasOto(vc2, ending.tone)) {
-                    phonemes.Add(vc2);
-                } else if (!HasOto(vc2, ending.tone) && !HasOto(vc2, ending.tone)) {
-                    phonemes.Add($"{cc[0]}");
                 }
             } else if (ending.IsEndingVCWithMoreThanOneConsonant) {   // ending VCC (very rare, usually only occurs in words ending with "x")
                 var vcc = $"{v} {string.Join("", cc)}";
@@ -325,12 +316,7 @@ namespace OpenUtau.Plugin.Builtin {
                 var vc2 = $"{v}{cc[0]}";
                 var cc1 = $"{cc[0]} {cc[1]}";
                 var cc2 = $"{cc[0]}{cc[1]}";
-                if (HasOto(vcc, ending.tone)) {   // applies ending VCC
-                    phonemes.Add(vcc);
-                }
-                if (!HasOto(vcc, ending.tone)) {   // if no ending VCC, then CC transitions
-                    TryAddPhoneme(phonemes, ending.tone, vcc2);
-                }
+                TryAddPhoneme(phonemes, ending.tone, vcc, vcc2);
                 if (!HasOto(vcc, ending.tone) && !HasOto(vcc2, ending.tone) && HasOto(vc, ending.tone)) {
                     phonemes.Add(vc);
                     TryAddPhoneme(phonemes, ending.tone, cc1);


### PR DESCRIPTION
The Spanish to Japanese Phonemizer is mostly based on the English to Japanese Phonemizer, code-wise; just with some tweaks specific to Spanish. But it functions more or less the same way.
Will add info to the wiki as soon as it's merged.

I also noticed that the ENtoJA Phonemizer didn't have support for vowel endings, so I added it.

I also tweaked the ES-SYL phonemizer a bit, shouldn't be too different in terms of functionality though. No new functions have been added for now.