### PR TITLE
add reverse log order button

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -101,6 +101,7 @@ namespace OpenUtau.Core.Util {
             public double PlayPosMarkerMargin = 0.9;
             public int LockStartTime = 0;
             public int PlaybackAutoScroll = 1;
+            public bool ReverseLogOrder = true;
         }
     }
 }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -11,6 +11,8 @@
   <system:String x:Key="context.pitch.pointsnapprev">Snap to previous note</system:String>
 
   <system:String x:Key="debug.clear">Clear</system:String>
+    
+  <system:String x:Key="debug.reverselogorder">Reverse Log Order</system:String>
 
   <system:String x:Key="dialogs.about.caption">About OpenUTAU</system:String>
   <system:String x:Key="dialogs.about.message">

--- a/OpenUtau/Views/DebugWindow.axaml
+++ b/OpenUtau/Views/DebugWindow.axaml
@@ -29,6 +29,7 @@
         <ComboBoxItem Content="Error"/>
         <ComboBoxItem Content="Fatal"/>
       </ComboBox>
+      <Button Margin="0" Command="{Binding ReverseLogOrderCommand}" Content="{DynamicResource debug.reverselogorder}" />
       <Button Margin="0" Command="{Binding Clear}" Content="{DynamicResource debug.clear}"/>
     </StackPanel>
   </Grid>


### PR DESCRIPTION
Added reverse log order to preferences (`SerializablePreferences`)
Added reverse log order string (`Strings`, English only (let me know and I can add it to other language files too))
Added reverse log order functionality and sorted usings (`DebugViewModel`)
Added reverse log order button and command binding (`DebugWindow`)