### PR TITLE
Fixes/additions for 3 different phonemizers

### DIFF
--- a/OpenUtau.Plugin.Builtin/ENtoJAPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENtoJAPhonemizer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Api;
@@ -390,6 +390,10 @@ namespace OpenUtau.Plugin.Builtin {
                         solo = FixCv(solo, ending.tone);
                     }
                     phonemes.Add(solo);
+                }
+
+                if (solo.Contains("ん")) {
+                    TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
                 }
                 prevV = WanaKana.ToRomaji(solo).Last<char>().ToString();
             }

--- a/OpenUtau.Plugin.Builtin/ENtoJAPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENtoJAPhonemizer.cs
@@ -393,8 +393,21 @@ namespace OpenUtau.Plugin.Builtin {
                 }
 
                 if (solo.Contains("ん")) {
-                    TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                    if (ending.IsEndingVCWithOneConsonant) {
+                        TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                    } else if (ending.IsEndingVCWithMoreThanOneConsonant) {
+                        if (cc[1].Contains("n") && cc[1].Contains(cc.Last())) {
+                            TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                        } else if (cc[1].Contains("ng") && cc[1].Contains(cc.Last())) {
+                            TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                        } else if (cc[2].Contains("n") && cc[2].Contains(cc.Last())) {
+                            TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                        } else if (cc[2].Contains("ng") && cc[2].Contains(cc.Last())) {
+                            TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                        }
+                    }
                 }
+
                 prevV = WanaKana.ToRomaji(solo).Last<char>().ToString();
             }
             

--- a/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
@@ -542,6 +542,10 @@ namespace OpenUtau.Plugin.Builtin {
                     }
                     phonemes.Add(solo);
                 }
+
+                if (solo.Contains("ん")) {
+                    TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                }
                 prevV = WanaKana.ToRomaji(solo).Last<char>().ToString();
             }
 

--- a/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
@@ -544,8 +544,21 @@ namespace OpenUtau.Plugin.Builtin {
                 }
 
                 if (solo.Contains("ん")) {
-                    TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                    if (ending.IsEndingVCWithOneConsonant) {
+                        TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                    } else if (ending.IsEndingVCWithMoreThanOneConsonant) {
+                        if (cc[1].Contains("n") && cc[1].Contains(cc.Last())) {
+                            TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                        } else if (cc[1].Contains("ng") && cc[1].Contains(cc.Last())) {
+                            TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                        } else if (cc[2].Contains("n") && cc[2].Contains(cc.Last())) {
+                            TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                        } else if (cc[2].Contains("ng") && cc[2].Contains(cc.Last())) {
+                            TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
+                        }
+                    }
                 }
+
                 prevV = WanaKana.ToRomaji(solo).Last<char>().ToString();
             }
 

--- a/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EStoJAPhonemizer.cs
@@ -549,11 +549,11 @@ namespace OpenUtau.Plugin.Builtin {
                     } else if (ending.IsEndingVCWithMoreThanOneConsonant) {
                         if (cc[1].Contains("n") && cc[1].Contains(cc.Last())) {
                             TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
-                        } else if (cc[1].Contains("ng") && cc[1].Contains(cc.Last())) {
+                        } else if (cc[1].Contains("m") && cc[1].Contains(cc.Last())) {
                             TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
                         } else if (cc[2].Contains("n") && cc[2].Contains(cc.Last())) {
                             TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
-                        } else if (cc[2].Contains("ng") && cc[2].Contains(cc.Last())) {
+                        } else if (cc[2].Contains("m") && cc[2].Contains(cc.Last())) {
                             TryAddPhoneme(phonemes, ending.tone, $"n R", $"n -", $"n-");
                         }
                     }

--- a/OpenUtau.Plugin.Builtin/TetoEnglishPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/TetoEnglishPhonemizer.cs
@@ -38,8 +38,13 @@ namespace OpenUtau.Plugin.Builtin {
             if (syllable.IsStartingV) {
                 basePhoneme = $"- {v}";
             } else if (syllable.IsVV) {
-                basePhoneme = $"{prevV} {v}";
-                if (!HasOto(basePhoneme, syllable.vowelTone)) {
+                if (!CanMakeAliasExtension(syllable)) {
+                    basePhoneme = $"{prevV} {v}";
+                } else {
+                    // the previous alias will be extended
+                    basePhoneme = null;
+                } 
+                if (!HasOto($"{prevV} {v}", syllable.vowelTone)) {
                     basePhoneme = $"- {v}";
                     phonemes.Add($"{prevV} -");
                 }

--- a/OpenUtau.Plugin.Builtin/TetoEnglishPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/TetoEnglishPhonemizer.cs
@@ -113,6 +113,10 @@ namespace OpenUtau.Plugin.Builtin {
                                 lastC = i;
                                 basePhoneme = ccv;
                                 break;
+                            } else if (string.Join("", cc.Skip(i)) == "hj") {
+                                lastC = i;
+                                basePhoneme = $"- hju";
+                                break;
                             }
                         }
                     }

--- a/OpenUtau.Plugin.Builtin/TetoEnglishPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/TetoEnglishPhonemizer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -83,8 +83,13 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             } else { // VCV
                 var vcv = $"{prevV} h{v}";
-                if (cc[0] == "h" && HasOto(vcv, syllable.vowelTone)) {
+                if (cc[0] == "h" && syllable.IsVCVWithOneConsonant && HasOto(vcv, syllable.vowelTone)) {
                     basePhoneme = vcv;
+                } else if (string.Join("", cc) == "hj" && prevV == "u" && syllable.IsVCVWithMoreThanOneConsonant && HasOto($"u hju", syllable.vowelTone)) {
+                    basePhoneme = $"u hju";
+                } else if (string.Join("", cc) == "hj" && prevV != "u") {
+                    basePhoneme = $"- hju";
+                    phonemes.Add($"{prevV} -");
                 } else {
                     // try vcc
                     for (var i = lastC + 1; i >= 0; i--) {


### PR DESCRIPTION
ENtoJA/EStoJA:
- Added ending support for notes containing "ん" (for both phonemizers).

Teto EN:
- Fixed bug related to "hj" consonant cluster; it should now function correctly.
- Added vowel alias extension functionality.