### PR TITLE
Edit lyric: Hanzi mode / 歌词编辑：汉字模式

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -53,6 +53,7 @@
   <system:String x:Key="lyrics.apply">Apply</system:String>
   <system:String x:Key="lyrics.cancel">Cancel</system:String>
   <system:String x:Key="lyrics.caption">Edit Lyrics</system:String>
+  <system:String x:Key="lyrics.hanzimode">Hanzi</system:String>
   <system:String x:Key="lyrics.livepreview">Live preview</system:String>
   <system:String x:Key="lyrics.max">Max</system:String>
   <system:String x:Key="lyrics.reset">Reset</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -49,6 +49,7 @@
   <system:String x:Key="lyrics.apply">应用</system:String>
   <system:String x:Key="lyrics.cancel">取消</system:String>
   <system:String x:Key="lyrics.caption">编辑歌词</system:String>
+  <system:String x:Key="lyrics.hanzimode">汉字模式</system:String>
   <system:String x:Key="lyrics.livepreview">即时预览</system:String>
   <system:String x:Key="lyrics.max">最多</system:String>
   <system:String x:Key="lyrics.reset">重置</system:String>

--- a/OpenUtau/ViewModels/LyricsViewModel.cs
+++ b/OpenUtau/ViewModels/LyricsViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using DynamicData;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
@@ -15,6 +16,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int CurrentCount { get; set; }
         [Reactive] public int TotalCount { get; set; }
         [Reactive] public int MaxCount { get; set; }
+        [Reactive] public bool SeparatePerChar { get; set; }
         [Reactive] public bool SeparateBySpace { get; set; }
         [Reactive] public bool SeparateByComma { get; set; }
         [Reactive] public bool SeparateByQuote { get; set; }
@@ -31,7 +33,8 @@ namespace OpenUtau.App.ViewModels {
                 x => x.Text,
                 x => x.SeparateBySpace,
                 x => x.SeparateByComma,
-                x => x.SeparateByQuote)
+                x => x.SeparateByQuote,
+                x => x.SeparatePerChar)
                 .Subscribe(t => {
                     Preview(t.Item1);
                 });
@@ -45,6 +48,7 @@ namespace OpenUtau.App.ViewModels {
             SeparateBySpace = !lyrics.Any(l => l.Contains(' '));
             SeparateByComma = !lyrics.Any(l => l.Contains(','));
             SeparateByQuote = !lyrics.Any(l => l.Contains('"'));
+            SeparatePerChar = false;
             char sep = SeparateBySpace ? ' ' : SeparateByComma ? ',' : '\n';
             Text = string.Join(sep, lyrics);
             startLyrics = lyrics;
@@ -113,7 +117,11 @@ namespace OpenUtau.App.ViewModels {
                         }
                     }
                 } else {
-                    builder.Append(ele);
+                    if (SeparatePerChar) {
+                        lyrics.Add(ele);
+                    } else {
+                        builder.Append(ele);
+                    }
                 }
             }
             if (builder.Length > 0) {

--- a/OpenUtau/Views/LyricsDialog.axaml
+++ b/OpenUtau/Views/LyricsDialog.axaml
@@ -20,6 +20,9 @@
     </TextBlock>
     <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="4">
       <TextBlock Text="{StaticResource lyrics.separators}" Margin="0,2"/>
+      <ToggleButton Content="{StaticResource lyrics.hanzimode}" Margin="0" BorderThickness="1" CornerRadius="5"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                    IsChecked="{Binding SeparatePerChar}"/>
       <ToggleButton Content="⎵" Margin="0" BorderThickness="1" CornerRadius="5"
                     BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
                     IsChecked="{Binding SeparateBySpace}"/>


### PR DESCRIPTION
在“汉字模式”下，文本框中的每个字符将分配给一个音符。
OpenUTAU是面向全球用户的软件，“汉字模式”可能不太恰当，如果有更好的名称欢迎改正

---

In Hanzi mode, each single character in the textblock will be given to a note.
As OpenUTAU is used by people all around the world, "Hanzi mode" might be a bad name for this feature. If you have a better idea, feel free to correct it

<img width="960" alt="6397e46134e92961d6e78d373dbb210" src="https://user-images.githubusercontent.com/54425948/179785823-3a0151c4-758e-477e-a15c-6444badc4e3f.png">
