### PR TITLE
midi导入：支持歌词 / Midi importing: lyric support 

### DIFF
--- a/OpenUtau.Core/Format/Midi.cs
+++ b/OpenUtau.Core/Format/Midi.cs
@@ -17,12 +17,12 @@ namespace OpenUtau.Core.Format
         {
             List<UVoicePart> resultParts = new List<UVoicePart>();
             MidiFile midi = new MidiFile(file);
+            string lyric = NotePresets.Default.DefaultLyric;
             for (int i = 0; i < midi.Tracks; i++)
             {
                 Dictionary<int, UVoicePart> parts = new Dictionary<int, UVoicePart>();
-                foreach (var e in midi.Events.GetTrackEvents(i))
-                    if (e is NoteOnEvent)
-                    {
+                foreach (var e in midi.Events.GetTrackEvents(i)) {
+                    if (e is NoteOnEvent) {
                         var _e = e as NoteOnEvent;
                         if (_e.OffEvent == null) {
                             continue;
@@ -32,9 +32,21 @@ namespace OpenUtau.Core.Format
                             _e.NoteNumber,
                             (int)_e.AbsoluteTime * project.resolution / midi.DeltaTicksPerQuarterNote,
                             _e.NoteLength * project.resolution / midi.DeltaTicksPerQuarterNote);
+                        if(lyric=="-") {
+                            lyric = "+";
+                        }
+                        note.lyric = lyric;
                         if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) note.vibrato.length = NotePresets.Default.DefaultVibrato.VibratoLength;
                         parts[e.Channel].notes.Add(note);
+                        lyric = NotePresets.Default.DefaultLyric;
                     }
+                    else if (e is TextEvent) { //Lyric event
+                        var _e = e as TextEvent;
+                        if(_e.MetaEventType == MetaEventType.Lyric) {
+                            lyric = _e.Text;
+                        }
+                    }
+                }
                 foreach (var pair in parts)
                 {
                     pair.Value.Duration = pair.Value.GetMinDurTick(project);

--- a/OpenUtau.Core/Format/Midi.cs
+++ b/OpenUtau.Core/Format/Midi.cs
@@ -24,7 +24,6 @@ namespace OpenUtau.Core.Format
     {
         static public List<UVoicePart> Load(string file, UProject project)
         {
-
             List<UVoicePart> resultParts = new List<UVoicePart>();
             MidiFile midi = new MidiFile(file);
             string lyric = NotePresets.Default.DefaultLyric;

--- a/OpenUtau.Core/Format/Midi.cs
+++ b/OpenUtau.Core/Format/Midi.cs
@@ -5,21 +5,53 @@ using System.Text;
 using System.Threading.Tasks;
 
 using NAudio.Midi;
+using NChardet;
 
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
 
 namespace OpenUtau.Core.Format
 {
+    public class MyCharsetDetectionObserver: NChardet.ICharsetDetectionObserver
+    {
+        public string Charset = null;
+
+        public void Notify(string charset) {
+            Charset = charset;
+        }
+    }
     public static class Midi
     {
         static public List<UVoicePart> Load(string file, UProject project)
         {
+
             List<UVoicePart> resultParts = new List<UVoicePart>();
             MidiFile midi = new MidiFile(file);
             string lyric = NotePresets.Default.DefaultLyric;
             for (int i = 0; i < midi.Tracks; i++)
             {
+                //detect lyric encoding
+                Detector det = new Detector(6);
+                MyCharsetDetectionObserver cdo = new MyCharsetDetectionObserver();
+                det.Init(cdo);
+                bool done = false;
+                foreach (var e in midi.Events.GetTrackEvents(i)) {
+                    if (e is TextEvent) { //Lyric event
+                        var _e = e as TextEvent;
+                        if (_e.MetaEventType == MetaEventType.Lyric) {
+                            done = det.DoIt(_e.Data, _e.Data.Length, false);
+                            if (done) {
+                                break;
+                            }
+                        }
+                    }
+                }
+                det.DataEnd();
+                string Charset = cdo.Charset;
+                Encoding lyricEncoding = Encoding.UTF8;
+                if (Charset!=null){
+                    lyricEncoding = Encoding.GetEncoding(Charset);
+                }
                 Dictionary<int, UVoicePart> parts = new Dictionary<int, UVoicePart>();
                 foreach (var e in midi.Events.GetTrackEvents(i)) {
                     if (e is NoteOnEvent) {
@@ -43,7 +75,7 @@ namespace OpenUtau.Core.Format
                     else if (e is TextEvent) { //Lyric event
                         var _e = e as TextEvent;
                         if(_e.MetaEventType == MetaEventType.Lyric) {
-                            lyric = _e.Text;
+                            lyric = lyricEncoding.GetString(_e.Data);
                         }
                     }
                 }

--- a/OpenUtau.Core/OpenUtau.Core.csproj
+++ b/OpenUtau.Core/OpenUtau.Core.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="NAudio.Core" Version="2.0.0" />
     <PackageReference Include="NAudio.Midi" Version="2.0.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
+    <PackageReference Include="NChardet" Version="1.0.1.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.3.0" />
     <PackageReference Include="NumSharp" Version="0.30.0" />


### PR DESCRIPTION
不同软件导出的Midi文件歌词编码不同，因此使用[Nchardet](https://github.com/thinksea/NChardet)库（[开源协议](https://github.com/thinksea/NChardet/blob/master/LICENSE)）进行自动检测。

若不允许引用该库，可以合并我的[midi-lyric](https://github.com/oxygen-dioxide/OpenUtau/tree/midi-lyric)分支，该分支仅支持导入ascii编码的歌词