### PR TITLE
[JP CVVC Phonemizer] CV voice color fix + add crossfade vowel support

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
@@ -124,6 +124,7 @@ namespace OpenUtau.Plugin.Builtin {
             var note = notes[0];
             var currentUnicode = ToUnicodeElements(note.lyric);
             var vowLyric = note.lyric;
+            var cvLyric = note.lyric;
             var currentLyric = note.lyric;
             var attr0 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
             var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
@@ -143,8 +144,10 @@ namespace OpenUtau.Plugin.Builtin {
                         currentLyric = oto.Alias;
                     }
                 }
-            } else if (singer.TryGetMappedOto(currentLyric, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)) {
-                currentLyric = oto.Alias;
+            } else if (cvLyric.Contains(currentLyric)) {
+                if (singer.TryGetMappedOto(cvLyric, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)) {
+                    currentLyric = oto.Alias;
+                }
             }
 
             if (nextNeighbour != null) {

--- a/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
@@ -126,6 +126,7 @@ namespace OpenUtau.Plugin.Builtin {
             var vowLyric = note.lyric;
             var cvLyric = note.lyric;
             var currentLyric = note.lyric;
+            var cfLyric = $"* {currentLyric}";
             var attr0 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
             var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
 
@@ -134,6 +135,8 @@ namespace OpenUtau.Plugin.Builtin {
                 var initial = $"- {currentLyric}";
                 if (singer.TryGetMappedOto(initial, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)) {
                     currentLyric = oto.Alias;
+                } else if (singer.TryGetMappedOto(cvLyric, note.tone + attr0.toneShift, attr0.voiceColor, out var oto2)) {
+                    currentLyric = oto2.Alias;
                 }
             } else if (plainVowels.Contains(currentLyric)) {
                 var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
@@ -142,6 +145,10 @@ namespace OpenUtau.Plugin.Builtin {
                     vowLyric = $"{vow} {currentLyric}";
                     if (singer.TryGetMappedOto(vowLyric, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)) {
                         currentLyric = oto.Alias;
+                    } else if (singer.TryGetMappedOto(cfLyric, note.tone + attr0.toneShift, attr0.voiceColor, out var oto2)) {
+                        currentLyric = oto2.Alias;
+                    } else if (singer.TryGetMappedOto(cvLyric, note.tone + attr0.toneShift, attr0.voiceColor, out var oto3)) {
+                        currentLyric = oto3.Alias;
                     }
                 }
             } else if (cvLyric.Contains(currentLyric)) {


### PR DESCRIPTION
Please note that it will inherit the main voice color's ``[- CV]``, ``[V V]`` and/or ``[V C]`` notes if the voice color of your choice does not contain them but the main color does. However, there should be no issue with CV banks, as well as CVVC banks with a consistent aliasing system across all voice colors.

I've also added support for crossfade vowels (``[* V]``) if the voicebank has them. The above also applies here.