### PR TITLE
Add ghost notes feature (show notes in other tracks in piano roll)

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -101,6 +101,7 @@ namespace OpenUtau.Core.Util {
             public int PlaybackAutoScroll = 1;
             public bool ReverseLogOrder = true;
             public bool ShowPortrait = true;
+            public bool ShowGhostNotes = true;
             public Dictionary<string, string> DefaultResamplers = new Dictionary<string, string>();
             public Dictionary<string, string> DefaultWavtools = new Dictionary<string, string>();
         }

--- a/OpenUtau/Controls/NotesCanvas.cs
+++ b/OpenUtau/Controls/NotesCanvas.cs
@@ -106,7 +106,7 @@ namespace OpenUtau.App.Controls {
         public NotesCanvas() {
             ClipToBounds = true;
             pointGeometry = new EllipseGeometry(new Rect(-2.5, -2.5, 5, 5));
-            showGhostNotes = Convert.ToBoolean(Preferences.Default.ShowGhostNotes);
+
             MessageBus.Current.Listen<NotesRefreshEvent>()
                 .Subscribe(_ => InvalidateVisual());
             MessageBus.Current.Listen<NotesSelectionEvent>()
@@ -116,17 +116,15 @@ namespace OpenUtau.App.Controls {
                     selectedNotes.UnionWith(e.tempSelectedNotes);
                     InvalidateVisual();
                 });
-            if (showGhostNotes) {
-                RefreshGhostNotes();
-                MessageBus.Current.Listen<PartRefreshEvent>()
-                    .Subscribe(_ => RefreshGhostNotes());
-                this.WhenAnyValue(x => x.Part)
-                    .Subscribe(_ => RefreshGhostNotes());
-            }
+            MessageBus.Current.Listen<PartRefreshEvent>()
+                .Subscribe(_ => RefreshGhostNotes());
+            this.WhenAnyValue(x => x.Part)
+                .Subscribe(_ => RefreshGhostNotes());
         }
 
         void RefreshGhostNotes() {
-            if (Part == null) {
+            showGhostNotes = Convert.ToBoolean(Preferences.Default.ShowGhostNotes);
+            if (Part == null || !showGhostNotes) {
                 return;
             }
             otherPartsInView = DocManager.Inst.Project.parts

--- a/OpenUtau/Controls/NotesCanvas.cs
+++ b/OpenUtau/Controls/NotesCanvas.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using ReactiveUI;
 
 namespace OpenUtau.App.Controls {
@@ -98,9 +100,13 @@ namespace OpenUtau.App.Controls {
         private HashSet<UNote> selectedNotes = new HashSet<UNote>();
         private Geometry pointGeometry;
 
+        private bool showGhostNotes = true;
+        private List<UPart> otherPartsInView = new List<UPart>();
+
         public NotesCanvas() {
             ClipToBounds = true;
             pointGeometry = new EllipseGeometry(new Rect(-2.5, -2.5, 5, 5));
+            showGhostNotes = Convert.ToBoolean(Preferences.Default.ShowGhostNotes);
             MessageBus.Current.Listen<NotesRefreshEvent>()
                 .Subscribe(_ => InvalidateVisual());
             MessageBus.Current.Listen<NotesSelectionEvent>()
@@ -110,6 +116,24 @@ namespace OpenUtau.App.Controls {
                     selectedNotes.UnionWith(e.tempSelectedNotes);
                     InvalidateVisual();
                 });
+            if (showGhostNotes) {
+                RefreshGhostNotes();
+                MessageBus.Current.Listen<PartRefreshEvent>()
+                    .Subscribe(_ => RefreshGhostNotes());
+                this.WhenAnyValue(x => x.Part)
+                    .Subscribe(_ => RefreshGhostNotes());
+            }
+        }
+
+        void RefreshGhostNotes() {
+            if (Part == null) {
+                return;
+            }
+            otherPartsInView = DocManager.Inst.Project.parts
+                .Where(other => other.trackNo != Part.trackNo &&
+                    other.position < Part.End &&
+                    Part.position < other.End)
+                .ToList();
         }
 
         protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change) {
@@ -132,6 +156,20 @@ namespace OpenUtau.App.Controls {
             double leftTick = TickOffset - 480;
             double rightTick = TickOffset + Bounds.Width / TickWidth + 480;
             bool hidePitch = viewModel.TickWidth <= ViewConstants.PianoRollTickWidthShowDetails * 0.5;
+
+            if (showGhostNotes) {
+                foreach (UVoicePart otherPart in otherPartsInView) {
+                    var xOffset = otherPart.position - Part.position;
+                    foreach (var note in otherPart.notes) {
+                        if (note.LeftBound >= rightTick || note.RightBound <= leftTick) {
+                            continue;
+                        }
+                        RenderGhostNote(note, viewModel, context, xOffset);
+                    }
+
+                }
+            }
+
             foreach (var note in Part.notes) {
                 if (note.LeftBound >= rightTick || note.RightBound <= leftTick) {
                     continue;
@@ -185,6 +223,24 @@ namespace OpenUtau.App.Controls {
             using (var state = context.PushPreTransform(Matrix.CreateTranslation(textPosition.X, textPosition.Y))) {
                 textLayout.Draw(context);
             }
+        }
+
+        private void RenderGhostNote(UNote note, NotesViewModel viewModel, DrawingContext context, int partOffset) {
+            // REVIEW should ghost note be smaller?
+            double relativeSize = 0.5d;
+            double height = TrackHeight * relativeSize;
+            double yOffset = Math.Floor(height * 0.5f);
+            Point leftTop = viewModel.TickToneToPoint(partOffset + note.position, note.tone);
+            leftTop = leftTop.WithX(leftTop.X + 1).WithY(Math.Round(leftTop.Y + 1 + yOffset));
+
+            Size size = viewModel.TickToneToSize(note.duration, relativeSize);
+            size = size.WithWidth(size.Width - 1).WithHeight(Math.Floor(size.Height - 2));
+
+            Point rightBottom = new Point(leftTop.X + size.Width, leftTop.Y + size.Height);
+
+            // REVIEW Using existing color to avoid problems with theming. Not sure if ideal color.
+            var brush = ThemeManager.NeutralAccentBrushSemi;
+            context.DrawRectangle(brush, null, new Rect(leftTop, rightBottom), 2, 2);
         }
 
         private void RenderPitchBend(UNote note, NotesViewModel viewModel, DrawingContext context) {

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -215,6 +215,7 @@ Hold Ctrl to select</system:String>
   <system:String x:Key="prefs.appearance">Appearance</system:String>
   <system:String x:Key="prefs.appearance.lang">Language</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>
+  <system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>
   <system:String x:Key="prefs.appearance.theme">Theme</system:String>
   <system:String x:Key="prefs.appearance.theme.dark">Dark</system:String>
   <system:String x:Key="prefs.appearance.theme.light">Light</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -33,6 +33,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int PreRender { get; set; }
         [Reactive] public int Theme { get; set; }
         [Reactive] public int ShowPortrait { get; set; }
+        [Reactive] public int ShowGhostNotes { get; set; }
         public List<CultureInfo>? Languages { get; }
         public CultureInfo? Language {
             get => language;
@@ -76,6 +77,7 @@ namespace OpenUtau.App.ViewModels {
             PreRender = Preferences.Default.PreRender ? 1 : 0;
             Theme = Preferences.Default.Theme;
             ShowPortrait = Preferences.Default.ShowPortrait ? 1 : 0;
+            ShowGhostNotes = Preferences.Default.ShowGhostNotes ? 1 : 0;
 
             this.WhenAnyValue(vm => vm.AudioOutputDevice)
                 .WhereNotNull()
@@ -134,6 +136,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.ShowPortrait)
                 .Subscribe(index => {
                     Preferences.Default.ShowPortrait = index > 0;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.ShowGhostNotes)
+                .Subscribe(index => {
+                    Preferences.Default.ShowGhostNotes = index > 0;
                     Preferences.Save();
                 });
         }

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -103,6 +103,11 @@
               <ComboBoxItem Content="{DynamicResource prefs.off}"/>
               <ComboBoxItem Content="{DynamicResource prefs.on}"/>
             </ComboBox>
+            <TextBlock Margin="0,4,0,0" Text="{DynamicResource prefs.appearance.showghostnotes}" />
+            <ComboBox HorizontalAlignment="Stretch" SelectedIndex="{Binding ShowGhostNotes}">
+                <ComboBoxItem Content="{DynamicResource prefs.off}"/>
+                <ComboBoxItem Content="{DynamicResource prefs.on}"/>
+            </ComboBox>  
           </StackPanel>
         </HeaderedContentControl>
         <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.advanced}">


### PR DESCRIPTION
This PR adds a "Ghost Notes" feature to OpenUtau, that shows the notes of other tracks when viewing a part in the Piano Roll. This is similar to the "Ghost Notes" feature in FL Studio, or Ableton's multi-clip view.

* Added preferences option for enabling/disabling feature
* Handles part changes/moves

![ghost-notes](https://user-images.githubusercontent.com/2904993/188921929-84a7dc79-ca3e-4a1e-9b4f-c0341187fd97.png)

### TODO
[ ] Review naming / language - I'm not married to "Ghost Notes"
[ ] Review styling choices (currently uses existing "NeutralAccentBrushSemi" brush color, and display slightly thinner)
[ ] Add additional translation strings
[ ] Choose default option (enabled/disabled)
[ ] Handle initial load when preference not set *(I'm not familiar with this behavior)*