### PR TITLE
enunu english: fix a bug

### DIFF
--- a/OpenUtau.Core/Enunu/EnunuEnglishPhonemizer.cs
+++ b/OpenUtau.Core/Enunu/EnunuEnglishPhonemizer.cs
@@ -148,11 +148,7 @@ namespace OpenUtau.Core.Enunu {
                     noteIndex = noteIndex,
 
                 };
-                if (alignment.Item1 == alignments.Last().Item1 || !(alignment.Item3)) {
-                    endIndex= alignment.Item1;
-                } else {
-                    endIndex = alignment.Item1 - 1;
-                }
+                endIndex= alignment.Item1;
 
                 for(int index = startIndex; index < endIndex; index++) {
                     enunuNote.lyric += symbols[index] + " ";


### PR DESCRIPTION
Sometimes consonant will occupy the full length of a note
Before fix:
![image](https://user-images.githubusercontent.com/54425948/190544661-a8da093a-14b7-445e-b922-9d3ba2490d30.png)
After fix:
![image](https://user-images.githubusercontent.com/54425948/190544687-b400ee77-255d-4685-86f0-b770bcbff501.png)
