### PR TITLE
fix pen plus tool icon's color in dark mode

### DIFF
--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -195,7 +195,7 @@
                             Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="2+"
                             ToolTip.Tip="{DynamicResource pianoroll.tool.penplus}">
                 <Grid Width="18" Height="18">
-                  <Path Fill="Black" Data="M14.1,9L15,9.9L5.9,19H5V18.1L14.1,9M17.7,3C17.5,3 17.2,3.1 17,3.3L15.2,5.1L18.9,8.9L20.7,7C21.1,6.6 21.1,6 20.7,5.6L18.4,3.3C18.2,3.1 17.9,3 17.7,3M14.1,6.2L3,17.2V21H6.8L17.8,9.9L14.1,6.2M7,2V5H10V7H7V10H5V7H2V5H5V2H7Z" >
+                  <Path Classes="filled" Data="M14.1,9L15,9.9L5.9,19H5V18.1L14.1,9M17.7,3C17.5,3 17.2,3.1 17,3.3L15.2,5.1L18.9,8.9L20.7,7C21.1,6.6 21.1,6 20.7,5.6L18.4,3.3C18.2,3.1 17.9,3 17.7,3M14.1,6.2L3,17.2V21H6.8L17.8,9.9L14.1,6.2M7,2V5H10V7H7V10H5V7H2V5H5V2H7Z" >
                     <Path.RenderTransform>
                       <TransformGroup>
                         <ScaleTransform ScaleX=".6" ScaleY=".6" />


### PR DESCRIPTION
Before fix:
<img width="528" alt="image" src="https://user-images.githubusercontent.com/54425948/192666885-21a659f4-7bdf-44e9-840f-ab5597f53772.png">

After fix:
<img width="510" alt="image" src="https://user-images.githubusercontent.com/54425948/192666925-fa3b768e-be4c-4558-a9be-24538c9e7129.png">
I'm using Windows. I'm not sure know how it looks on other platforms.