### PR TITLE
[Multiple phonemizers] Add legacy mapping support

### DIFF
--- a/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
@@ -34,6 +34,9 @@ namespace OpenUtau.Plugin.Builtin {
 
         // Simply stores the singer in a field.
         public override void SetSinger(USinger singer) => this.singer = singer;
+        
+        // Legacy mapping. Might adjust later to new mapping style.
+		public override bool LegacyMapping => true;
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             // The overall logic is:

--- a/OpenUtau.Plugin.Builtin/KoreanCVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCCVPhonemizer.cs
@@ -199,6 +199,9 @@ namespace OpenUtau.Plugin.Builtin {
         private USinger singer;
         public override void SetSinger(USinger singer) => this.singer = singer;
         
+        // Legacy mapping. Might adjust later to new mapping style.
+		public override bool LegacyMapping => true;
+        
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevs) {
             var prevLyric = prevNeighbour?.lyric;
             var nextLyric = nextNeighbour?.lyric;

--- a/OpenUtau.Plugin.Builtin/KoreanCVVCStandardPronunciationPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVVCStandardPronunciationPhonemizer.cs
@@ -415,6 +415,9 @@ namespace OpenUtau.Plugin.Builtin {
         // Store singer in field, will try reading presamp.ini later
         private USinger singer;
         public override void SetSinger(USinger singer) => this.singer = singer;
+        
+        // Legacy mapping. Might adjust later to new mapping style.
+		public override bool LegacyMapping => true;
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             var prevLyric = prevNeighbour?.lyric;

--- a/OpenUtau.Plugin.Builtin/KoreanVCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanVCVPhonemizer.cs
@@ -115,6 +115,9 @@ namespace OpenUtau.Plugin.Builtin
 
 		// Store singer
 		public override void SetSinger(USinger singer) => this.singer = singer;
+        
+        // Legacy mapping. Might adjust later to new mapping style.
+		public override bool LegacyMapping => true;
 
 		public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours)
 		{

--- a/OpenUtau.Plugin.Builtin/VietnameseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/VietnameseCVVCPhonemizer.cs
@@ -41,6 +41,9 @@ namespace OpenUtau.Plugin.Builtin {
         private USinger singer;
 
         public override void SetSinger(USinger singer) => this.singer = singer;
+        
+        // Legacy mapping. Might adjust later to new mapping style.
+		public override bool LegacyMapping => true;
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             var note = notes[0];

--- a/OpenUtau.Plugin.Builtin/VietnameseVCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/VietnameseVCVPhonemizer.cs
@@ -41,6 +41,9 @@ namespace OpenUtau.Plugin.Builtin {
         private USinger singer;
 
         public override void SetSinger(USinger singer) => this.singer = singer;
+        
+        // Legacy mapping. Might adjust later to new mapping style.
+		public override bool LegacyMapping => true;
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             var note = notes[0];


### PR DESCRIPTION
This restores pitch symbol support in certain legacy phonemizers, and in certain cases, voice color as well.

Affected phonemizers:
- ZH CVV
- KO CVCCV
- KO CVVC
- KO VCV (also restores voice color)
- VIE CVVC (also restores voice color)
- VIE VCV (also restores voice color)

I might replace legacy mapping in these phonemizers one day with a better solution, similar to KO CVC (which uses a different, non-legacy mapping method).

Phonemizers not listed weren't affected, so no action needed to be taken there.