### PR TITLE
Implement note multi-selection by `Ctrl + Click` and `Shift + Click`

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -402,9 +402,26 @@ namespace OpenUtau.App.ViewModels {
             Notify();
         }
 
+        private void DeselectNote(UNote note) {
+            if (Selection.Remove(note)) {
+                MessageBus.Current.SendMessage(new NotesSelectionEvent(Selection));
+            }
+        }
+
         public void DeselectNotes() {
             Selection.SelectNone();
             MessageBus.Current.SendMessage(new NotesSelectionEvent(Selection));
+        }
+
+        public void ToggleSelectNote(UNote note) {
+            if (Part == null) {
+                return;
+            }
+            if (Selection.Contains(note)) {
+                DeselectNote(note);
+            } else {
+                SelectNote(note);
+            }
         }
 
         public void SelectNote(UNote note) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -440,6 +440,47 @@ namespace OpenUtau.App.ViewModels {
             MessageBus.Current.SendMessage(new NotesSelectionEvent(Selection));
         }
 
+        public void SelectNotesUntil(UNote note) {
+            if (Part == null) {
+                return;
+            }
+            if (Part.notes.Intersect(Selection).ToList().Count == 0) {
+                SelectNote(note);
+                return;
+            }
+            var thisIndex = Part.notes.IndexOf(note);
+            if (thisIndex < 0) {
+                return;
+            }
+            var firstSelectedNote = Part.notes.FirstOrDefault(x => Selection.Contains(x));
+            if (firstSelectedNote == null) {
+                return;
+            }
+            var rangeStart = Part.notes.IndexOf(firstSelectedNote);
+            var lastSelectedNote = Part.notes.LastOrDefault(x => Selection.Contains(x));
+            if (lastSelectedNote == null) {
+                return;
+            }
+            var rangeEndInclusive = Part.notes.IndexOf(lastSelectedNote);
+            int rangeToAddStart;
+            int rangeToAddEndInclusive;
+            if (thisIndex < rangeStart) {
+                rangeToAddStart = thisIndex;
+                rangeToAddEndInclusive = rangeEndInclusive;
+            } else if (thisIndex > rangeEndInclusive) {
+                rangeToAddStart = rangeStart;
+                rangeToAddEndInclusive = thisIndex;
+            } else {
+                rangeToAddStart = rangeStart;
+                rangeToAddEndInclusive = rangeEndInclusive;
+            }
+            var notesToAdd = Part.notes.ToList().GetRange(rangeToAddStart, rangeToAddEndInclusive - rangeToAddStart + 1);
+            var changed = Selection.Add(notesToAdd);
+            if (changed) {
+                MessageBus.Current.SendMessage(new NotesSelectionEvent(Selection));
+            }
+        }
+
         public void TempSelectNotes(int x0, int x1, int y0, int y1) {
             if (Part == null) {
                 return;

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -310,6 +310,8 @@ namespace OpenUtau.App.Views {
                     Cursor = ViewConstants.cursorSizeWE;
                 } else if (args.KeyModifiers == cmdKey) {
                     ViewModel.NotesViewModel.ToggleSelectNote(noteHitInfo.note);
+                } else if (args.KeyModifiers == KeyModifiers.Shift) {
+                    ViewModel.NotesViewModel.SelectNotesUntil(noteHitInfo.note);
                 } else {
                     editState = new NoteMoveEditState(canvas, ViewModel, this, noteHitInfo.note);
                     Cursor = ViewConstants.cursorSizeAll;

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -308,6 +308,8 @@ namespace OpenUtau.App.Views {
                         canvas, ViewModel, this, noteHitInfo.note,
                         args.KeyModifiers == KeyModifiers.Alt);
                     Cursor = ViewConstants.cursorSizeWE;
+                } else if (args.KeyModifiers == cmdKey) {
+                    ViewModel.NotesViewModel.ToggleSelectNote(noteHitInfo.note);
                 } else {
                     editState = new NoteMoveEditState(canvas, ViewModel, this, noteHitInfo.note);
                     Cursor = ViewConstants.cursorSizeAll;


### PR DESCRIPTION
## Summary
- Implement note multi-selection toggle by `Control + Click`:
  - If the clicked note is not selected, select it
  - If the clicked note is already selected, deselect it
- Implement note range multi-selection by `Shift + Click`:
  - If the clicked note is not in the range of currently selected notes (the range means the first selected ~ the last selected), select the all the notes in the range [clicked, last] or [first, clicked]
  - If the clicked note is in the currently selected range, select all the notes in the range

## Preview

### Ctrl + Click

https://user-images.githubusercontent.com/7665216/193639591-364a3224-5e16-43b8-aa19-3715f3dbb254.mp4

### Shift + Click

https://user-images.githubusercontent.com/7665216/193639625-b67d9605-bb67-4133-9f37-793781fef3a4.mp4

