### PR TITLE
Skip process name check when debugging in VS for mac

### DIFF
--- a/OpenUtau/Program.cs
+++ b/OpenUtau/Program.cs
@@ -22,10 +22,12 @@ namespace OpenUtau.App {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             InitLogging();
             string processName = Process.GetCurrentProcess().ProcessName;
-            var exists = Process.GetProcessesByName(processName).Count() > 1;
-            if (exists) {
-                Log.Information($"Process {processName} already open. Exiting.");
-                return;
+            if (processName != "dotnet") {
+                var exists = Process.GetProcessesByName(processName).Count() > 1;
+                if (exists) {
+                    Log.Information($"Process {processName} already open. Exiting.");
+                    return;
+                }
             }
             Log.Information($"{Environment.OSVersion}");
             Log.Information($"{RuntimeInformation.OSDescription} " +


### PR DESCRIPTION
When running in debug mode in VS for mac, the process name uses `dotnet`, which could be used already, and thus the program exits.

This PR is just for your information as an example of the solution. It works in my case, but I am not sure if it's complete.