### PR TITLE
enable classic plugins to use encodings other than shift_jis / 允许UTAU插件使用非shift_jis编码

### DIFF
--- a/OpenUtau.Core/Classic/Plugin.cs
+++ b/OpenUtau.Core/Classic/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO;
 
 namespace OpenUtau.Classic {
@@ -7,6 +7,7 @@ namespace OpenUtau.Classic {
         public string Executable;
         public bool AllNotes;
         public bool UseShell;
+        public string Encoding = "shift_jis";
 
         public void Run(string tempFile) {
             if (!File.Exists(Executable)) {

--- a/OpenUtau.Core/Classic/PluginLoader.cs
+++ b/OpenUtau.Core/Classic/PluginLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -41,6 +41,8 @@ namespace OpenUtau.Classic {
                                 plugin.AllNotes = true;
                             } else if (s[0] == "shell" && s[1] == "use") {
                                 plugin.UseShell = true;
+                            } else if (s[0] == "encoding"){
+                                plugin.Encoding = s[1];
                             } else {
                                 otherLines.Add(line);
                             }

--- a/OpenUtau.Core/Classic/Ust.cs
+++ b/OpenUtau.Core/Classic/Ust.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -274,7 +274,7 @@ namespace OpenUtau.Classic {
             return ustNotes;
         }
 
-        public static List<UNote> WritePlugin(UProject project, UVoicePart part, UNote first, UNote last, string filePath) {
+        public static List<UNote> WritePlugin(UProject project, UVoicePart part, UNote first, UNote last, string filePath, string encoding = "shift_jis") {
             var prev = first.Prev;
             if (prev == null) {
                 if (first.position > 0) {
@@ -298,7 +298,7 @@ namespace OpenUtau.Classic {
             }
             var sequence = new List<UNote>();
             var track = project.tracks[part.trackNo];
-            using (var writer = new StreamWriter(filePath, false, ShiftJIS)) {
+            using (var writer = new StreamWriter(filePath, false, Encoding.GetEncoding(encoding))) {
                 WriteHeader(project, part, writer);
                 var position = 0;
                 if (prev != null) {
@@ -361,10 +361,10 @@ namespace OpenUtau.Classic {
 
         public static (List<UNote>, List<UNote>) ParsePlugin(
             UProject project, UVoicePart part, UNote first, UNote last,
-            List<UNote> sequence, string diffFile) {
+            List<UNote> sequence, string diffFile, string encoding = "shift_jis") {
             var toRemove = new List<UNote>();
             var toAdd = new List<UNote>();
-            using (var reader = new StreamReader(diffFile, ShiftJIS)) {
+            using (var reader = new StreamReader(diffFile, Encoding.GetEncoding(encoding))) {
                 var blocks = Ini.ReadBlocks(reader, diffFile, @"\[#\w+\]");
                 int index = 0;
                 foreach (var block in blocks) {

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -121,7 +121,7 @@ namespace OpenUtau.App.ViewModels {
                         first = NotesViewModel.Selection.FirstOrDefault();
                         last = NotesViewModel.Selection.LastOrDefault();
                     }
-                    var sequence = Classic.Ust.WritePlugin(project, part, first, last, tempFile);
+                    var sequence = Classic.Ust.WritePlugin(project, part, first, last, tempFile, encoding: plugin.Encoding);
                     byte[]? beforeHash = HashFile(tempFile);
                     plugin.Run(tempFile);
                     byte[]? afterHash = HashFile(tempFile);
@@ -130,7 +130,7 @@ namespace OpenUtau.App.ViewModels {
                         return;
                     }
                     Log.Information("Legacy plugin temp file has changed.");
-                    var (toRemove, toAdd) = Classic.Ust.ParsePlugin(project, part, first, last, sequence, tempFile);
+                    var (toRemove, toAdd) = Classic.Ust.ParsePlugin(project, part, first, last, sequence, tempFile, encoding: plugin.Encoding);
                     DocManager.Inst.StartUndoGroup();
                     DocManager.Inst.ExecuteCmd(new RemoveNoteCommand(part, toRemove));
                     DocManager.Inst.ExecuteCmd(new AddNoteCommand(part, toAdd));


### PR DESCRIPTION
In non-Japanese OS, we will see paths that can't be encoded to shift_jis sometimes. This patch add an "encoding" option that enables classic plugins to use a different encoding for their temp files, such as UTF-8.
<img width="890" alt="image" src="https://user-images.githubusercontent.com/54425948/193719689-4ec3764a-73eb-435b-932e-9c3b484cf424.png">

(left: shift-jis, right: UTF-8)

plugin.txt example:
```
name=OpenUTAU Pack Tool
execute=main.bat
shell=use
encoding=utf-8
```
notes:
* plugin.txt still have to be shift_jis
* The default encoding of temp files is still shift_jis