### PR TITLE
Fix vLabeler integration for macOS

### DIFF
--- a/OpenUtau.Core/Util/OS.cs
+++ b/OpenUtau.Core/Util/OS.cs
@@ -43,6 +43,14 @@ namespace OpenUtau {
             });
         }
 
+        public static bool AppExists(string path) {
+            if (IsMacOS()) {
+                return Directory.Exists(path) && path.EndsWith(".app");
+            } else {
+                return File.Exists(path);
+            }
+        }
+
         public static string GetUpdaterRid() {
             if (IsWindows()) {
                 if (RuntimeInformation.ProcessArchitecture == Architecture.X86) {

--- a/OpenUtau/Integrations/VLabelerClient.cs
+++ b/OpenUtau/Integrations/VLabelerClient.cs
@@ -116,16 +116,20 @@ namespace OpenUtau.Integrations {
                 if (Heartbeat()) {
                     return true;
                 }
-                var exe = Core.Util.Preferences.Default.VLabelerPath;
-                if (!File.Exists(exe)) {
-                    throw new FileNotFoundException($"Cannot find file {exe}.");
+                var path = Core.Util.Preferences.Default.VLabelerPath;
+                if (!OS.AppExists(path)) {
+                    throw new FileNotFoundException($"Cannot find file {path}.");
                 }
                 using (var proc = new Process()) {
-                    proc.StartInfo = new ProcessStartInfo(exe) {
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                    };
-                    proc.Start();
+                    if (OS.IsMacOS()) {
+                        OS.OpenFolder(path);
+                    } else {
+                        proc.StartInfo = new ProcessStartInfo(path) {
+                            UseShellExecute = false,
+                            CreateNoWindow = true,
+                        };
+                        proc.Start();
+                    }
                     Log.Information("Starting vLabeler.");
                 }
                 for (int i = 0; i < 50; i++) {

--- a/OpenUtau/Integrations/VLabelerClient.cs
+++ b/OpenUtau/Integrations/VLabelerClient.cs
@@ -133,6 +133,7 @@ namespace OpenUtau.Integrations {
                     Log.Information("Starting vLabeler.");
                 }
                 for (int i = 0; i < 50; i++) {
+                    Task.Delay(100);
                     if (Heartbeat()) {
                         Log.Information("vLabeler started.");
                         return true;

--- a/OpenUtau/Integrations/VLabelerClient.cs
+++ b/OpenUtau/Integrations/VLabelerClient.cs
@@ -79,7 +79,7 @@ namespace OpenUtau.Integrations {
                 client.Connect("tcp://localhost:32342");
                 string reqStr = JsonConvert.SerializeObject(new HeartbeatRequest());
                 client.SendFrame(reqStr);
-                if (client.TryReceiveFrameString(TimeSpan.FromMilliseconds(200), out string? respStr)) {
+                if (client.TryReceiveFrameString(TimeSpan.FromMilliseconds(1000), out string? respStr)) {
                     return true;
                 }
                 return false;
@@ -105,7 +105,7 @@ namespace OpenUtau.Integrations {
                 client.Connect("tcp://localhost:32342");
                 string reqStr = JsonConvert.SerializeObject(request);
                 client.SendFrame(reqStr);
-                if (!client.TryReceiveFrameString(TimeSpan.FromMilliseconds(200), out string? respStr)) {
+                if (!client.TryReceiveFrameString(TimeSpan.FromMilliseconds(1000), out string? respStr)) {
                     Log.Warning($"Failed to OpenOrCreate with vLabeler");
                 }
             }

--- a/OpenUtau/Views/PreferencesDialog.axaml.cs
+++ b/OpenUtau/Views/PreferencesDialog.axaml.cs
@@ -39,12 +39,13 @@ namespace OpenUtau.App.Views {
         }
 
         async void SelectVLabelerPath(object sender, RoutedEventArgs e) {
+            var extension = OS.IsWindows() ? "exe" : OS.IsMacOS() ? "app" : "*";
             var dialog = new OpenFileDialog() {
                 AllowMultiple = false,
                 Filters = new List<FileDialogFilter>() {
                     new FileDialogFilter() {
                          Name = "vLabeler",
-                         Extensions = new List<string>() { "exe" },
+                         Extensions = new List<string>() { extension },
                     }
                 }
             };
@@ -52,7 +53,7 @@ namespace OpenUtau.App.Views {
             if (paths == null || paths.Length != 1 || string.IsNullOrEmpty(paths[0])) {
                 return;
             }
-            if (File.Exists(paths[0])) {
+            if (OS.AppExists(paths[0])) {
                 ((PreferencesViewModel)DataContext!).SetVLabelerPath(paths[0]);
             }
         }

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -203,7 +203,7 @@ namespace OpenUtau.App.Views {
                 return;
             }
             string path = Core.Util.Preferences.Default.VLabelerPath;
-            if (string.IsNullOrEmpty(path) || !File.Exists(path)) {
+            if (string.IsNullOrEmpty(path) || !OS.AppExists(path)) {
                 MessageBox.Show(
                     this,
                     ThemeManager.GetString("singers.editoto.setvlabelerpath"),


### PR DESCRIPTION
## Summary
1. Fix the app path
2. Add delay between heartbeat tries
3. Make request timeout longer

## Issue
When running `vLabeler production` and `OpenUtau` in VS,
If once started `vLabeler` by `OpenUtau`, the `dotnet` process cannot be correctly closed (even if `vLabeler` has already been closed).
May need some cleanup for the started process?