### PR TITLE
Replace "\" with "/" in the oto set name when sending request to vLabeler

### DIFF
--- a/OpenUtau/Integrations/VLabelerClient.cs
+++ b/OpenUtau/Integrations/VLabelerClient.cs
@@ -99,7 +99,7 @@ namespace OpenUtau.Integrations {
                 },
             };
             if (oto != null) {
-                request.gotoEntryByName = new GotoEntryByName(oto.Set, oto.Alias);
+                request.gotoEntryByName = new GotoEntryByName(oto.Set.Replace("\\","/"), oto.Alias);
             }
             using (var client = new RequestSocket()) {
                 client.Connect("tcp://localhost:32342");


### PR DESCRIPTION
vLabeler is now supporting folders like `aaa/bbb` but the separator is always `/`, so we need to replace `\` on Windows with `/` to make it work.
