### PR TITLE
Implemented Replace audio for UWavePart

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -6,7 +6,7 @@
   <system:String x:Key="context.note.delete">Delete note</system:String>
   <system:String x:Key="context.part.delete">Delete part</system:String>
   <system:String x:Key="context.part.rename">Rename part</system:String>
-    <system:String x:Key="context.part.replaceaudio">Reselect audio file</system:String>
+  <system:String x:Key="context.part.replaceaudio">Reselect audio file</system:String>
   <system:String x:Key="context.pitch.easein">Ease in</system:String>
   <system:String x:Key="context.pitch.easeinout">Ease in/out</system:String>
   <system:String x:Key="context.pitch.easeout">Ease out</system:String>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -6,6 +6,7 @@
   <system:String x:Key="context.note.delete">Delete note</system:String>
   <system:String x:Key="context.part.delete">Delete part</system:String>
   <system:String x:Key="context.part.rename">Rename part</system:String>
+    <system:String x:Key="context.part.replaceaudio">Reselect audio file</system:String>
   <system:String x:Key="context.pitch.easein">Ease in</system:String>
   <system:String x:Key="context.pitch.easeinout">Ease in/out</system:String>
   <system:String x:Key="context.pitch.easeout">Ease out</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -6,6 +6,7 @@
   <system:String x:Key="context.note.delete">删除音符</system:String>
   <system:String x:Key="context.part.delete">删除片段</system:String>
   <system:String x:Key="context.part.rename">重命名片段</system:String>
+  <system:String x:Key="context.part.replaceaudio">替换音频</system:String>
   <system:String x:Key="context.pitch.easein">缓入</system:String>
   <system:String x:Key="context.pitch.easeinout">缓入缓出</system:String>
   <system:String x:Key="context.pitch.easeout">缓出</system:String>

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -15,8 +15,10 @@ namespace OpenUtau.App.ViewModels {
     public class PartsContextMenuArgs {
         public UPart? Part { get; set; }
         public bool IsVoicePart => Part is UVoicePart;
+        public bool IsWavePart => Part is UWavePart;
         public ReactiveCommand<UPart, Unit>? PartDeleteCommand { get; set; }
         public ReactiveCommand<UPart, Unit>? PartRenameCommand { get; set; }
+        public ReactiveCommand<UPart, Unit>? PartReplaceAudioCommand { get; set; }
     }
 
     public class MainWindowViewModel : ViewModelBase, ICmdSubscriber {

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -212,6 +212,10 @@
             <MenuItem Header="{DynamicResource context.part.delete}"
                       Command="{Binding PartDeleteCommand}"
                       CommandParameter="{Binding Part}"/>
+            <MenuItem Header="{DynamicResource context.part.replaceaudio}"
+                      IsVisible="{Binding IsWavePart}"
+                      Command="{Binding PartReplaceAudioCommand}"
+                      CommandParameter="{Binding Part}"/>
             <MenuItem Header="{DynamicResource context.part.rename}"
                       IsVisible="{Binding IsVoicePart}"
                       Command="{Binding PartRenameCommand}"


### PR DESCRIPTION
Implemented Replace audio in the context menu of UWavePart in the parts editor. This can be useful when i.e. sending project to others, moving to a new computer, etc.

Known issue need help: When undoing this action, without a seek action, the original audio will still play.