### PR TITLE
[Korean CVC Phonemizer + English Delta Phonemizers] KR end breath bug fix for "eo", "eu" + EN consonants overhaul

### DIFF
--- a/OpenUtau.Plugin.Builtin/ENDeltaVer1Phonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaVer1Phonemizer.cs
@@ -23,8 +23,10 @@ namespace OpenUtau.Plugin.Builtin
 
         private readonly string[] vowels = "a,A,@,{,V,O,aU,aI,E,3,eI,I,i,oU,OI,U,u,Q,Ol,aUn,e@,eN,IN,e,o,Ar,Er,Ir,Or,Ur,ir,ur,@l,@m,@n,@N,1,e@m,e@n".Split(',');
         private readonly string[] consonants = "b,tS,d,D,4,f,g,h,dZ,k,l,m,n,N,p,r,s,S,t,T,v,w,W,j,z,Z,t_},・,_".Split(',');
-        private readonly string[] burstConsonants = "b,tS,d,dZ,4,g,k,p,t".Split(',');
         private readonly string[] affricates = "tS,dZ".Split(',');
+        private readonly string[] shortConsonants = "4".Split(",");
+        private readonly string[] longConsonants = "tS,f,dZ,k,p,s,S,t,T,t_}".Split(",");
+        private readonly string[] normalConsonants = "b,d,D,g,h,l,m,n,N,r,v,w,W,j,z,Z,・".Split(',');
         private readonly Dictionary<string, string> dictionaryReplacements = ("aa=A;ae={;ah=V;ao=O;aw=aU;ax=@;ay=aI;" +
             "b=b;ch=tS;d=d;dh=D;dx=4;eh=E;el=@l;em=@m;en=@n;eng=@N;er=3;ey=eI;f=f;g=g;hh=h;ih=I;iy=i;jh=dZ;k=k;l=l;m=m;n=n;ng=N;ow=oU;oy=OI;" +
             "p=p;q=・;r=r;s=s;sh=S;t=t;th=T;uh=U;uw=u;v=v;w=w;y=j;z=z;zh=Z").Split(';')
@@ -262,28 +264,28 @@ namespace OpenUtau.Plugin.Builtin
                             }
                         } else if (TryAddPhoneme(phonemes, syllable.tone, $"{cc[i]} {cc[i + 1]}-")) {
                             // like [V C1] [C1 C2-] [C3 ..]
-                            if (burstConsonants.Contains(cc[i + 1])) {
+                            if (affricates.Contains(cc[i + 1])) {
                                 i++;
                             } else {
                                 // continue as usual
                             }
-                        } else if (burstConsonants.Contains(cc[i])) {
+                        } else if (affricates.Contains(cc[i])) {
                             // like [V C1] [C1] [C2 ..]
                             TryAddPhoneme(phonemes, syllable.tone, cc[i], $"{cc[i]} -");
-                            if (cc[i] == cc.Last() && !affricates.Contains(cc[i])) {
-                                phonemes.Remove(cc[i]);
-                                phonemes.Remove($"{cc[i]} -");
-                            }
+                            //if (cc[i] == cc.Last() && !affricates.Contains(cc[i])) {
+                            //    phonemes.Remove(cc[i]);
+                            //    phonemes.Remove($"{cc[i]} -");
+                            //}
                         }
                     } else {
                         // like [V C1] [C1 C2]  [C2 ..] or like [V C1] [C1 -] [C3 ..]
                         TryAddPhoneme(phonemes, syllable.tone, cc1);
-                        if (burstConsonants.Contains(cc[i]) && !HasOto(cc1, syllable.tone)) {
+                        if (affricates.Contains(cc[i]) && !HasOto(cc1, syllable.tone)) {
                             TryAddPhoneme(phonemes, syllable.tone, cc[i], $"{cc[i]} -");
-                            if (!affricates.Contains(cc[i]) && cc[i] == cc.Last()) {
-                                phonemes.Remove(cc[i]);
-                                phonemes.Remove($"{cc[i]} -");
-                            }
+                            //if (!affricates.Contains(cc[i]) && cc[i] == cc.Last()) {
+                            //    phonemes.Remove(cc[i]);
+                            //    phonemes.Remove($"{cc[i]} -");
+                            //}
                         }
                     }
                 }
@@ -322,7 +324,7 @@ namespace OpenUtau.Plugin.Builtin
                     if (v == "V" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"A {cc[0]}", ending.tone)) {
                         v.Replace("V", "A");
                     }
-                    if (burstConsonants.Contains(cc[0])) {
+                    if (affricates.Contains(cc[0])) {
                         TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", cc[0]);
                     } else {
                         TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -");
@@ -384,7 +386,7 @@ namespace OpenUtau.Plugin.Builtin
                                     // like [C1C2][C3 ...]
                                 } else if (!cc.First().Contains(cc[i + 1]) || !cc.First().Contains(cc[i + 2])) {
                                     // like [C1][C2 ...]
-                                    if (burstConsonants.Contains(cc[i]) && (!HasOto(vcc4, ending.tone))) {
+                                    if (affricates.Contains(cc[i]) && (!HasOto(vcc4, ending.tone))) {
                                         TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -");
                                     }
                                     TryAddPhoneme(phonemes, ending.tone, cc[i + 1], $"{cc[i + 1]} -");
@@ -403,7 +405,7 @@ namespace OpenUtau.Plugin.Builtin
                                 i++;
                             } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}")) {
                                 // like [C1C2][C2 -]
-                                if (burstConsonants.Contains(cc[i + 1])) {
+                                if (affricates.Contains(cc[i + 1])) {
                                     TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
                                 } else {
                                     TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -");
@@ -411,7 +413,7 @@ namespace OpenUtau.Plugin.Builtin
                                 i++;
                             } else if (TryAddPhoneme(phonemes, ending.tone, cc1)) {
                                 // like [C1 C2][C2 -]
-                                if (burstConsonants.Contains(cc[i + 1])) {
+                                if (affricates.Contains(cc[i + 1])) {
                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
                                 } else {
                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -");
@@ -421,7 +423,7 @@ namespace OpenUtau.Plugin.Builtin
                                 // like [C1][C2 -]
                                 if (!HasOto(vcc4, ending.tone)) {
                                     TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -");
-                                    if (!burstConsonants.Contains(cc[0])) {
+                                    if (!affricates.Contains(cc[0])) {
                                         phonemes.Remove(cc[0]);
                                     }
                                     TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
@@ -443,6 +445,34 @@ namespace OpenUtau.Plugin.Builtin
                 alias = alias.Replace(vowel, "A");
             }
             return alias;
+        }
+
+        protected override double GetTransitionBasicLengthMs(string alias = "") {
+            foreach (var c in longConsonants) {
+                if (alias.Contains(c)) {
+                    if (!alias.StartsWith(c)) {
+                        return base.GetTransitionBasicLengthMs() * 2.0;
+                    }
+                }
+            }
+            foreach (var c in normalConsonants) {
+                if (!alias.Contains("_D")) {
+                    if (alias.Contains(c)) {
+                        if (!alias.StartsWith(c)) {
+                            return base.GetTransitionBasicLengthMs();
+                        }
+                    }   
+                }
+            }
+
+            foreach (var c in shortConsonants) {
+                if (alias.Contains(c)) {
+                    if (!alias.Contains(" _")) {
+                        return base.GetTransitionBasicLengthMs() * 0.50;
+                    }
+                }
+            }
+            return base.GetTransitionBasicLengthMs();
         }
     }
 }

--- a/OpenUtau.Plugin.Builtin/ENDeltaVer2Phonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaVer2Phonemizer.cs
@@ -19,8 +19,10 @@ namespace OpenUtau.Plugin.Builtin
 
         private readonly string[] vowels = "a,A,@,{,V,O,aU,aI,E,3,eI,I,i,oU,OI,U,u,Q,e,o,1".Split(',');
         private readonly string[] consonants = "b,tS,d,D,4,f,g,h,dZ,k,l,m,n,N,p,r,s,S,t,T,v,w,W,j,z,Z,t_},・,_".Split(',');
-        private readonly string[] burstConsonants = "b,tS,d,dZ,4,g,k,p,t".Split(',');
         private readonly string[] affricates = "tS,dZ".Split(',');
+        private readonly string[] shortConsonants = "4".Split(",");
+        private readonly string[] longConsonants = "tS,f,dZ,k,p,s,S,t,T,t_}".Split(",");
+        private readonly string[] normalConsonants = "b,d,D,g,h,l,m,n,N,r,v,w,W,j,z,Z,・".Split(',');
         private readonly Dictionary<string, string> dictionaryReplacements = ("aa=A;ae={;ah=V;ao=O;aw=aU;ax=@;ay=aI;" +
             "b=b;ch=tS;d=d;dh=D;dx=4;eh=E;er=3;ey=eI;f=f;g=g;hh=h;ih=I;iy=i;jh=dZ;k=k;l=l;m=m;n=n;ng=N;ow=oU;oy=OI;" +
             "p=p;q=・;r=r;s=s;sh=S;t=t;th=T;uh=U;uw=u;v=v;w=w;y=j;z=z;zh=Z").Split(';')
@@ -316,28 +318,28 @@ namespace OpenUtau.Plugin.Builtin
                             }
                         } else if (TryAddPhoneme(phonemes, syllable.tone, $"{cc[i]} {cc[i + 1]}-")) {
                             // like [V C1] [C1 C2-] [C3 ..]
-                            if (burstConsonants.Contains(cc[i + 1])) {
+                            if (affricates.Contains(cc[i + 1])) {
                                 i++;
                             } else {
                                 // continue as usual
                             }
-                        } else if (burstConsonants.Contains(cc[i])) {
+                        } else if (affricates.Contains(cc[i])) {
                             // like [V C1] [C1] [C2 ..]
                             TryAddPhoneme(phonemes, syllable.tone, cc[i], $"{cc[i]} -");
-                            if (cc[i] == cc.Last() && !affricates.Contains(cc[i])) {
-                                phonemes.Remove(cc[i]);
-                                phonemes.Remove($"{cc[i]} -");
-                            }
+                            //if (cc[i] == cc.Last() && !affricates.Contains(cc[i])) {
+                            //    phonemes.Remove(cc[i]);
+                            //    phonemes.Remove($"{cc[i]} -");
+                            //}
                         }
                     } else {
                         // like [V C1] [C1 C2]  [C2 ..] or like [V C1] [C1 -] [C3 ..]
                         TryAddPhoneme(phonemes, syllable.tone, cc1);
-                        if (burstConsonants.Contains(cc[i]) && !HasOto(cc1, syllable.tone)) {
+                        if (affricates.Contains(cc[i]) && !HasOto(cc1, syllable.tone)) {
                             TryAddPhoneme(phonemes, syllable.tone, cc[i], $"{cc[i]} -");
-                            if (!affricates.Contains(cc[i]) && cc[i] == cc.Last()) {
-                                phonemes.Remove(cc[i]);
-                                phonemes.Remove($"{cc[i]} -");
-                            }
+                            //if (!affricates.Contains(cc[i]) && cc[i] == cc.Last()) {
+                            //    phonemes.Remove(cc[i]);
+                            //    phonemes.Remove($"{cc[i]} -");
+                            //}
                         }
                     }
                 }
@@ -396,7 +398,7 @@ namespace OpenUtau.Plugin.Builtin
                     } else if (v == "U" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"U {cc[0]}", ending.tone)) {
                         v.Replace("U", "u");
                     }
-                    if (burstConsonants.Contains(cc[0])) {
+                    if (affricates.Contains(cc[0])) {
                         TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", cc[0]);
                     } else {
                         TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -");
@@ -458,7 +460,7 @@ namespace OpenUtau.Plugin.Builtin
                                     // like [C1C2][C3 ...]
                                 } else if (!cc.First().Contains(cc[i + 1]) || !cc.First().Contains(cc[i + 2])) {
                                     // like [C1][C2 ...]
-                                    if (burstConsonants.Contains(cc[i]) && (!HasOto(vcc4, ending.tone))) {
+                                    if (affricates.Contains(cc[i]) && (!HasOto(vcc4, ending.tone))) {
                                         TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -");
                                     }
                                     TryAddPhoneme(phonemes, ending.tone, cc[i + 1], $"{cc[i + 1]} -");
@@ -477,7 +479,7 @@ namespace OpenUtau.Plugin.Builtin
                                 i++;
                             } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}")) {
                                 // like [C1C2][C2 -]
-                                if (burstConsonants.Contains(cc[i + 1])) {
+                                if (affricates.Contains(cc[i + 1])) {
                                     TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
                                 } else {
                                     TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -");
@@ -485,7 +487,7 @@ namespace OpenUtau.Plugin.Builtin
                                 i++;
                             } else if (TryAddPhoneme(phonemes, ending.tone, cc1)) {
                                 // like [C1 C2][C2 -]
-                                if (burstConsonants.Contains(cc[i + 1])) {
+                                if (affricates.Contains(cc[i + 1])) {
                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
                                 } else {
                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -");
@@ -495,7 +497,7 @@ namespace OpenUtau.Plugin.Builtin
                                 // like [C1][C2 -]
                                 if (!HasOto(vcc4, ending.tone)) {
                                     TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -");
-                                    if (!burstConsonants.Contains(cc[0])) {
+                                    if (!affricates.Contains(cc[0])) {
                                         phonemes.Remove(cc[0]);
                                     }
                                     TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
@@ -529,6 +531,34 @@ namespace OpenUtau.Plugin.Builtin
                 alias = alias.Replace(vowel, "u");
             }
             return alias;
+        }
+
+        protected override double GetTransitionBasicLengthMs(string alias = "") {
+            foreach (var c in longConsonants) {
+                if (alias.Contains(c)) {
+                    if (!alias.StartsWith(c)) {
+                        return base.GetTransitionBasicLengthMs() * 2.0;
+                    }
+                }
+            }
+            foreach (var c in normalConsonants) {
+                if (!alias.Contains("_D")) {
+                    if (alias.Contains(c)) {
+                        if (!alias.StartsWith(c)) {
+                            return base.GetTransitionBasicLengthMs();
+                        }
+                    }   
+                }
+            }
+
+            foreach (var c in shortConsonants) {
+                if (alias.Contains(c)) {
+                    if (!alias.Contains(" _")) {
+                        return base.GetTransitionBasicLengthMs() * 0.50;
+                    }
+                }
+            }
+            return base.GetTransitionBasicLengthMs();
         }
     }
 }

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -586,9 +586,9 @@ namespace OpenUtau.Plugin.Builtin {
                     vowel = vow;
                     
                     var endBreath = $"{vow} R";
-                    if (prevLyric.Contains("eo")) {
+                    if (prevLyric.EndsWith("eo")) {
                         endBreath = $"eo R";
-                    } else if (prevLyric.Contains("eu")) {
+                    } else if (prevLyric.EndsWith("eu")) {
                         endBreath = $"eu R";
                     }
                                         

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -581,10 +581,20 @@ namespace OpenUtau.Plugin.Builtin {
                 var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
                 // end breath note
                 if (vowelLookup.TryGetValue(prevUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
+                    var vowel = "";
+                    var prevLyric = string.Join("", prevUnicode);;   
+                    vowel = vow;
+                    
                     var endBreath = $"{vow} R";
+                    if (prevLyric.Contains("eo")) {
+                        endBreath = $"eo R";
+                    } else if (prevLyric.Contains("eu")) {
+                        endBreath = $"eu R";
+                    }
+                                        
                     // try end breath
                     string[] tests = new string[] {endBreath, currentLyric};
-                    if (checkOtoUntilHit(tests, note, out var oto)){
+                    if (checkOtoUntilHit(tests, note, out var oto)){ 
                         currentLyric = oto.Alias;
                     }
                 }


### PR DESCRIPTION
KR CVC:
This fixes an end breath issue on Romanized notes containing "eo" or "eu", similar to #530.

--

EN Delta:
- Burst consonants overhaul/removal; this function has now been made exclusive to affricates. This was done due to how English pronunciation is affected in singing.
- Applied consonant length differences (short + long + normal).