### PR TITLE
Restore render thread option

### DIFF
--- a/OpenUtau.Core/Classic/ClassicRenderer.cs
+++ b/OpenUtau.Core/Classic/ClassicRenderer.cs
@@ -9,6 +9,7 @@ using OpenUtau.Core;
 using OpenUtau.Core.Format;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using Serilog;
 
 namespace OpenUtau.Classic {
@@ -60,7 +61,7 @@ namespace OpenUtau.Classic {
             }
             var task = Task.Run(() => {
                 Parallel.ForEach(source: resamplerItems, parallelOptions: new ParallelOptions() {
-                    MaxDegreeOfParallelism = 2
+                    MaxDegreeOfParallelism = Preferences.Default.NumRenderThreads
                 }, body: item => {
                     if (!cancellation.IsCancellationRequested && !File.Exists(item.outputFile)) {
                         if (!(item.resampler is WorldlineResampler)) {

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -85,6 +85,7 @@ namespace OpenUtau.Core.Util {
             public bool ShowTips = true;
             public int Theme;
             public bool PreRender = true;
+            public int NumRenderThreads = 2;
             public string Language = string.Empty;
             public List<string> RecentFiles = new List<string>();
             public string SkipUpdate = string.Empty;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -255,7 +255,10 @@ Hold Ctrl to select</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>
   <system:String x:Key="prefs.rendering.prerender">Pre-render</system:String>
-  <system:String x:Key="prefs.rendering.prerender.threads">Pre-render Threads</system:String>
+  <system:String x:Key="prefs.rendering.threads.numthreads">Maximum Render Threads</system:String>
+  <system:String x:Key="prefs.rendering.threads.cpuwarn">
+    Warning: too many render threads may cause OpenUtau to run slowly.
+  </system:String>
   <system:String x:Key="prefs.rendering.resampler">Resampler</system:String>
   <system:String x:Key="prefs.rendering.resampler.morewarn">
     Warning: moresampler is not fully supported. It may be slow and cause high CPU usage. If you insist, please:

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -31,11 +31,19 @@ namespace OpenUtau.App.ViewModels {
         public string AdditionalSingersPath => PathManager.Inst.AdditionalSingersPath;
         [Reactive] public int InstallToAdditionalSingersPath { get; set; }
         [Reactive] public int PreRender { get; set; }
+        [Reactive] public int NumRenderThreads { get; set; }
+        [Reactive] public bool HighThreads { get; set; }
         [Reactive] public int Theme { get; set; }
         [Reactive] public int ShowPortrait { get; set; }
         [Reactive] public int ShowGhostNotes { get; set; }
         [Reactive] public int OtoEditor { get; set; }
         public string VLabelerPath => Preferences.Default.VLabelerPath;
+        public int LogicalCoreCount {
+            get => Environment.ProcessorCount; 
+        }
+        public int SafeMaxThreadCount { 
+            get => Math.Min(8, LogicalCoreCount / 2);
+        }
 
         public List<CultureInfo>? Languages { get; }
         public CultureInfo? Language {
@@ -93,6 +101,7 @@ namespace OpenUtau.App.ViewModels {
                 ? null
                 : CultureInfo.GetCultureInfo(Preferences.Default.Language);
             PreRender = Preferences.Default.PreRender ? 1 : 0;
+            NumRenderThreads = Preferences.Default.NumRenderThreads;
             Theme = Preferences.Default.Theme;
             ShowPortrait = Preferences.Default.ShowPortrait ? 1 : 0;
             ShowGhostNotes = Preferences.Default.ShowGhostNotes ? 1 : 0;
@@ -178,6 +187,12 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.OtoEditor)
                 .Subscribe(index => {
                     Preferences.Default.OtoEditor = index;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.NumRenderThreads)
+                .Subscribe(index => {
+                    Preferences.Default.NumRenderThreads = index;
+                    HighThreads = index > SafeMaxThreadCount ? true : false;
                     Preferences.Save();
                 });
         }

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -79,6 +79,20 @@
               <ComboBoxItem Content="{DynamicResource prefs.off}"/>
               <ComboBoxItem Content="{DynamicResource prefs.on}"/>
             </ComboBox>
+            <Grid ColumnDefinitions="Auto,8,16,8,*" Margin="0,8,0,0">
+              <TextBlock Grid.Column="0" Text="{DynamicResource prefs.rendering.threads.numthreads}"/>
+              <TextBlock Grid.Column="2">
+                <TextBlock.Text>
+                  <MultiBinding StringFormat="{}{0:#0}">
+                    <Binding Path="NumRenderThreads"/>
+                  </MultiBinding>
+                </TextBlock.Text>
+              </TextBlock>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding NumRenderThreads}" Minimum="1" Maximum="{Binding LogicalCoreCount, Mode=OneTime}"
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
+            </Grid>
+            <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.rendering.threads.cpuwarn}" FontWeight="Bold"
+                       Foreground="Red" Margin="0,0,0,4" IsVisible="{Binding HighThreads}" FontSize="11"/>
           </StackPanel>
         </HeaderedContentControl>
         <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.appearance}">


### PR DESCRIPTION
Added new "Maximum Render Threads" slider to preferences. 
Max threads are determined by number of logical processors (cores/simultaneous threads) of the system CPU. 
Setting only affects classic resamplers using internal wavtools (convergence, simple).