### PR TITLE
Piano Roll keyboard control

### DIFF
--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -6,7 +6,7 @@ using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core {
     public abstract class NoteCommand : UCommand {
-        protected readonly UNote[] Notes;
+        public readonly UNote[] Notes;
         public readonly UVoicePart Part;
         public override ValidateOptions ValidateOptions => new ValidateOptions {
             SkipTiming = true,

--- a/OpenUtau/ViewModels/NoteSelectionViewModel.cs
+++ b/OpenUtau/ViewModels/NoteSelectionViewModel.cs
@@ -211,11 +211,11 @@ namespace OpenUtau.App.ViewModels {
             }
             int movesRemaining = Math.Abs(delta);
             bool isForwardMove = delta > 0;
-            bool wasChange = false;
-            // if multiple selection then collapse to first/last item (unless delta is > 1)
+            // if multiple selection then collapse to first/last item
             if (IsMultiple) {
-                movesRemaining--;
+                return Select(isForwardMove ? _notes.Last() : _notes.First());
             }
+            bool wasChange = false;
             lock (_notes) {
                 UNote? cursor = IsReversed ? _notes.First() : _notes.Last();
                 while (

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -732,6 +732,12 @@ namespace OpenUtau.App.ViewModels {
                 CleanupSelectedNotes();
                 if (noteCommand.Part == Part) {
                     MessageBus.Current.SendMessage(new NotesRefreshEvent());
+
+                    if (noteCommand is RemoveNoteCommand && isUndo) {
+                        if (Selection.Select(noteCommand.Notes)) {
+                            MessageBus.Current.SendMessage(new NotesSelectionEvent(Selection));
+                        }
+                    }
                 }
             } else if (cmd is ExpCommand) {
                 MessageBus.Current.SendMessage(new NotesRefreshEvent());

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -695,6 +695,9 @@ namespace OpenUtau.App.ViewModels {
                 } else if (cmd is FocusNoteNotification focusNote) {
                     if (focusNote.part == Part) {
                         FocusNote(focusNote.note);
+                        if (Selection.Count <= 1) {
+                            SelectNote(focusNote.note);
+                        }
                     }
                 } else if (cmd is ValidateProjectNotification
                     || cmd is SingersRefreshedNotification

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -487,6 +487,26 @@ namespace OpenUtau.App.ViewModels {
             Selection.Remove(toCleanup);
         }
 
+        public void InsertNote() {
+            if(Part == null) {
+                return;
+            }
+
+            var project = DocManager.Inst.Project;
+            int snapUnit = project.resolution * 4 / SnapDiv;
+
+            var fromNote = Selection.LastOrDefault();
+            int DEFAULT_TONE = 12 * 5; // C4
+            int tone = fromNote?.tone ?? DEFAULT_TONE;
+            int tick = fromNote?.RightBound ?? (int)TickOffset;
+            int dur = fromNote?.duration ?? snapUnit;
+            DocManager.Inst.StartUndoGroup();
+            UNote note = DocManager.Inst.Project.CreateNote(tone, tick, dur);
+            DocManager.Inst.ExecuteCmd(new AddNoteCommand(Part, note));
+            SelectNote(note);
+            DocManager.Inst.EndUndoGroup();
+        }
+
         public void TransposeSelection(int deltaNoteNum) {
             if (Selection.IsEmpty) {
                 return;

--- a/OpenUtau/Views/LyricsDialog.axaml
+++ b/OpenUtau/Views/LyricsDialog.axaml
@@ -5,11 +5,13 @@
         mc:Ignorable="d" MinWidth="400" MinHeight="200" Width="600" Height="300"
         x:Class="OpenUtau.App.Views.LyricsDialog" WindowStartupLocation="CenterOwner"
         Icon="/Assets/open-utau.ico"
-        Title="{StaticResource lyrics.caption}">
+        Title="{StaticResource lyrics.caption}"
+        KeyDown="OnKeyDown"
+        Opened="OnOpened">
   <Grid Margin="10,10,10,4" RowDefinitions="*,6,Auto,4,Auto">
-    <TextBox Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
-             AcceptsReturn="True" AcceptsTab="True" TextWrapping="Wrap" Height="NaN"
-             Text="{Binding Text}"/>
+    <TextBox Name="DIALOG_Box" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
+             AcceptsReturn="False" AcceptsTab="False" TextWrapping="Wrap" Height="NaN"
+             Text="{Binding Text}" Focusable="True" />
     <TextBlock Grid.Row="2" Text="" Margin="0,2" HorizontalAlignment="Right">
       <TextBlock.Text>
         <MultiBinding StringFormat="{}{0}/{1} ({2} Max)">

--- a/OpenUtau/Views/LyricsDialog.axaml.cs
+++ b/OpenUtau/Views/LyricsDialog.axaml.cs
@@ -1,13 +1,19 @@
-﻿using Avalonia;
+﻿using System;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 using OpenUtau.App.ViewModels;
 
 namespace OpenUtau.App.Views {
     public partial class LyricsDialog : Window {
+        private TextBox box;
         public LyricsDialog() {
             InitializeComponent();
+            box = this.FindControl<TextBox>("DIALOG_Box");
+
 #if DEBUG
             this.AttachDevTools();
 #endif
@@ -17,18 +23,39 @@ namespace OpenUtau.App.Views {
             AvaloniaXamlLoader.Load(this);
         }
 
+        void OnOpened(object? sender, EventArgs e) {
+            box.Focus();
+        }
+
         void OnReset(object? sender, RoutedEventArgs e) {
             (DataContext as LyricsViewModel)!.Reset();
         }
 
         void OnCancel(object? sender, RoutedEventArgs e) {
             (DataContext as LyricsViewModel)!.Cancel();
+            KeyboardDevice.Instance.SetFocusedElement(null, NavigationMethod.Unspecified, KeyModifiers.None);
             Close();
         }
 
         void OnFinish(object? sender, RoutedEventArgs e) {
             (DataContext as LyricsViewModel)!.Finish();
+            KeyboardDevice.Instance.SetFocusedElement(null, NavigationMethod.Unspecified, KeyModifiers.None);
             Close();
+        }
+
+        private void OnKeyDown(object? sender, KeyEventArgs e) {
+            switch (e.Key) {
+                case Key.Enter:
+                    OnFinish(sender, e);
+                    e.Handled = true;
+                    break;
+                case Key.Escape:
+                    OnCancel(sender, e);
+                    e.Handled = true;
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/OpenUtau/Views/NoteEditStates.cs
+++ b/OpenUtau/Views/NoteEditStates.cs
@@ -140,7 +140,6 @@ namespace OpenUtau.App.Views {
             this.note = note;
             var notesVm = vm.NotesViewModel;
             if (!notesVm.Selection.Contains(note)) {
-                notesVm.DeselectNotes();
                 notesVm.SelectNote(note);
             }
         }

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -332,7 +332,7 @@
                            TextAlignment="Right" FontSize="10" FontFamily="monospace"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
                 <Button.ContextMenu>
-                  <ContextMenu Name="SnapDivMenu" PlacementMode="Bottom" Items="{Binding NotesViewModel.SnapDivs}">
+                  <ContextMenu Name="SnapDivMenu" PlacementMode="Bottom" Items="{Binding NotesViewModel.SnapDivs}" KeyDown="OnSnapDivKeyDown">
                     <ContextMenu.DataTemplates>
                       <DataTemplate DataType="vm:MenuItemViewModel">
                         <MenuItem Header="{Binding Header}" Command="{Binding Command}" CommandParameter="{Binding CommandParameter}"/>

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -836,10 +836,11 @@ namespace OpenUtau.App.Views {
                     break;
                 case Key.Enter:
                     if (isNone) {
-                        if (notesVm.Selection.Count > 1) {
+                        if (notesVm.Selection.Count == 1) {
+                            var note = notesVm.Selection.First();
+                            lyricBox?.Show(ViewModel.NotesViewModel.Part!, new LyricBoxNote(note), note.lyric);
+                        } else if (notesVm.Selection.Count > 1) {
                             EditLyrics();
-                        } else if (!notesVm.Selection.IsEmpty) {
-                            OpenLyricBox();
                         }
                         return true;
                     }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1161,8 +1161,19 @@ namespace OpenUtau.App.Views {
                         notesVm.ShowWaveform = !notesVm.ShowWaveform;
                         return true;
                     }
+                    // scroll up
+                    // NOTE set to alt to avoid conflict with showwaveform toggle
+                    if (isAlt) {
+                        notesVm.TrackOffset = Math.Max(notesVm.TrackOffset - 2, 0);
+                        return true;
+                    }
                     break;
                 case Key.S:
+                    // scroll down
+                    if (isAlt) {
+                        notesVm.TrackOffset = Math.Min(notesVm.TrackOffset + 2, notesVm.VScrollBarMax);
+                        return true;
+                    }
                     if (isCtrl) {
                         _ = MainWindow?.Save();
                         return true;

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -13,6 +13,8 @@ using Avalonia.Markup.Xaml;
 using Avalonia.VisualTree;
 using OpenUtau.App.Controls;
 using OpenUtau.App.ViewModels;
+using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
 using ReactiveUI;
 using Serilog;
 
@@ -779,90 +781,247 @@ namespace OpenUtau.App.Views {
                 args.Handled = false;
                 return;
             }
-            if (args.KeyModifiers == KeyModifiers.None) {
-                args.Handled = true;
-                switch (args.Key) {
-                    case Key.Back:
-                    case Key.Delete:
-                        notesVm.DeleteSelectedNotes();
-                        break;
-                    case Key.D1: notesVm.SelectToolCommand?.Execute("1").Subscribe(); break;
-                    case Key.D2: notesVm.SelectToolCommand?.Execute("2").Subscribe(); break;
-                    case Key.D3: notesVm.SelectToolCommand?.Execute("3").Subscribe(); break;
-                    case Key.D4: notesVm.SelectToolCommand?.Execute("4").Subscribe(); break;
-                    case Key.D5: notesVm.SelectToolCommand?.Execute("5").Subscribe(); break;
-                    case Key.R: notesVm.ShowFinalPitch = !notesVm.ShowFinalPitch; break;
-                    case Key.T: notesVm.ShowTips = !notesVm.ShowTips; break;
-                    case Key.Y: notesVm.PlayTone = !notesVm.PlayTone; break;
-                    case Key.U: notesVm.ShowVibrato = !notesVm.ShowVibrato; break;
-                    case Key.I: notesVm.ShowPitch = !notesVm.ShowPitch; break;
-                    case Key.O: notesVm.ShowPhoneme = !notesVm.ShowPhoneme; break;
-                    case Key.W: notesVm.ShowWaveform = !notesVm.ShowWaveform; break;
-                    case Key.P: notesVm.IsSnapOn = !notesVm.IsSnapOn; break;
-                    case Key.Up: notesVm.TransposeSelection(1); break;
-                    case Key.Down: notesVm.TransposeSelection(-1); break;
-                    case Key.Space:
-                        if (ViewModel.PlaybackViewModel != null) {
-                            try {
-                                ViewModel.PlaybackViewModel.PlayOrPause();
-                            } catch (Exception e) {
-                                MessageBox.ShowError(this, e);
-                            }
-                        }
-                        break;
-                    case Key.Home:
-                        if (ViewModel.NotesViewModel.Part != null) {
-                            ViewModel.PlaybackViewModel?.MovePlayPos(ViewModel.NotesViewModel.Part.position);
-                        }
-                        break;
-                    case Key.End:
-                        if (ViewModel.NotesViewModel.Part != null) {
-                            ViewModel.PlaybackViewModel?.MovePlayPos(ViewModel.NotesViewModel.Part.End);
-                        }
-                        break;
-                    default:
-                        args.Handled = false;
-                        break;
-                }
-            } else if (args.KeyModifiers == cmdKey) {
-                args.Handled = true;
-                switch (args.Key) {
-                    case Key.D2: notesVm.SelectToolCommand?.Execute("2+").Subscribe(); break;
-                    case Key.A: notesVm.SelectAllNotes(); break;
-                    case Key.S: _ = MainWindow?.Save(); break;
-                    case Key.Z: ViewModel.Undo(); break;
-                    case Key.Y: ViewModel.Redo(); break;
-                    case Key.C: notesVm.CopyNotes(); break;
-                    case Key.X: notesVm.CutNotes(); break;
-                    case Key.V: notesVm.PasteNotes(); break;
-                    case Key.Up: notesVm.TransposeSelection(12); break;
-                    case Key.Down: notesVm.TransposeSelection(-12); break;
-                    default:
-                        args.Handled = false;
-                        break;
-                }
-            } else if (args.KeyModifiers == (cmdKey | KeyModifiers.Shift)) {
-                args.Handled = true;
-                switch (args.Key) {
-                    case Key.Z: ViewModel.Redo(); break;
-                    default:
-                        args.Handled = false;
-                        break;
-                }
-            } else if (args.KeyModifiers == KeyModifiers.Alt) {
-                args.Handled = true;
-                switch (args.Key) {
-                    case Key.D1: expSelector1?.SelectExp(); break;
-                    case Key.D2: expSelector2?.SelectExp(); break;
-                    case Key.D3: expSelector3?.SelectExp(); break;
-                    case Key.D4: expSelector4?.SelectExp(); break;
-                    case Key.D5: expSelector5?.SelectExp(); break;
-                    case Key.F4: Hide(); break;
-                    default:
-                        args.Handled = false;
-                        break;
-                }
+
+            // returns true if handled
+            args.Handled = OnKeyExtendedHandler(args);
+        }
+
+        bool OnKeyExtendedHandler(KeyEventArgs args) {
+            var notesVm = ViewModel.NotesViewModel;
+            var playVm = ViewModel.PlaybackViewModel;
+            if (notesVm?.Part == null || playVm == null) {
+                return false;
             }
+            var project = Core.DocManager.Inst.Project;
+            int snapUnit = project.resolution * 4 / notesVm.SnapDiv;
+            int deltaTicks = notesVm.IsSnapOn ? snapUnit : 15;
+
+            bool isNone = args.KeyModifiers == KeyModifiers.None;
+            bool isAlt = args.KeyModifiers == KeyModifiers.Alt;
+            bool isCtrl = args.KeyModifiers == cmdKey;
+            bool isShift = args.KeyModifiers == KeyModifiers.Shift;
+            bool isBoth = args.KeyModifiers == (cmdKey | KeyModifiers.Shift);
+
+            switch (args.Key) {
+                case Key.Space:
+                    if (isNone) {
+                        try {
+                            playVm.PlayOrPause();
+                        } catch (Exception e) {
+                            MessageBox.ShowError(this, e);
+                        }
+                        return true;
+                    }
+                    break;
+                case Key.F4:
+                    if (isAlt) {
+                        Hide();
+                        return true;
+                    }
+                    break;
+                case Key.Enter:
+                    if (isNone) {
+                        OpenLyricBox();
+                        return true;
+                    }
+                    break;
+                case Key.D1:
+                    if (isNone) {
+                        notesVm.SelectToolCommand?.Execute("1").Subscribe();
+                        return true;
+                    }
+                    if (isAlt) {
+                        expSelector1?.SelectExp();
+                        return true;
+                    }
+                    break;
+                case Key.D2:
+                    if (isNone) {
+                        notesVm.SelectToolCommand?.Execute("2").Subscribe();
+                        return true;
+                    }
+                    if (isAlt) {
+                        expSelector2?.SelectExp();
+                        return true;
+                    }
+                    if (isCtrl) {
+                        notesVm.SelectToolCommand?.Execute("2+").Subscribe();
+                        return true;
+                    }
+                    break;
+                case Key.D3:
+                    if (isNone) {
+                        notesVm.SelectToolCommand?.Execute("3").Subscribe();
+                        return true;
+                    }
+                    if (isAlt) {
+                        expSelector3?.SelectExp();
+                        return true;
+                    }
+                    break;
+                case Key.D4:
+                    if (isNone) {
+                        notesVm.SelectToolCommand?.Execute("4").Subscribe();
+                        return true;
+                    }
+                    if (isAlt) {
+                        expSelector4?.SelectExp();
+                        return true;
+                    }
+                    break;
+                case Key.D5:
+                    if (isNone) {
+                        notesVm.SelectToolCommand?.Execute("5").Subscribe();
+                        return true;
+                    }
+                    if (isAlt) {
+                        expSelector5?.SelectExp();
+                        return true;
+                    }
+                    break;
+                case Key.R:
+                    if (isNone) {
+                        notesVm.ShowFinalPitch = !notesVm.ShowFinalPitch;
+                        return true;
+                    }
+                    break;
+                case Key.T:
+                    if (isNone) {
+                        notesVm.ShowTips = !notesVm.ShowTips;
+                        return true;
+                    }
+                    break;
+                case Key.U:
+                    if (isNone) {
+                        notesVm.ShowVibrato = !notesVm.ShowVibrato;
+                        return true;
+                    }
+                    break;
+                case Key.I:
+                    if (isNone) {
+                        notesVm.ShowPitch = !notesVm.ShowPitch;
+                        return true;
+                    }
+                    break;
+                case Key.O:
+                    if (isNone) {
+                        notesVm.ShowPhoneme = !notesVm.ShowPhoneme;
+                        return true;
+                    }
+                    break;
+                case Key.P:
+                    if (isNone) {
+                        notesVm.IsSnapOn = !notesVm.IsSnapOn;
+                        return true;
+                    }
+                    break;
+                case Key.Up:
+                    if (isNone) {
+                        notesVm.TransposeSelection(1);
+                        return true;
+                    }
+                    if (isCtrl) {
+                        notesVm.TransposeSelection(12);
+                        return true;
+                    }
+                    break;
+                case Key.Down:
+                    if (isNone) {
+                        notesVm.TransposeSelection(-1);
+                        return true;
+                    }
+                    if (isCtrl) {
+                        notesVm.TransposeSelection(-12);
+                        return true;
+                    }
+                    break;
+                case Key.Z:
+                    if (isBoth) {
+                        ViewModel.Redo();
+                        return true;
+                    }
+                    if (isCtrl) {
+                        ViewModel.Undo();
+                        return true;
+                    }
+                    break;
+                case Key.Y:
+                    // toggle play tone
+                    if (isNone) {
+                        notesVm.PlayTone = !notesVm.PlayTone;
+                        return true;
+                    }
+                    if (isCtrl) {
+                        ViewModel.Redo();
+                        return true;
+                    }
+                    break;
+                case Key.C:
+                    if (isCtrl) {
+                        notesVm.CopyNotes();
+                        return true;
+                    }
+                    break;
+                case Key.X:
+                    if (isCtrl) {
+                        notesVm.CutNotes();
+                        return true;
+                    }
+                    break;
+                case Key.V:
+                    if (isCtrl) {
+                        notesVm.PasteNotes();
+                        return true;
+                    }
+                    break;
+                case Key.Delete:
+                case Key.Back:
+                    if (isNone) {
+                        notesVm.DeleteSelectedNotes();
+                        return true;
+                    }
+                    break;
+                case Key.Home:
+                    if (isNone) {
+                        playVm.MovePlayPos(notesVm.Part.position);
+                        return true;
+                    }
+                    break;
+                case Key.End:
+                    if (isNone) {
+                        playVm.MovePlayPos(notesVm.Part.End);
+                        return true;
+                    }
+                    break;
+                case Key.A:
+                    // select all
+                    if (isCtrl) {
+                        notesVm.SelectAllNotes();
+                        return true;
+                    }
+                    break;
+                case Key.D:
+                    // select none
+                    if (isCtrl) {
+                        notesVm.SelectAllNotes();
+                        return true;
+                    }
+                    break;
+                case Key.W:
+                    // toggle show waveform
+                    if (isNone) {
+                        notesVm.ShowWaveform = !notesVm.ShowWaveform;
+                        return true;
+                    }
+                    break;
+                case Key.S:
+                    if (isCtrl) {
+                        _ = MainWindow?.Save();
+                        return true;
+                    }
+                    break;
+            }
+            return false;
         }
     }
 }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1089,6 +1089,45 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                case Key.OemOpenBrackets:
+                    // move playhead left
+                    if (isNone) {
+                        playVm.MovePlayPos(playVm.PlayPosTick - snapUnit);
+                        return true;
+                    }
+                    // to selection start
+                    if (isCtrl) {
+                        if (!notesVm.Selection.IsEmpty) {
+                            playVm.MovePlayPos(notesVm.Part.position + notesVm.Selection.FirstOrDefault()!.position);
+                        }
+                        return true;
+                    }
+                    // to view start
+                    if (isShift) {
+                        playVm.MovePlayPos(notesVm.Part.position + (int)notesVm.TickOffset);
+                        return true;
+                    }
+                    break;
+                case Key.OemCloseBrackets:
+                    // move playhead right
+                    if (isNone) {
+                        playVm.MovePlayPos(playVm.PlayPosTick + snapUnit);
+                        return true;
+                    }
+                    // to selection end
+                    if (isCtrl) {
+                        if (!notesVm.Selection.IsEmpty) {
+                            playVm.MovePlayPos(notesVm.Part.position + notesVm.Selection.LastOrDefault()!.RightBound);
+                        }
+                        return true;
+                    }
+                    // to view end
+                    if (isShift) {
+                        playVm.MovePlayPos(notesVm.Part.position + (int)(notesVm.TickOffset));
+                        return true;
+                    }
+                    break;
+
                 #endregion
                 #region scroll and select keys
                 // SCROLL / SELECT

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -803,6 +803,7 @@ namespace OpenUtau.App.Views {
             bool isBoth = args.KeyModifiers == (cmdKey | KeyModifiers.Shift);
 
             switch (args.Key) {
+                #region document keys
                 case Key.Space:
                     if (isNone) {
                         try {
@@ -821,10 +822,17 @@ namespace OpenUtau.App.Views {
                     break;
                 case Key.Enter:
                     if (isNone) {
-                        OpenLyricBox();
+                        if (notesVm.Selection.Count > 1) {
+                            EditLyrics();
+                        } else if (!notesVm.Selection.IsEmpty) {
+                            OpenLyricBox();
+                        }
                         return true;
                     }
                     break;
+                #endregion
+                #region tool select keys
+                // TOOL SELECT
                 case Key.D1:
                     if (isNone) {
                         notesVm.SelectToolCommand?.Execute("1").Subscribe();
@@ -879,6 +887,8 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                #endregion
+                #region toggle show keyws
                 case Key.R:
                     if (isNone) {
                         notesVm.ShowFinalPitch = !notesVm.ShowFinalPitch;
@@ -914,7 +924,11 @@ namespace OpenUtau.App.Views {
                         notesVm.IsSnapOn = !notesVm.IsSnapOn;
                         return true;
                     }
+
                     break;
+                #endregion
+                #region navigate keys
+                // NAVIGATE/EDIT/SELECT HANDLERS
                 case Key.Up:
                     if (isNone) {
                         notesVm.TransposeSelection(1);
@@ -935,6 +949,8 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                #endregion
+                #region clipboard and edit keys
                 case Key.Z:
                     if (isBoth) {
                         ViewModel.Redo();
@@ -981,6 +997,9 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                #endregion
+                #region play position and select keys
+                // PLAY POSITION + SELECTION
                 case Key.Home:
                     if (isNone) {
                         playVm.MovePlayPos(notesVm.Part.position);
@@ -1020,6 +1039,7 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                #endregion
             }
             return false;
         }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -938,6 +938,10 @@ namespace OpenUtau.App.Views {
                         notesVm.IsSnapOn = !notesVm.IsSnapOn;
                         return true;
                     }
+                    if (isAlt) {
+                        var menu = this.FindControl<ContextMenu>("SnapDivMenu");
+                        menu.Open();
+                    }
 
                     break;
                 #endregion

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1183,6 +1183,22 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                case Key.F:
+                    // scroll selection into focus
+                    if (isNone) {
+                        var note = notesVm.Selection.FirstOrDefault();
+                        if (note != null) {
+                            DocManager.Inst.ExecuteCmd(new FocusNoteNotification(notesVm.Part, note));
+                        }
+                        return true;
+                    }
+                    if (isCtrl) {
+                        if (!notesVm.Selection.IsEmpty) {
+                            playVm.MovePlayPos(notesVm.Part.position + notesVm.Selection.FirstOrDefault()!.position);
+                        }
+                        return true;
+                    }
+                    break;
                 case Key.E:
                     // zoom in
                     if (isNone) {

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -963,6 +963,26 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                case Key.Left:
+                    if (isNone) {
+                        notesVm.MoveCursor(-1);
+                        return true;
+                    }
+                    if (isShift) {
+                        notesVm.ExtendSelection(-1);
+                        return true;
+                    }
+                    break;
+                case Key.Right:
+                    if (isNone) {
+                        notesVm.MoveCursor(1);
+                        return true;
+                    }
+                    if (isShift) {
+                        notesVm.ExtendSelection(1);
+                        return true;
+                    }
+                    break;
                 #endregion
                 #region clipboard and edit keys
                 case Key.Z:
@@ -1019,13 +1039,24 @@ namespace OpenUtau.App.Views {
                         playVm.MovePlayPos(notesVm.Part.position);
                         return true;
                     }
+                    if (isShift) {
+                        notesVm.ExtendSelection(notesVm.Part.notes.FirstOrDefault());
+                        return true;
+                    }
                     break;
                 case Key.End:
                     if (isNone) {
                         playVm.MovePlayPos(notesVm.Part.End);
                         return true;
                     }
+                    if (isShift) {
+                        notesVm.ExtendSelection(notesVm.Part.notes.LastOrDefault());
+                        return true;
+                    }
                     break;
+                #endregion
+                #region scroll and select keys
+                // SCROLL / SELECT
                 case Key.A:
                     // select all
                     if (isCtrl) {

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -968,6 +968,14 @@ namespace OpenUtau.App.Views {
                         notesVm.MoveCursor(-1);
                         return true;
                     }
+                    if (isAlt) {
+                        notesVm.ResizeSelectedNotes(-1 * deltaTicks);
+                        return true;
+                    }
+                    if (isCtrl) {
+                        notesVm.MoveSelectedNotes(-1 * deltaTicks);
+                        return true;
+                    }
                     if (isShift) {
                         notesVm.ExtendSelection(-1);
                         return true;
@@ -978,8 +986,28 @@ namespace OpenUtau.App.Views {
                         notesVm.MoveCursor(1);
                         return true;
                     }
+                    if (isAlt) {
+                        notesVm.ResizeSelectedNotes(deltaTicks);
+                        return true;
+                    }
+                    if (isCtrl) {
+                        notesVm.MoveSelectedNotes(deltaTicks);
+                        return true;
+                    }
                     if (isShift) {
                         notesVm.ExtendSelection(1);
+                        return true;
+                    }
+                    break;
+                case Key.OemPlus:
+                    if (isNone) {
+                        notesVm.ResizeSelectedNotes(deltaTicks);
+                        return true;
+                    }
+                    break;
+                case Key.OemMinus:
+                    if (isNone) {
+                        notesVm.ResizeSelectedNotes(-1 * deltaTicks);
                         return true;
                     }
                     break;

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1179,6 +1179,38 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                case Key.E:
+                    // zoom in
+                    if (isNone) {
+                        double x = 0;
+                        double y = 0;
+                        if (!notesVm.Selection.IsEmpty) {
+                            x = (notesVm.Selection.Head!.position - notesVm.TickOffset) / notesVm.ViewportTicks;
+                            y = (ViewConstants.MaxTone - 1 - notesVm.Selection.Head.tone - notesVm.TrackOffset) / notesVm.ViewportTracks;
+                        } else if (notesVm.TickOffset != 0) {
+                            x = 0.5;
+                            y = 0.5;
+                        }
+                        notesVm.OnXZoomed(new Point(x, y), 0.1);
+                        return true;
+                    }
+                    break;
+                case Key.Q:
+                    // zoom out
+                    if (isNone) {
+                        double x = 0;
+                        double y = 0;
+                        if (!notesVm.Selection.IsEmpty) {
+                            x = (notesVm.Selection.Head!.position - notesVm.TickOffset) / notesVm.ViewportTicks;
+                            y = (ViewConstants.MaxTone - 1 - notesVm.Selection.Head.tone - notesVm.TrackOffset) / notesVm.ViewportTracks;
+                        } else if (notesVm.TickOffset != 0) {
+                            x = 0.5;
+                            y = 0.5;
+                        }
+                        notesVm.OnXZoomed(new Point(x, y), -0.1);
+                        return true;
+                    }
+                    break;
                 #endregion
             }
             return false;

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -729,6 +729,14 @@ namespace OpenUtau.App.Views {
             menu.Open();
         }
 
+        void OnSnapDivKeyDown(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Enter && e.KeyModifiers == KeyModifiers.None) {
+                if (sender is ContextMenu menu && menu.SelectedItem is MenuItemViewModel item) {
+                    item.Command?.Execute(item.CommandParameter);
+                }
+            }
+        }
+
         #region value tip
 
         void IValueTip.ShowValueTip() {

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -814,6 +814,20 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                case Key.Escape:
+                    if (isNone) {
+                        // collapse/empty selection
+                        var numSelected = notesVm.Selection.Count;
+                        // if single or all notes then clear
+                        if (numSelected == 1 || numSelected == notesVm.Part.notes.Count) {
+                            notesVm.DeselectNotes();
+                        } else if (numSelected > 1) {
+                            // collapse selection
+                            notesVm.SelectNote(notesVm.Selection.Head!);
+                        }
+                        return true;
+                    }
+                    break;
                 case Key.F4:
                     if (isAlt) {
                         Hide();

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1132,6 +1132,11 @@ namespace OpenUtau.App.Views {
                 #region scroll and select keys
                 // SCROLL / SELECT
                 case Key.A:
+                    // scroll left
+                    if (isNone) {
+                        notesVm.TickOffset = Math.Max(0, notesVm.TickOffset - snapUnit);
+                        return true;
+                    }
                     // select all
                     if (isCtrl) {
                         notesVm.SelectAllNotes();
@@ -1139,6 +1144,11 @@ namespace OpenUtau.App.Views {
                     }
                     break;
                 case Key.D:
+                    // scroll right
+                    if (isNone) {
+                        notesVm.TickOffset = Math.Min(notesVm.TickOffset + snapUnit, notesVm.HScrollBarMax);
+                        return true;
+                    }
                     // select none
                     if (isCtrl) {
                         notesVm.SelectAllNotes();

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1052,6 +1052,13 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     break;
+                // INSERT + DELETE
+                case Key.Insert:
+                    if (isNone) {
+                        notesVm.InsertNote();
+                        return true;
+                    }
+                    break;
                 case Key.Delete:
                 case Key.Back:
                     if (isNone) {

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -399,7 +399,7 @@ namespace OpenUtau.App.Views {
                 if (hitInfo.hitBody) {
                     // if note in question was already in selection before clearing
                     if (selectedNotes.Contains(hitInfo.note)) {
-                        ViewModel.NotesViewModel.SelectNote(hitInfo.note);
+                        ViewModel.NotesViewModel.SelectNote(hitInfo.note, false);
                     }
                 }
                 if (ViewModel.NotesViewModel.Selection.Count > 0) {


### PR DESCRIPTION
This PR addresses #386 and adds a number of additional keyboard shortcuts to the piano roll view. This is a fairly big PR so I tried to break the changes into smaller commits to *(hopefully)* make reviewing easier. 

### Major Features ###
* navigate through notes using Left+Right. Scrolls view as necessary.
* move/resize notes
* enter key opens Lyric Dialog instead of Lyric Box if multiple notes selected (dialog is not accessible and listens for Enter/Esc)
* playback position control
* view scroll/zoom
* add new note with insert key
* **my favorite** - Set playback position to current note with `Ctrl+F`, great when combined with Left+Right to quickly review a phrase

### Changed Behaviors ###
* Lyric Dialog no longer accepts Tab/Enter keys (I don't see the use case for using them. You can still paste in text with these characters). It also focuses the text input area automatically.
* Pressing Tab/Shift+Tab in the lyric box changes the current selection accordingly
* Undoing a note deletion re-selects the deleted notes

### Question ###
Where should the keyboard shortcuts be documented? They could go in the "Tips" popup I guess, but it may get kinda big. Easiest option would be to put in the [Wiki](https://github.com/stakira/OpenUtau/wiki)