### PR TITLE
[Multiple phonemizers] Added functions and tweaks; please read description

### DIFF
--- a/OpenUtau.Plugin.Builtin/Data/Resources.Designer.cs
+++ b/OpenUtau.Plugin.Builtin/Data/Resources.Designer.cs
@@ -79,5 +79,15 @@ namespace OpenUtau.Plugin.Builtin.Data {
                 return ((byte[])(obj));
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] xsampa_template {
+            get {
+                object obj = ResourceManager.GetObject("xsampa_template", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
     }
 }

--- a/OpenUtau.Plugin.Builtin/Data/Resources.resx
+++ b/OpenUtau.Plugin.Builtin/Data/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -123,5 +123,8 @@
   </data>
   <data name="envccv_template" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>envccv.template.yaml;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="xsampa_template" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>xsampa.template.yaml;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/OpenUtau.Plugin.Builtin/Data/xsampa.template.yaml
+++ b/OpenUtau.Plugin.Builtin/Data/xsampa.template.yaml
@@ -83,6 +83,7 @@ symbols:
   - {symbol: ir, type: vowel}
   - {symbol: ur, type: vowel}
   - {symbol: Q, type: vowel}
+  - {symbol: 1, type: vowel}
   - {symbol: Ol, type: vowel}
   - {symbol: aUn, type: vowel}
   - {symbol: '@r', type: vowel}

--- a/OpenUtau.Plugin.Builtin/Data/xsampa.template.yaml
+++ b/OpenUtau.Plugin.Builtin/Data/xsampa.template.yaml
@@ -1,0 +1,99 @@
+%YAML 1.2
+---
+symbols:
+#Delta-style (X-SAMPA) symbols
+  - {symbol: a, type: vowel}
+  - {symbol: e, type: vowel}
+  - {symbol: i, type: vowel}
+  - {symbol: o, type: vowel}
+  - {symbol: u, type: vowel}
+  - {symbol: A, type: vowel}
+  - {symbol: E, type: vowel}
+  - {symbol: I, type: vowel}
+  - {symbol: O, type: vowel}
+  - {symbol: U, type: vowel}
+  - {symbol: '{', type: vowel}
+  - {symbol: V, type: vowel}
+  - {symbol: 3, type: vowel}
+  - {symbol: aI, type: vowel}
+  - {symbol: eI, type: vowel}
+  - {symbol: OI, type: vowel}
+  - {symbol: aU, type: vowel}
+  - {symbol: oU, type: vowel}
+  - {symbol: tS, type: affricate}
+  - {symbol: D, type: fricative}
+  - {symbol: h, type: aspirate}
+  - {symbol: dZ, type: affricate}
+  - {symbol: N, type: nasal}
+  - {symbol: S, type: fricative}
+  - {symbol: T, type: fricative}
+  - {symbol: j, type: semivowel}
+  - {symbol: Z, type: fricative}
+#Arpasing
+  - {symbol: aa, type: vowel}
+  - {symbol: ae, type: vowel}
+  - {symbol: ah, type: vowel}
+  - {symbol: ao, type: vowel}
+  - {symbol: aw, type: vowel}
+  - {symbol: ay, type: vowel}
+  - {symbol: b, type: stop}
+  - {symbol: ch, type: affricate}
+  - {symbol: d, type: stop}
+  - {symbol: dh, type: fricative}
+  - {symbol: eh, type: vowel}
+  - {symbol: er, type: vowel}
+  - {symbol: ey, type: vowel}
+  - {symbol: f, type: fricative}
+  - {symbol: g, type: stop}
+  - {symbol: hh, type: aspirate}
+  - {symbol: ih, type: vowel}
+  - {symbol: iy, type: vowel}
+  - {symbol: jh, type: affricate}
+  - {symbol: k, type: stop}
+  - {symbol: l, type: liquid}
+  - {symbol: m, type: nasal}
+  - {symbol: n, type: nasal}
+  - {symbol: ng, type: nasal}
+  - {symbol: ow, type: vowel}
+  - {symbol: oy, type: vowel}
+  - {symbol: p, type: stop}
+  - {symbol: r, type: liquid}
+  - {symbol: s, type: fricative}
+  - {symbol: sh, type: fricative}
+  - {symbol: t, type: stop}
+  - {symbol: th, type: fricative}
+  - {symbol: uh, type: vowel}
+  - {symbol: uw, type: vowel}
+  - {symbol: v, type: fricative}
+  - {symbol: w, type: semivowel}
+  - {symbol: y, type: semivowel}
+  - {symbol: z, type: fricative}
+  - {symbol: zh, type: fricative}
+  #bonus symbols
+  - {symbol: 'e@', type: vowel}
+  - {symbol: 'e@n', type: vowel}
+  - {symbol: 'e@m', type: vowel}
+  - {symbol: eN, type: vowel}
+  - {symbol: IN, type: vowel}
+  - {symbol: Ar, type: vowel}
+  - {symbol: Er, type: vowel}
+  - {symbol: Ir, type: vowel}
+  - {symbol: Or, type: vowel}
+  - {symbol: Ur, type: vowel}
+  - {symbol: ir, type: vowel}
+  - {symbol: ur, type: vowel}
+  - {symbol: Q, type: vowel}
+  - {symbol: Ol, type: vowel}
+  - {symbol: aUn, type: vowel}
+  - {symbol: '@r', type: vowel}
+  - {symbol: '@l', type: vowel}
+  - {symbol: '@m', type: vowel}
+  - {symbol: '@n', type: vowel}
+  - {symbol: '@N', type: vowel}
+  - {symbol: '@', type: vowel}
+  - {symbol: 4, type: tap}
+  - {symbol: W, type: fricative}
+
+entries:
+  - grapheme: openutau
+    phonemes: [ow, p, ah, n, uw, t, aw]

--- a/OpenUtau.Plugin.Builtin/Data/xsampa.template.yaml
+++ b/OpenUtau.Plugin.Builtin/Data/xsampa.template.yaml
@@ -94,6 +94,7 @@ symbols:
   - {symbol: '@', type: vowel}
   - {symbol: 4, type: tap}
   - {symbol: W, type: fricative}
+  - {symbol: 't_}', type: stop}
 
 entries:
   - grapheme: openutau

--- a/OpenUtau.Plugin.Builtin/Data/xsampa.template.yaml
+++ b/OpenUtau.Plugin.Builtin/Data/xsampa.template.yaml
@@ -70,9 +70,9 @@ symbols:
   - {symbol: z, type: fricative}
   - {symbol: zh, type: fricative}
   #bonus symbols
-  - {symbol: 'e@', type: vowel}
-  - {symbol: 'e@n', type: vowel}
-  - {symbol: 'e@m', type: vowel}
+  - {symbol: e@, type: vowel}
+  - {symbol: e@n, type: vowel}
+  - {symbol: e@m, type: vowel}
   - {symbol: eN, type: vowel}
   - {symbol: IN, type: vowel}
   - {symbol: Ar, type: vowel}

--- a/OpenUtau.Plugin.Builtin/ENDeltaVer1Phonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaVer1Phonemizer.cs
@@ -39,7 +39,31 @@ namespace OpenUtau.Plugin.Builtin
         protected override string GetDictionaryName() => "cmudict-0_7b.txt";
         protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
 
-        protected override IG2p LoadBaseDictionary() => new ArpabetG2p();
+        protected override IG2p LoadBaseDictionary() {
+            var g2ps = new List<IG2p>();
+
+            // Load dictionary from plugin folder.
+            string path = Path.Combine(PluginDir, "xsampa.yaml");
+            if (!File.Exists(path)) {
+                Directory.CreateDirectory(PluginDir);
+                File.WriteAllBytes(path, Data.Resources.xsampa_template);
+            }
+            g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(path)).Build());
+
+            // Load dictionary from singer folder.
+            if (singer != null && singer.Found && singer.Loaded) {
+                string file = Path.Combine(singer.Location, "xsampa.yaml");
+                if (File.Exists(file)) {
+                    try {
+                        g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
+                    } catch (Exception e) {
+                        Log.Error(e, $"Failed to load {file}");
+                    }
+                }
+            }
+            g2ps.Add(new ArpabetG2p());
+            return new G2pFallbacks(g2ps.ToArray());
+        }
 
         protected override List<string> ProcessSyllable(Syllable syllable)
         {

--- a/OpenUtau.Plugin.Builtin/ENDeltaVer1Phonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaVer1Phonemizer.cs
@@ -21,7 +21,7 @@ namespace OpenUtau.Plugin.Builtin
         /// All of these sounds are optional and should be inserted manually/phonetically, if the voicebank supports them.
         ///</summary>
 
-        private readonly string[] vowels = "a,A,@,{,V,O,aU,aI,E,3,eI,I,i,oU,OI,U,u,Q,Ol,aUn,e@,eN,IN,e,o,Ar,Er,Ir,Or,Ur,ir,ur,@l,@m,@n,@N,1,e@m,e@n".Split(',');
+        private readonly string[] vowels = "a,A,@,{,V,O,aU,aI,E,3,eI,I,i,oU,OI,U,u,Q,Ol,aUn,e@,eN,IN,e,o,Ar,Er,Ir,Or,Ur,ir,ur,@r,@l,@m,@n,@N,1,e@m,e@n".Split(',');
         private readonly string[] consonants = "b,tS,d,D,4,f,g,h,dZ,k,l,m,n,N,p,r,s,S,t,T,v,w,W,j,z,Z,t_},・,_".Split(',');
         private readonly string[] affricates = "tS,dZ".Split(',');
         private readonly string[] shortConsonants = "4".Split(",");
@@ -58,12 +58,17 @@ namespace OpenUtau.Plugin.Builtin
                     basePhoneme = rv;
                     if (rv.Contains("V") && !HasOto(rv, syllable.vowelTone) && HasOto($"- A", syllable.vowelTone)) {
                         basePhoneme = $"- A";
+                    } else if(rv.Contains("3") && !HasOto(rv, syllable.vowelTone) && HasOto($"- @r", syllable.vowelTone)) {
+                        basePhoneme = $"- @r";
                     }
                 }
                 else {
                     basePhoneme = v;
                     if (v.Contains("V") && !HasOto(v, syllable.vowelTone) && HasOto($"A", syllable.vowelTone)) {
                         basePhoneme = $"A";
+                    }
+                    else if (v.Contains("3") && !HasOto(v, syllable.vowelTone) && HasOto($"@r", syllable.vowelTone)) {
+                        basePhoneme = $"@r";
                     }
                 }
             }
@@ -83,6 +88,10 @@ namespace OpenUtau.Plugin.Builtin
                         syllable.prevV = "A";
                     } else if (v == "V" && !HasOto(v, syllable.vowelTone)) {
                         syllable.v = "A";
+                    } else if (prevV == "3" && !HasOto(prevV, syllable.vowelTone)) {
+                        syllable.prevV = "@r";
+                    } else if (v == "3" && !HasOto(v, syllable.vowelTone)) {
+                        syllable.v = "@r";
                     } else {
                         basePhoneme = $"{v}";
                     }
@@ -100,12 +109,15 @@ namespace OpenUtau.Plugin.Builtin
                 else if (v == "V" && !HasOto(rcv, syllable.vowelTone) && HasOto($"- {cc[0]}A", syllable.vowelTone))
                 {
                     basePhoneme = $"- {cc[0]}A";
-                }
-                else
+                } else if (v == "3" && !HasOto(rcv, syllable.vowelTone) && HasOto($"- {cc[0]}@r", syllable.vowelTone)) {
+                    basePhoneme = $"- {cc[0]}@r";
+                } else
                 {
                     basePhoneme = cv;
                     if (v == "V" && !HasOto(rcv, syllable.vowelTone) && !HasOto(cv, syllable.vowelTone) && HasOto($"{cc[0]}A", syllable.vowelTone)) {
                         basePhoneme = $"{cc[0]}A";
+                    } else if (v == "3" && !HasOto(rcv, syllable.vowelTone) && !HasOto(cv, syllable.vowelTone) && HasOto($"{cc[0]}@r", syllable.vowelTone)) {
+                        basePhoneme = $"{cc[0]}@r";
                     }
                     if (consonants.Contains(cc[0]))
                     {
@@ -126,6 +138,8 @@ namespace OpenUtau.Plugin.Builtin
                     basePhoneme = $"{cc.Last()}{v}";
                     if (!HasOto($"{cc.Last()}V", syllable.vowelTone) && HasOto($"{cc.Last()}A", syllable.vowelTone)) {
                         basePhoneme = $"{cc.Last()}A";
+                    } else if (!HasOto($"{cc.Last()}3", syllable.vowelTone) && HasOto($"{cc.Last()}@r", syllable.vowelTone)) {
+                        basePhoneme = $"{cc.Last()}@r";
                     }
                     if (HasOto($"_{cc.Last()}{v}", syllable.vowelTone)) {
                         basePhoneme = $"_{cc.Last()}{v}";
@@ -171,8 +185,10 @@ namespace OpenUtau.Plugin.Builtin
                 {
                     basePhoneme = $"{cc.Last()}{v}";
                     phonemes.Add($"A {cc[0]}");
-                }
-                else
+                } else if (prevV == "3" && !HasOto($"3 {cc[0]}", syllable.vowelTone) && !HasOto(vcv, syllable.vowelTone) && !HasOto(vccv, syllable.vowelTone)) {
+                    basePhoneme = $"{cc.Last()}{v}";
+                    phonemes.Add($"@r {cc[0]}");
+                } else
                 {
                     basePhoneme = cc.Last() + v;
                     // try CCV
@@ -306,6 +322,8 @@ namespace OpenUtau.Plugin.Builtin
                     phonemes.Add($"{v} -");
                 } else if (v == "V" && !HasOto($"{v} -", ending.tone) && HasOto($"A -", ending.tone)) {
                     phonemes.Add($"A -");
+                } else if (v == "3" && !HasOto($"{v} -", ending.tone) && HasOto($"@r -", ending.tone)) {
+                    phonemes.Add($"@r -");
                 } else {
                     //continue as usual
                 }
@@ -319,10 +337,14 @@ namespace OpenUtau.Plugin.Builtin
                     phonemes.Add($"{v}{cc[0]} -");
                 } else if (v == "V" && !HasOto(vcr, ending.tone) && HasOto($"A {cc[0]}-", ending.tone)) {
                     phonemes.Add($"A {cc[0]}-");
+                } else if (v == "3" && !HasOto(vcr, ending.tone) && HasOto($"@r {cc[0]}-", ending.tone)) {
+                    phonemes.Add($"@r {cc[0]}-");
                 } else {
                     phonemes.Add($"{v} {cc[0]}");
                     if (v == "V" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"A {cc[0]}", ending.tone)) {
                         v.Replace("V", "A");
+                    } else if (v == "3" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"@r {cc[0]}", ending.tone)) {
+                        v.Replace("3", "@r");
                     }
                     if (affricates.Contains(cc[0])) {
                         TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", cc[0]);
@@ -443,6 +465,9 @@ namespace OpenUtau.Plugin.Builtin
             foreach (var vowel in new[] { "V" })
             {
                 alias = alias.Replace(vowel, "A");
+            }
+            foreach (var vowel in new[] { "3" }) {
+                alias = alias.Replace(vowel, "@r");
             }
             return alias;
         }

--- a/OpenUtau.Plugin.Builtin/ENDeltaVer1Phonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaVer1Phonemizer.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core.G2p;
+using Serilog;
 
 namespace OpenUtau.Plugin.Builtin
 {

--- a/OpenUtau.Plugin.Builtin/ENDeltaVer2Phonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaVer2Phonemizer.cs
@@ -35,7 +35,31 @@ namespace OpenUtau.Plugin.Builtin
         protected override string GetDictionaryName() => "cmudict-0_7b.txt";
         protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
 
-        protected override IG2p LoadBaseDictionary() => new ArpabetG2p();
+        protected override IG2p LoadBaseDictionary() {
+            var g2ps = new List<IG2p>();
+
+            // Load dictionary from plugin folder.
+            string path = Path.Combine(PluginDir, "xsampa.yaml");
+            if (!File.Exists(path)) {
+                Directory.CreateDirectory(PluginDir);
+                File.WriteAllBytes(path, Data.Resources.xsampa_template);
+            }
+            g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(path)).Build());
+
+            // Load dictionary from singer folder.
+            if (singer != null && singer.Found && singer.Loaded) {
+                string file = Path.Combine(singer.Location, "xsampa.yaml");
+                if (File.Exists(file)) {
+                    try {
+                        g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
+                    } catch (Exception e) {
+                        Log.Error(e, $"Failed to load {file}");
+                    }
+                }
+            }
+            g2ps.Add(new ArpabetG2p());
+            return new G2pFallbacks(g2ps.ToArray());
+        }
 
         protected override string[] GetSymbols(Note note)
         {

--- a/OpenUtau.Plugin.Builtin/ENDeltaVer2Phonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaVer2Phonemizer.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core.G2p;
+using Serilog;
 
 namespace OpenUtau.Plugin.Builtin
 {

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -30,7 +30,7 @@ namespace OpenUtau.Plugin.Builtin {
         // ======================================================================================
 
 
-        static readonly string[] plainVowels = new string[] { "eu", "eo", "a", "i", "u", "e", "o" };
+        static readonly string[] plainVowels = new string[] { "eu", "eo", "a", "i", "u", "e", "o", "er" };
 
         static readonly string[] vowels = new string[] {
             "eu=geu,neu,deu,reu,leu,meu,beu,seu,eu,jeu,cheu,keu,teu,peu,heu,ggeu,ddeu,bbeu,sseu,jjeu,feu,veu,zeu,theu,rreu",
@@ -46,7 +46,8 @@ namespace OpenUtau.Plugin.Builtin {
             "l=al,il,ul,el,ol,eul,eol",
             "p=ap,ip,up,ep,op,eup,eop",
             "t=at,it,ut,et,ot,eut,eot",
-            "k=ak,ik,uk,ek,ok,euk,eok"
+            "k=ak,ik,uk,ek,ok,euk,eok",
+            "er=er"
         };
 
         static readonly string[] consonants = new string[] {
@@ -501,6 +502,8 @@ namespace OpenUtau.Plugin.Builtin {
                             mixVV = $"eo {CV}";
                         } else if (prevLyric.EndsWith("eu")) {
                             mixVV = $"eu {CV}";
+                        } else if (prevLyric.EndsWith("er")) {
+                            mixVV = $"er {CV}";
                         }
 
                         // try vowlyric then currentlyric
@@ -675,6 +678,8 @@ namespace OpenUtau.Plugin.Builtin {
                         vowLyric = $"eo {currentLyric}";
                     } else if (prevLyric.EndsWith("eu")) {
                         vowLyric = $"eu {currentLyric}";
+                    } else if (prevLyric.EndsWith("er")) {
+                        vowLyric = $"er {currentLyric}";
                     }
 
                     // try vowlyric then currentlyric
@@ -703,6 +708,8 @@ namespace OpenUtau.Plugin.Builtin {
                         endBreath = $"eo R";
                     } else if (prevLyric.EndsWith("eu")) {
                         endBreath = $"eu R";
+                    } else if (prevLyric.EndsWith("er")) {
+                        endBreath = $"er R";
                     }
 
                     // try end breath

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -478,6 +478,13 @@ namespace OpenUtau.Plugin.Builtin {
                         CV = oto.Alias;
                     }
                 }
+                
+                if (!prevExist && TCLconsonant == "r") {
+                    string[] tests = new string[] { $"- {CV}", $"l{TCLvowel}", CV, currentLyric };
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
+                        CV = oto.Alias;
+                    }
+                }
 
                 if (prevExist && TCLconsonant == "" && TPLfinal == "") {
                     string[] tests = new string[] { $"{TPLplainvowel} {CV}", CV, currentLyric };

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -464,16 +464,75 @@ namespace OpenUtau.Plugin.Builtin {
                 string CV = (TCLconsonant + TCLvowel);
                 string VC = "";
 
-                if (nextExist && (TCLfinal == "")) { VC = TCLplainvowel + " " + TNLconsonant; }
-
+                if (nextExist && (TCLfinal == "") && nextHangeul) { VC = TCLplainvowel + " " + TNLconsonant; }
                 string FC = "";
                 if (TCLfinal != "") { FC = TCLplainvowel + TCLfinal; }
-
 
                 if (lCL == 1) { CV = CV.Replace("r", "l"); }
 
                 // 만약 앞에 노트가 없다면
-                if (!prevExist) { CV = $"- {CV}"; }
+                if (!prevExist) {
+                    string[] tests = new string[] { $"- {CV}", CV, currentLyric };
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
+                        CV = oto.Alias;
+                    }
+                }
+
+                if (prevExist && TCLconsonant == "" && TPLfinal == "") {
+                    string[] tests = new string[] { $"{TPLplainvowel} {CV}", CV, currentLyric };
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
+                        CV = oto.Alias;
+                    }
+                }
+
+                if (prevNeighbour != null && prevExist && !prevHangeul && TCLconsonant == "") {
+                    var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
+                    var vowel = "";
+
+                    var prevLyric = string.Join("", prevUnicode);
+
+                    // Current note is VV
+                    if (vowelLookup.TryGetValue(prevUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
+                        vowel = vow;
+
+                        var mixVV = $"{vow} {CV}";
+
+                        if (prevLyric.EndsWith("eo")) {
+                            mixVV = $"eo {CV}";
+                        } else if (prevLyric.EndsWith("eu")) {
+                            mixVV = $"eu {CV}";
+                        }
+
+                        // try vowlyric then currentlyric
+                        string[] tests = new string[] { mixVV, CV, currentLyric };
+                        if (checkOtoUntilHit(tests, note, out var oto)) {
+                            CV = oto.Alias;
+                        }
+                    }
+
+                }
+
+                if (nextNeighbour != null) { // 다음에 노트가 있으면
+                    var nextUnicode = ToUnicodeElements(nextNeighbour?.lyric);
+                    var nextLyric = string.Join("", nextUnicode);
+
+                    // Insert VC before next neighbor
+                    // Get vowel from current note
+                    var vowel = TCLplainvowel;
+
+                    // Get consonant from next note
+                    var consonant = "";
+                    if (consonantLookup.TryGetValue(nextUnicode.FirstOrDefault() ?? string.Empty, out var con)) {
+                        consonant = getConsonant(nextNeighbour?.lyric); //로마자만 가능
+                        if ((!isAlphaCon(consonant))) { consonant = con; }
+                    } else if (nextExist && nextHangeul) {
+                        consonant = TNLconsonant;
+                    }
+
+                    if (!nextHangeul) {
+                        VC = TCLplainvowel + " " + consonant;
+                    }
+                }
 
                 // 만약 받침이 있다면
                 if (FC != "") {
@@ -527,21 +586,45 @@ namespace OpenUtau.Plugin.Builtin {
                                 },
                             };
                         }
-                        
+                    } else if (VC != "" && TNLconsonant == "") {
+                        int totalDuration = notes.Sum(n => n.duration);
+                        int vcLength = 60;
+                        var nextAttr = nextNeighbour.Value.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+                        var nextUnicode = ToUnicodeElements(nextNeighbour?.lyric);
+                        var nextLyric = string.Join("", nextUnicode);
+                        if (singer.TryGetMappedOto(nextLyric, nextNeighbour.Value.tone + nextAttr.toneShift, nextAttr.voiceColor, out var oto0)) {
+                            vcLength = MsToTick(oto0.Preutter);
+                            
+                        }
+                        vcLength = Math.Min(totalDuration / 2, vcLength);
+
+                        if (singer.TryGetMappedOto(CV, note.tone + attr0.toneShift, attr0.voiceColor, out var oto1) && singer.TryGetMappedOto(VC, note.tone + attr0.toneShift, attr0.voiceColor, out var oto2)) {
+                            CV = oto1.Alias;
+                            VC = oto2.Alias;
+                            return new Result {
+                                phonemes = new Phoneme[] {
+                                    new Phoneme() {
+                                        phoneme = CV,
+                                    },
+                                    new Phoneme() {
+                                        phoneme = VC,
+                                        position = totalDuration - vcLength,
+                                    }
+                                },
+                            };
+                        }
                     }
-                }
-
-
-                // 그 외(받침 없는 마지막 노트)
-                if (singer.TryGetMappedOto(CV, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)){
+                    // 그 외(받침 없는 마지막 노트)
+                    if (singer.TryGetMappedOto(CV, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)) {
                         CV = oto.Alias;
                         return new Result {
                             phonemes = new Phoneme[] {
                             new Phoneme() {
                                 phoneme = CV,
-                            }
-                        },
-                    };
+                                }
+                            },
+                        };
+                    }
                 }
             }
 
@@ -553,9 +636,9 @@ namespace OpenUtau.Plugin.Builtin {
                 }
 
                 if (singer.TryGetMappedOto(endBreath, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)){
-                        endBreath = oto.Alias;
-                        return new Result {
-                            phonemes = new Phoneme[] {
+                    endBreath = oto.Alias;
+                    return new Result {
+                        phonemes = new Phoneme[] {
                             new Phoneme() {
                                 phoneme = endBreath,
                             }
@@ -577,24 +660,54 @@ namespace OpenUtau.Plugin.Builtin {
                 if (checkOtoUntilHit(tests, note, out var oto)){
                     currentLyric = oto.Alias;
                 }
+            } else if (plainVowels.Contains(currentLyric)) {
+                var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
+                var vowel = "";
+
+                var prevLyric = string.Join("", prevUnicode);
+                // Current note is VV
+                if (vowelLookup.TryGetValue(prevUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
+                    vowel = vow;
+
+                    var vowLyric = $"{vow} {currentLyric}";
+
+                    if (prevLyric.EndsWith("eo")) {
+                        vowLyric = $"eo {currentLyric}";
+                    } else if (prevLyric.EndsWith("eu")) {
+                        vowLyric = $"eu {currentLyric}";
+                    }
+
+                    // try vowlyric then currentlyric
+                    string[] tests = new string[] { vowLyric, currentLyric };
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
+                        currentLyric = oto.Alias;
+                    }
+                } else if (prevExist && prevHangeul && TPLfinal == "") {
+                    var vowLyric = $"{TPLplainvowel} {currentLyric}";
+
+                    string[] tests = new string[] { vowLyric, currentLyric };
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
+                        currentLyric = oto.Alias;
+                    }
+                }
             } else if ("R".Contains(currentLyric)) {
                 var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
                 // end breath note
                 if (vowelLookup.TryGetValue(prevUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
                     var vowel = "";
-                    var prevLyric = string.Join("", prevUnicode);;   
+                    var prevLyric = string.Join("", prevUnicode);
                     vowel = vow;
-                    
+
                     var endBreath = $"{vow} R";
                     if (prevLyric.EndsWith("eo")) {
                         endBreath = $"eo R";
                     } else if (prevLyric.EndsWith("eu")) {
                         endBreath = $"eu R";
                     }
-                                        
+
                     // try end breath
                     string[] tests = new string[] {endBreath, currentLyric};
-                    if (checkOtoUntilHit(tests, note, out var oto)){ 
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
                         currentLyric = oto.Alias;
                     }
                 }
@@ -626,8 +739,11 @@ namespace OpenUtau.Plugin.Builtin {
 
                 if (vowelLookup.TryGetValue(currentUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
                     vowel = vow;
+                    if (currentLyric.Contains(TCLplainvowel)) {
+                        vow = TCLplainvowel;
+                    }
 
-                    if (currentLyric.Contains("e")) {
+                    if (currentLyric.Contains("e") && !currentLyric.Contains("eui")) {
                         vowel = "e" + vowel;
                         vowel = vowel.Replace("ee", "e");
                     }
@@ -637,7 +753,9 @@ namespace OpenUtau.Plugin.Builtin {
                 var consonant = "";
                 if (consonantLookup.TryGetValue(nextUnicode.FirstOrDefault() ?? string.Empty, out var con)) {
                     consonant = getConsonant(nextNeighbour?.lyric); //로마자만 가능
-                    if (!(isAlphaCon(consonant))) { consonant = con; }
+                    if ((!isAlphaCon(consonant))) { consonant = con; }
+                } else if (nextExist && nextHangeul) {
+                    consonant = TNLconsonant;
                 }
 
                 if (consonant == "") {
@@ -669,10 +787,11 @@ namespace OpenUtau.Plugin.Builtin {
                 var nextAttr = nextNeighbour.Value.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
                 if (singer.TryGetMappedOto(nextLyric, nextNeighbour.Value.tone + nextAttr.toneShift, nextAttr.voiceColor, out var oto)) {
                     vcLength = MsToTick(oto.Preutter);
-                }
-                vcLength = Math.Min(totalDuration / 2, vcLength);
-
-
+                } else if ((TNLconsonant == "r") || (TNLconsonant == "h")) { vcLength = 30; }
+                else if (TNLconsonant == "s") { vcLength = totalDuration / 3; }
+                else if ((TNLconsonant == "k") || (TNLconsonant == "t") || (TNLconsonant == "p") || (TNLconsonant == "ch")) { vcLength = totalDuration / 2; }
+                else if ((TNLconsonant == "gg") || (TNLconsonant == "dd") || (TNLconsonant == "bb") || (TNLconsonant == "ss") || (TNLconsonant == "jj")) { vcLength = totalDuration / 2; }
+                vcLength = Math.Min(totalDuration / 2, vcLength);           
 
                 return new Result {
                     phonemes = new Phoneme[] {

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -485,6 +485,13 @@ namespace OpenUtau.Plugin.Builtin {
                         CV = oto.Alias;
                     }
                 }
+                
+                if (prevExist && TCLconsonant == "" && TPLfinal == "ng") {
+                    string[] tests = new string[] { $"ng{CV}", CV, currentLyric };
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
+                        CV = oto.Alias;
+                    }
+                }
 
                 if (prevNeighbour != null && prevExist && !prevHangeul && TCLconsonant == "") {
                     var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -701,6 +701,11 @@ namespace OpenUtau.Plugin.Builtin {
                     if (checkOtoUntilHit(tests, note, out var oto)) {
                         currentLyric = oto.Alias;
                     }
+                } else if (prevExist && prevHangeul && TPLfinal == "ng") {
+                    string[] tests = new string[] { $"ng{currentLyric}", currentLyric };
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
+                        currentLyric = oto.Alias;
+                    }
                 }
             } else if ("R".Contains(currentLyric)) {
                 var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -475,7 +475,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                 // 만약 앞에 노트가 없다면
                 if (!prevExist && TCLconsonant == "r") {
-                    string[] tests = new string[] { $"- {CV}", $"l{TCLplainvowel}", CV, currentLyric };
+                    string[] tests = new string[] { $"- {CV}", $"l{TCLvowel}", CV, currentLyric };
                     if (checkOtoUntilHit(tests, note, out var oto)) {
                         CV = oto.Alias;
                     }

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -474,15 +474,14 @@ namespace OpenUtau.Plugin.Builtin {
                 if (lCL == 1) { CV = CV.Replace("r", "l"); }
 
                 // 만약 앞에 노트가 없다면
-                if (!prevExist) {
-                    string[] tests = new string[] { $"- {CV}", CV, currentLyric };
+                if (!prevExist && TCLconsonant == "r") {
+                    string[] tests = new string[] { $"- {CV}", $"l{TCLplainvowel}", CV, currentLyric };
                     if (checkOtoUntilHit(tests, note, out var oto)) {
                         CV = oto.Alias;
                     }
                 }
-                
-                if (!prevExist && TCLconsonant == "r") {
-                    string[] tests = new string[] { $"- {CV}", $"l{TCLvowel}", CV, currentLyric };
+                else if (!prevExist && TCLconsonant != "r") {
+                    string[] tests = new string[] { $"- {CV}", CV, currentLyric };
                     if (checkOtoUntilHit(tests, note, out var oto)) {
                         CV = oto.Alias;
                     }

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -32,6 +32,8 @@ namespace OpenUtau.Plugin.Builtin {
 
         static readonly string[] plainVowels = new string[] { "eu", "eo", "a", "i", "u", "e", "o", "er" };
 
+        static readonly string[] plainDiphthongs = new string[] { "ya", "yeo", "yo", "yu", "ye", "wa", "weo", "wi", "we", "eui" };
+
         static readonly string[] vowels = new string[] {
             "eu=geu,neu,deu,reu,leu,meu,beu,seu,eu,jeu,cheu,keu,teu,peu,heu,ggeu,ddeu,bbeu,sseu,jjeu,feu,veu,zeu,theu,rreu",
             "eo=geo,neo,deo,reo,leo,meo,beo,seo,eo,jeo,cheo,keo,teo,peo,heo,ggeo,ddeo,bbeo,sseo,jjeo,feo,veo,zeo,theo,rreo,gyeo,nyeo,dyeo,ryeo,lyeo,myeo,byeo,syeo,yeo,jyeo,chyeo,kyeo,tyeo,pyeo,hyeo,ggyeo,ddyeo,bbyeo,ssyeo,jjyeo,fyeo,vyeo,zyeo,thyeo,gweo,nweo,dweo,rweo,lweo,mweo,bweo,sweo,weo,jweo,chweo,kweo,tweo,pweo,hweo,ggweo,ddweo,bbweo,ssweo,jjweo,fweo,vweo,zweo,thweo",
@@ -677,7 +679,7 @@ namespace OpenUtau.Plugin.Builtin {
                 if (checkOtoUntilHit(tests, note, out var oto)){
                     currentLyric = oto.Alias;
                 }
-            } else if (plainVowels.Contains(currentLyric)) {
+            } else if (plainVowels.Contains(currentLyric) || plainDiphthongs.Contains(currentLyric)) {
                 var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
                 var vowel = "";
 

--- a/OpenUtau.Plugin.Builtin/KoreanVCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanVCVPhonemizer.cs
@@ -206,10 +206,10 @@ namespace OpenUtau.Plugin.Builtin
 			}
 
 			// Adjust current phoneme based on previous neighbor
-			if (prevNeighbour != null && singer.TryGetMappedOto(prevNeighbour?.lyric, note.tone + shift, color, out _)) currPhoneme = $"{GetLastSoundOfAlias(prevNeighbour?.lyric)} {currPhoneme}";
+			if (prevNeighbour != null && prevNeighbour?.lyric != "bre" && singer.TryGetMappedOto(prevNeighbour?.lyric, note.tone + shift, color, out _)) currPhoneme = $"{GetLastSoundOfAlias(prevNeighbour?.lyric)} {currPhoneme}";
 			else
 			{
-				if (prevNeighbour == null || prevNeighbour?.lyric == "R" || prevNeighbour?.lyric == "-" || prevNeighbour?.lyric == "H" || prevNeighbour?.lyric == "B") currPhoneme = $"- {currPhoneme}";
+				if (prevNeighbour == null || prevNeighbour?.lyric == "R" || prevNeighbour?.lyric == "-" || prevNeighbour?.lyric == "H" || prevNeighbour?.lyric == "B" || prevNeighbour?.lyric == "bre") currPhoneme = $"- {currPhoneme}";
 				else
 				{
 					if (string.IsNullOrEmpty(prevNeighbour?.phoneticHint))

--- a/OpenUtau.Plugin.Builtin/KoreanVCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanVCVPhonemizer.cs
@@ -37,7 +37,7 @@ namespace OpenUtau.Plugin.Builtin
 		/// <summary>
 		/// Extra English-based sounds for phonetic hint input + alternate romanizations for tense plosives (ㄲ, ㄸ, ㅃ)
 		/// </summary>
-		static readonly string[] extras = { "f", "v", "th", "dh", "z", "kk", "pp", "tt" };
+		static readonly string[] extras = { "f", "v", "th", "dh", "z", "rr", "kk", "pp", "tt" };
 
 		/// <summary>
 		/// Gets the romanized initial, medial, and final components of the passed Hangul syllable.


### PR DESCRIPTION
KOR VCV:
- Fixes end breaths aliased with ``bre``.
- Adds support for English "r" (aliased ``rr``).

KOR CVC:
- Optional VV support
- Make Hangul initial optional
- Support for VV and VC notes between different scripts (e,g. from Hangul to romaja & from romaja to Hangul)
- Fix romaja ``eui`` VC bug
- Added Konglish rhotic "er" vowel (only V/VV, no C+V or VC. Unless someone really wants it)
- Added optional ``ng`` connectors
- Automatic change of "r" to "l" if there's no starting CV
- **TODO (for future PR):**
  - "L" bug fix
  - Automatic romaja finals? (I don't know how to code that yet)
 
EN Delta Phonemizers:
- Added support for ``@r`` phoneme (Version 1 only)
- Added custom dictionary support (both phonemizers; associated resource templates have been created as well)