### PR TITLE
Fix null lyric on USTX load

### DIFF
--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -65,6 +65,8 @@ namespace OpenUtau.Core.Ustx {
                     exp.descriptor = descriptor;
                 }
             }
+            if (lyric == null) lyric = NotePresets.Default.DefaultLyric;
+            lyric = lyric.Replace("\"", ""); // erase all containing quotes in lyrics
         }
 
         public void BeforeSave(UProject project, UTrack track, UVoicePart part) {
@@ -72,6 +74,8 @@ namespace OpenUtau.Core.Ustx {
                 .OrderBy(exp => exp.index)
                 .ThenBy(exp => exp.abbr)
                 .ToList();
+
+            lyric = "\"" + lyric + "\""; // surround lyric with quotes
         }
 
         public void Validate(ValidateOptions options, UProject project, UTrack track, UVoicePart part) {

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -78,6 +78,10 @@ namespace OpenUtau.Core.Ustx {
             lyric = "\"" + lyric + "\""; // surround lyric with quotes
         }
 
+        public void AfterSave(UProject project, UTrack track, UVoicePart part) {
+            lyric = lyric.Replace("\"", ""); // prevent multiple quotes after consecutive saves
+        }
+
         public void Validate(ValidateOptions options, UProject project, UTrack track, UVoicePart part) {
             duration = Math.Max(10, duration);
             PositionMs = project.timeAxis.TickPosToMsPos(part.position + position);

--- a/OpenUtau.Core/Ustx/UPart.cs
+++ b/OpenUtau.Core/Ustx/UPart.cs
@@ -28,6 +28,7 @@ namespace OpenUtau.Core.Ustx {
         public abstract int GetMinDurTick(UProject project);
 
         public virtual void BeforeSave(UProject project, UTrack track) { }
+        public virtual void AfterSave(UProject project, UTrack track) { }
         public virtual void AfterLoad(UProject project, UTrack track) { }
 
         public virtual void Validate(ValidateOptions options, UProject project, UTrack track) { }
@@ -68,6 +69,12 @@ namespace OpenUtau.Core.Ustx {
         public override void BeforeSave(UProject project, UTrack track) {
             foreach (var note in notes) {
                 note.BeforeSave(project, track, this);
+            }
+        }
+
+        public override void AfterSave(UProject project, UTrack track) {
+            foreach (var note in notes) {
+                note.AfterSave(project, track, this);
             }
         }
 

--- a/OpenUtau.Core/Ustx/UProject.cs
+++ b/OpenUtau.Core/Ustx/UProject.cs
@@ -128,6 +128,9 @@ namespace OpenUtau.Core.Ustx {
         }
 
         public void AfterSave() {
+            foreach (var part in parts) {
+                part.AfterSave(this, tracks[part.trackNo]);
+            }
             voiceParts = null;
             waveParts = null;
         }


### PR DESCRIPTION
The English word "null" cannot be used in lyrics when saved as a USTX file. The YAML parser reads a literal `null` on load and fails. [Discord bug report](https://discord.com/channels/551606189386104834/801525671775043625/1054981543170428928)

- Surround UNote lyrics with quotes `" "` to force YAML to serialize literal strings
- Remove quotes from lyric on load
- Literal `null` lyrics convert to default lyric on load to prevent loading null lyric
- Add `AfterSave` to UPart, make UProject execute `AfterSave` to remove multiple quotes on consecutive saves

Admittedly this is probably clunky and not perfect, but it's better than failing to load because of a YAML quirk