### PR TITLE
Fix "null" strings on writing yaml files

### DIFF
--- a/OpenUtau.Core/OpenUtau.Core.csproj
+++ b/OpenUtau.Core/OpenUtau.Core.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="TinyPinyin.Net" Version="1.0.2" />
     <PackageReference Include="UTF.Unknown" Version="2.5.1" />
     <PackageReference Include="WanaKana-net" Version="1.0.0" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="YamlDotNet" Version="12.0.0" />
     <PackageReference Include="NetMQ" Version="4.0.1.9" />
   </ItemGroup>
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/OpenUtau.Core/OpenUtau.Core.csproj
+++ b/OpenUtau.Core/OpenUtau.Core.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="TinyPinyin.Net" Version="1.0.2" />
     <PackageReference Include="UTF.Unknown" Version="2.5.1" />
     <PackageReference Include="WanaKana-net" Version="1.0.0" />
-    <PackageReference Include="YamlDotNet" Version="12.0.0" />
+    <PackageReference Include="YamlDotNet" Version="12.0.1" />
     <PackageReference Include="NetMQ" Version="4.0.1.9" />
   </ItemGroup>
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/OpenUtau.Core/Util/Yaml.cs
+++ b/OpenUtau.Core/Util/Yaml.cs
@@ -13,6 +13,7 @@ namespace OpenUtau.Core {
             .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
             .WithEventEmitter(next => new FlowEmitter(next))
             .DisableAliases()
+            .WithQuotingNecessaryStrings()
             .Build();
 
         public static IDeserializer DefaultDeserializer = new DeserializerBuilder()

--- a/OpenUtau.Test/Classic/VoicebankConfigTest.cs
+++ b/OpenUtau.Test/Classic/VoicebankConfigTest.cs
@@ -51,35 +51,36 @@ namespace OpenUtau.Classic {
             var yaml = Yaml.DefaultSerializer.Serialize(CreateConfig());
             output.WriteLine(yaml);
 
+            //"" evaluates to " in verbatim string literals
             Assert.Equal(@"portrait_opacity: 0.75
 symbol_set:
   preset: hiragana
   head: '-'
   tail: R
 subbanks:
-- prefix: ''
-  suffix: ''
+- prefix: """"
+  suffix: """"
   tone_ranges:
   - C1-C4
-- prefix: ''
+- prefix: """"
   suffix: D4
   tone_ranges:
   - C#4-F4
-- prefix: ''
+- prefix: """"
   suffix: G4
   tone_ranges:
   - F#4-A#4
-- prefix: ''
+- prefix: """"
   suffix: C5
   tone_ranges:
   - B4-B7
 - color: power
-  prefix: ''
+  prefix: """"
   suffix: C5P
   tone_ranges:
   - B4-B7
 - color: shout
-  prefix: ''
+  prefix: """"
   suffix: C5S
   tone_ranges:
   - B4-B7

--- a/OpenUtau.Test/Core/USTx/UstxYamlTest.cs
+++ b/OpenUtau.Test/Core/USTx/UstxYamlTest.cs
@@ -72,6 +72,14 @@ phoneme_overrides: []
             yaml = Yaml.DefaultSerializer.Serialize(new UNote() { lyric = "-&" });
             actual = Yaml.DefaultDeserializer.Deserialize<UNote>(yaml);
             Assert.Equal("-&", actual.lyric);
+
+            yaml = Yaml.DefaultSerializer.Serialize(new UNote() { lyric = "null" });
+            actual = Yaml.DefaultDeserializer.Deserialize<UNote>(yaml);
+            Assert.Equal("null", actual.lyric);
+
+            yaml = Yaml.DefaultSerializer.Serialize(new UNote() { lyric = "true" });
+            actual = Yaml.DefaultDeserializer.Deserialize<UNote>(yaml);
+            Assert.Equal("true", actual.lyric);
         }
     }
 }


### PR DESCRIPTION
The English word "null" cannot be used in lyrics when saved as a USTX file. The YAML parser reads a literal null on load and fails. [Discord bug report](https://discord.com/channels/551606189386104834/801525671775043625/1054981543170428928)

* `.WithQuotingNecessaryStrings()` is used in yaml serializer to force quote "null", "true", "false" and numbers strings
* ~Updating YamlDotNet to 12.0.0~ 
* Updating YamlDotNet to 12.0.1, 
  * `.WithQuotingNecessaryStrings()` is only supported in YamlDotNet version 12.0.0 and above. See https://github.com/aaubry/YamlDotNet/issues/591
  * YamlDotNet version 12.0.0 has bug deserializing string "-@" and "-&". This bug is fixed in version 12.0.1. See https://github.com/aaubry/YamlDotNet/issues/719
* "null" and "true" serializing are added to test.