### PR TITLE
fix: Korean CVCCV

### DIFF
--- a/OpenUtau.Plugin.Builtin/KoreanCVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCCVPhonemizer.cs
@@ -3,27 +3,66 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core.Ustx;
+using static OpenUtau.Api.Phonemizer;
 
 namespace OpenUtau.Plugin.Builtin {
     [Phonemizer("Korean CVCCV Phonemizer", "KO CVCCV", "RYUUSEI", language:"KO")]
     public class KoreanCVCCVPhonemizer : Phonemizer {
         static readonly string initialConsonantsTable = "ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ";
         static readonly string vowelsTable = "ㅏㅐㅑㅒㅓㅔㅕㅖㅗㅘㅙㅚㅛㅜㅝㅞㅟㅠㅡㅢㅣ";
+        static readonly string YVowelsTable = "ㅣㅑㅖㅛㅠㅕ";
         static readonly string lastConsonantsTable = "　ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ";
 
         static readonly ushort unicodeKoreanBase = 0xAC00;
         static readonly ushort unicodeKoreanLast = 0xD79F;
 
-        static readonly string continuousinitialConsonantsTable = "ㄱㄴㄷㄹㅁㅂㅅㅇㅈㅎ";
+        public enum TYPE_FLAG {
+            VC_CV,
+            VRC_CV,
+            VC_RCV,
+            VC_NCV,
+            VC_NRCV,
+            VRC_NCV,
+            VC_CV_ADDED_Y,
+            VCC_CV,
+            VCC_CV_ADDED_Y,
+            VC_CCV,
+            VC_CCV_ADDED_Y,
+            _VCV,
+            CV,
+        };
 
-        static readonly string cvvcInitialConsonantsTable = "ㅋㅌㅍㅊㄲㄸㅃㅉㅆ";
-
-        static readonly string vccLastConsonantsTable = "ㄴㄵㅁㄹㄺㄻㄼㄽㄾㄿㅀㅇ";
-        static readonly string vccSubInitialConsonantsTable = "ㄱㅋㄲㅅㅈㅌㄷㅆㅎㅊㅂㅍ";
-
-        static readonly string vcc2LastConsonantsTable = "ㄱㄲㄳㅂㅄㅍㅌㅆ";
-        static readonly string vcc2SubInitialConsonantsTable = "ㅅㅆ";
-        
+        static readonly TYPE_FLAG[,] typeTable = new TYPE_FLAG[,] {
+            {   TYPE_FLAG._VCV,   TYPE_FLAG.VRC_CV,   TYPE_FLAG._VCV,     TYPE_FLAG._VCV,     TYPE_FLAG.VRC_CV,   TYPE_FLAG._VCV,     TYPE_FLAG._VCV,     TYPE_FLAG._VCV,     TYPE_FLAG.VRC_CV,   TYPE_FLAG._VCV,           TYPE_FLAG.VC_CV_ADDED_Y,    TYPE_FLAG._VCV,     TYPE_FLAG._VCV,     TYPE_FLAG.VRC_CV,   TYPE_FLAG.VRC_CV,   TYPE_FLAG.VRC_CV,   TYPE_FLAG.VRC_CV,   TYPE_FLAG.VRC_CV, TYPE_FLAG._VCV,   }, // 받침누락
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV_ADDED_Y, TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.CV,       TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㄱ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV_ADDED_Y, TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.VC_RCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㄲ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV_ADDED_Y, TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㄳ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.CV,       TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄴ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.CV,       TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄵ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.CV,       TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄶ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,          TYPE_FLAG.VC_CV_ADDED_Y,    TYPE_FLAG.CV,       TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㄷ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.CV,       TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄹ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄺ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄼ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄻ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄽ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄾ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㄿ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㅀ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,         TYPE_FLAG.VC_CCV_ADDED_Y,   TYPE_FLAG.CV,       TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㅁ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,         TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.CV,       TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅂ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,         TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅄ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,          TYPE_FLAG.VC_CV_ADDED_Y,    TYPE_FLAG.CV,       TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅅ
+            {   TYPE_FLAG.VRC_NCV,TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,        TYPE_FLAG.VRC_NCV,          TYPE_FLAG.VC_RCV,   TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,  TYPE_FLAG.VRC_NCV,TYPE_FLAG.VRC_NCV,}, // ㅆ
+            {   TYPE_FLAG.VC_CCV, TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,         TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV,   TYPE_FLAG.VCC_CV, TYPE_FLAG.VC_CCV, }, // ㅇ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,         TYPE_FLAG.VC_CV_ADDED_Y,    TYPE_FLAG.CV,       TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅈ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,         TYPE_FLAG.VC_CV_ADDED_Y,    TYPE_FLAG.CV,       TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅊ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,         TYPE_FLAG.VC_CV_ADDED_Y,    TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅋ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,         TYPE_FLAG.VC_CV_ADDED_Y,    TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅌ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VCC_CV,         TYPE_FLAG.VCC_CV_ADDED_Y,   TYPE_FLAG.VC_NRCV,  TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅍ
+            {   TYPE_FLAG.VC_NCV, TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,          TYPE_FLAG.VC_CV_ADDED_Y,    TYPE_FLAG.CV,       TYPE_FLAG.VC_NCV,   TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,    TYPE_FLAG.VC_CV,  TYPE_FLAG.VC_NCV, }, // ㅎ
+                // ㄱ             // ㄲ               // ㄴ               // ㄷ               // ㄸ               // ㄹ               // ㅁ               // ㅂ               // ㅃ               // ㅅ                 // ㅆ                       // ㅇ               // ㅈ               // ㅉ               // ㅊ               // ㅋ               // ㅌ               // ㅍ             // ㅎ
+        };
 
         private char[] SeparateHangul(char letter) {
             if (letter == 0) return new char[] { '　', '　', '　' };
@@ -45,25 +84,64 @@ namespace OpenUtau.Plugin.Builtin {
 
         // 초성
         static readonly string[] continuousinitialConsonants = new string[] {
-            "g=ㄱ",
-            "n=ㄴ",
+            "g=ㄱ,ㄺ",
+            "gg=ㄲ",
+            "n=ㄴ,ㄵ,ㄶ",
             "d=ㄷ",
+            "dd=ㄸ",
             "r=ㄹ",
-            "m=ㅁ",
-            "b=ㅂ",
-            "s=ㅅ",
+            "m=ㅁ,ㄻ",
+            "b=ㅂ,ㄼ",
+            "bb=ㅃ",
+            "s=ㅅ,ㅄ,ㄽ,ㄳ",
+            "ss=ㅆ",
             "=ㅇ",
             "j=ㅈ",
+            "jj=ㅉ",
+            "ch=ㅊ",
+            "k=ㅋ",
+            "t=ㅌ",
+            "p=ㅍ,ㄿ",
+            "h=ㅎ,ㅀ",
+        };
+
+        static readonly string[] ccvContinuousinitialConsonants = new string[] {
+            "g=ㄱ",
+            "gg=ㄲ",
+            "n=ㄴ",
+            "d=ㄷ",
+            "dd=ㄸ",
+            "l=ㄹ,ㄺ,ㄼ,ㄻ,ㄽ,ㄾ,ㄿ,ㅀ",
+            "m=ㅁ",
+            "b=ㅂ",
+            "bb=ㅃ",
+            "s=ㅅ",
+            "ss=ㅆ",
+            "=ㅇ",
+            "j=ㅈ",
+            "jj=ㅉ",
             "ch=ㅊ",
             "k=ㅋ",
             "t=ㅌ",
             "p=ㅍ",
             "h=ㅎ",
-            "gg=ㄲ",
-            "dd=ㄸ",
-            "bb=ㅃ",
-            "ss=ㅆ",
-            "jj=ㅉ",
+        };
+
+        static readonly string[] vrcContinuousinitialConsonants = new string[] {
+            "gg=ㄱ,ㄲ",
+            "n=ㄴ,ㄵ,ㄶ",
+            "dd=ㄷ,ㄸ",
+            "r=ㄹ",
+            "m=ㅁ",
+            "d=ㅎ",
+            "bb=ㅂ,ㅃ",
+            "ss=ㅅ,ㅆ",
+            "=ㅇ",
+            "jj=ㅈ,ㅉ",
+            "ch=ㅊ",
+            "k=ㅋ",
+            "t=ㅌ",
+            "p=ㅍ",
         };
 
         // 일반 모음
@@ -97,55 +175,62 @@ namespace OpenUtau.Plugin.Builtin {
             "i=ㅣ,ㅢ,ㅟ",
         };
 
-        static readonly string[] noNextLastConsonants = new string[] {
-            "K=ㄱ,ㅋ,ㄲ",
-            "T=ㅅ,ㅈ,ㅌ,ㄷ,ㅆ,ㅎ,ㅊ",
-            "P=ㅂ,ㅍ",
+        static readonly string[] lastConsonants = new string[] {
+            "K=ㄱ,ㅋ,ㄲ,ㄳ",
+            "T=ㅅ,ㅈ,ㅌ,ㄷ,ㅆ,ㅎ,ㅊ,ㄸ",
+            "P=ㅂ,ㅍ,ㅃ,ㅄ",
             "m=ㅁ",
             "n=ㄴ,ㄵ",
             "ng=ㅇ",
-            "l=ㄹ,ㄺ,ㄻ,ㄼ,ㄽ,ㄾ,ㄿ,ㅀ"
-        };
-
-        static readonly string[] nextExistLastConsonants = new string[] {
-            "k=ㅋ,ㄲ",
-            "t=ㅌ,ㄸ,ㅊ,ㅉ",
-            "p=ㅍ,ㅃ",
-            "ss=ㅆ"
-        };
-
-        static readonly string[] nextExistSpecialLastConsonants = new string[] {
-            "k=ㅋ,ㄲ",
-            "t=ㅌ,ㄸ,ㅊ,ㅉ",
-            "p=ㅍ,ㅃ",
-            "s=ㅆ"
-        };
-
-        static readonly string[] nextExistVCCLastconsonants = new string[] {
-            "k=ㄱ,ㄲ,ㄳ",
-            "ss=ㅌ",
-            "p=ㅂ,ㅄ,ㅍ"
-        };
-
-        static readonly string[] prevLastConsonantsExists = new string[] {
-            "n=ㄴ,ㄵ",
-            "m=ㅁ",
             "l=ㄹ,ㄺ,ㄻ,ㄼ,ㄽ,ㄾ,ㄿ,ㅀ",
-            "ng=ㅇ"
+            "-=　"
+        };
+
+        static readonly string[] vcLastConsonants = new string[] {
+            "k=ㄱ,ㅋ,ㄲ,ㄳ",
+            "t=ㅅ,ㅈ,ㅌ,ㄸ,ㅊ,ㅉ,ㄷ,ㅎ",
+            "p=ㅍ,ㅃ,ㅂ,ㅄ",
+            "m=ㅁ",
+            "n=ㄴ,ㄵ,ㄶ",
+            "ng=ㅇ",
+            "l=ㄹ,ㄺ,ㄻ,ㄼ,ㄽ,ㄾ,ㄿ,ㅀ",
+            "ss=ㅆ",
+        };
+
+        static readonly string[] vrcLastConsonants = new string[] {
+            "k=ㄱ,ㅋ,ㄲ,ㄳ",
+            "t=ㅅ,ㅈ,ㅌ,ㄸ,ㅊ,ㅉ,ㄷ,ㅎ,ㅆ",
+            "p=ㅍ,ㅃ,ㅂ,ㅄ",
+            "m=ㅁ",
+            "n=ㄴ,ㄵ,ㄶ",
+            "ng=ㅇ",
+            "l=ㄹ,ㄺ,ㄻ,ㄼ,ㄽ,ㄾ,ㄿ,ㅀ",
         };
 
         static readonly Dictionary<string, string> initialConsonantLookup;
+        static readonly Dictionary<string, string> ccvContinuousinitialConsonantsLookup;
+        static readonly Dictionary<string, string> vrcInitialConsonantLookup;
         static readonly Dictionary<string, string> vowelLookup;
         static readonly Dictionary<string, string> subsequentVowelLookup;
-        static readonly Dictionary<string, string> noNextLastConsonantsLookup;
-        static readonly Dictionary<string, string> nextExistLastLastConsonantsLookup;
-        static readonly Dictionary<string, string> nextExistSpecialLastConsonantsLookup;
-        static readonly Dictionary<string, string> nextExistSpecialCurrentLastConsonantsLookup;
-        static readonly Dictionary<string, string> prevLastConsonantsExistsLookup;
+        static readonly Dictionary<string, string> lastConsonantsLookup;
+        static readonly Dictionary<string, string> vcLastConsonantsLookup;
+        static readonly Dictionary<string, string> vrcLastConsonantsLookup;
 
 
         static KoreanCVCCVPhonemizer() {
             initialConsonantLookup = continuousinitialConsonants.ToList()
+                .SelectMany(line => {
+                    var parts = line.Split('=');
+                    return parts[1].Split(',').Select(cv => (cv, parts[0]));
+                })
+                .ToDictionary(t => t.Item1, t => t.Item2);
+            ccvContinuousinitialConsonantsLookup = ccvContinuousinitialConsonants.ToList()
+                .SelectMany(line => {
+                    var parts = line.Split('=');
+                    return parts[1].Split(',').Select(cv => (cv, parts[0]));
+                })
+                .ToDictionary(t => t.Item1, t => t.Item2);
+            vrcInitialConsonantLookup = vrcContinuousinitialConsonants.ToList()
                 .SelectMany(line => {
                     var parts = line.Split('=');
                     return parts[1].Split(',').Select(cv => (cv, parts[0]));
@@ -163,31 +248,19 @@ namespace OpenUtau.Plugin.Builtin {
                     return parts[1].Split(',').Select(cv => (cv, parts[0]));
                 })
                 .ToDictionary(t => t.Item1, t => t.Item2);
-            noNextLastConsonantsLookup = noNextLastConsonants.ToList()
+            lastConsonantsLookup = lastConsonants.ToList()
                 .SelectMany(line => {
                     var parts = line.Split('=');
                     return parts[1].Split(',').Select(cv => (cv, parts[0]));
                 })
                 .ToDictionary(t => t.Item1, t => t.Item2);
-            nextExistLastLastConsonantsLookup = nextExistLastConsonants.ToList()
+            vcLastConsonantsLookup = vcLastConsonants.ToList()
                 .SelectMany(line => {
                     var parts = line.Split('=');
                     return parts[1].Split(',').Select(cv => (cv, parts[0]));
                 })
                 .ToDictionary(t => t.Item1, t => t.Item2);
-            nextExistSpecialLastConsonantsLookup = nextExistSpecialLastConsonants.ToList()
-                .SelectMany(line => {
-                    var parts = line.Split('=');
-                    return parts[1].Split(',').Select(cv => (cv, parts[0]));
-                })
-                .ToDictionary(t => t.Item1, t => t.Item2);
-            nextExistSpecialCurrentLastConsonantsLookup = nextExistVCCLastconsonants.ToList()
-                .SelectMany(line => {
-                    var parts = line.Split('=');
-                    return parts[1].Split(',').Select(cv => (cv, parts[0]));
-                })
-                .ToDictionary(t => t.Item1, t => t.Item2);
-            prevLastConsonantsExistsLookup = prevLastConsonantsExists.ToList()
+            vrcLastConsonantsLookup = vrcLastConsonants.ToList()
                 .SelectMany(line => {
                     var parts = line.Split('=');
                     return parts[1].Split(',').Select(cv => (cv, parts[0]));
@@ -197,6 +270,7 @@ namespace OpenUtau.Plugin.Builtin {
 
         // Store singer in field, will try reading presamp.ini later
         private USinger singer;
+
         public override void SetSinger(USinger singer) => this.singer = singer;
         
         // Legacy mapping. Might adjust later to new mapping style.
@@ -217,189 +291,333 @@ namespace OpenUtau.Plugin.Builtin {
             var currentLyric = notes[0].lyric;
             currentKoreanLyrics = SeparateHangul(currentLyric != null ? currentLyric[0] : '\0');
 
+            if (currentLyric[0] >= '가' && currentLyric[0] <= '힣') {
 
-            // 글자 앞 부분
-            initialConsonantLookup.TryGetValue(currentKoreanLyrics[0].ToString(), out var currentInitialConsonants);
-            vowelLookup.TryGetValue(currentKoreanLyrics[1].ToString(), out var currentVowel);
-            if (prevLyric == null) {
+            } else {
+                return new Result {
+                    phonemes = new Phoneme[] {
+                        new Phoneme {
+                        phoneme = currentLyric,
+                    }
+                }};
+            }
+
+            if (prevLyric != null && prevLyric[0] >= '가' && prevLyric[0] <= '힣') {
+                // 앞글자 있음
+                prevKoreanLyrics = SeparateHangul(prevLyric[0]);
+
+                TYPE_FLAG type = typeTable[lastConsonantsTable.IndexOf(prevKoreanLyrics[2]), initialConsonantsTable.IndexOf(currentKoreanLyrics[0])];
+
+
+                initialConsonantLookup.TryGetValue(currentKoreanLyrics[0].ToString(), out var currentConsonants);
+                ccvContinuousinitialConsonantsLookup.TryGetValue(currentKoreanLyrics[0].ToString(), out var currentCCVConsonants);
+                vrcInitialConsonantLookup.TryGetValue(currentKoreanLyrics[0].ToString(), out var vrcInitialConsonants);
+                vowelLookup.TryGetValue(currentKoreanLyrics[1].ToString(), out var currentVowel);
+                lastConsonantsLookup.TryGetValue(prevKoreanLyrics[2].ToString(), out var prevLastConsonants);
+                subsequentVowelLookup.TryGetValue(currentKoreanLyrics[1].ToString(), out var currentSubsequentVowel);
+                subsequentVowelLookup.TryGetValue(prevKoreanLyrics[1].ToString(), out var prevSubsequentVowel);
+                initialConsonantLookup.TryGetValue(prevKoreanLyrics[2].ToString(), out var prevInitialConsonants);
+
+                switch (type) {
+                    case TYPE_FLAG.VCC_CV:
+                        phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"{currentConsonants}{currentVowel}",
+                                }
+                            );
+                        break;
+
+                    case TYPE_FLAG.VCC_CV_ADDED_Y:
+                        phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"ss{currentVowel}",
+                                }
+                            );
+                        break;
+
+                    case TYPE_FLAG.VC_CCV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{prevLastConsonants} {currentCCVConsonants}{currentVowel}",
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VC_CCV_ADDED_Y:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentCCVConsonants}{currentVowel}",
+                            }
+                        );
+                                                
+                        break;
+
+                    case TYPE_FLAG.VC_NCV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"- {currentCCVConsonants}{currentVowel}",
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VC_NRCV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"- {prevInitialConsonants}{currentVowel}",
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VC_CV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentConsonants}{currentVowel}",
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VRC_CV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentConsonants}{currentVowel}",
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VRC_NCV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"- {vrcInitialConsonants}{currentVowel}",
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VC_CV_ADDED_Y:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentConsonants}{currentVowel}",
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VC_RCV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{prevInitialConsonants}{currentVowel}",
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG._VCV:
+
+                        phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"{prevSubsequentVowel} {currentConsonants}{currentVowel}",
+                                }
+                            );
+
+                        break;
+
+                    case TYPE_FLAG.CV:
+                        phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"{prevSubsequentVowel} {prevInitialConsonants}{currentVowel}",
+                                }
+                            );
+
+                        break;
+                }
+
+            } else {
+                // 앞글자 없음
+
+                initialConsonantLookup.TryGetValue(currentKoreanLyrics[0].ToString(), out var currentConsonants);
+                vowelLookup.TryGetValue(currentKoreanLyrics[1].ToString(), out var currentVowel);
 
                 phonemesArr.Add(
                     new Phoneme {
-                        phoneme = $"- {currentInitialConsonants}{currentVowel}",
+                        phoneme = $"- {currentConsonants}{currentVowel}",
                     }
                 );
-            } else {
-                if (prevLyric[0] >= '가' && prevLyric[0] <= '힣') {
-                    prevKoreanLyrics = SeparateHangul(prevLyric != null ? prevLyric[0] : '\0');
-                }
-
-                if (continuousinitialConsonantsTable.Contains(currentKoreanLyrics[0].ToString())) {
-                    if(lastConsonantsTable.Contains(prevKoreanLyrics[2]) && prevKoreanLyrics[2] != '　') {
-                        // 이전 글자에서 받침이 있음
-
-                        if (prevKoreanLyrics[2] == 'ㄹ' && currentKoreanLyrics[0] == 'ㄹ') {
-                            phonemesArr.Add(
-                                new Phoneme {
-                                    phoneme = $"{"l"} {"l"}{currentVowel}",
-                                }
-                            );
-                        } else if(vccSubInitialConsonantsTable.Contains(prevKoreanLyrics[2])) {
-                            // 받침 ㄱㅂ 뒤에 ㅅ ㅆ있으면 VCC(3) 조건
-                            if (vcc2LastConsonantsTable.Contains(prevKoreanLyrics[2]) && (currentKoreanLyrics[0] == 'ㅆ')) {
-                                phonemesArr.Add(
-                                    new Phoneme {
-                                        phoneme = $"{currentInitialConsonants}{currentVowel}",
-                                    }
-                                );
-                            } else {
-                                phonemesArr.Add(
-                                    new Phoneme {
-                                        phoneme = $"- {currentInitialConsonants}{currentVowel}",
-                                    }
-                                );
-                            }
-                        } else if (vccLastConsonantsTable.Contains(prevKoreanLyrics[2])) {
-                        prevLastConsonantsExistsLookup.TryGetValue(prevKoreanLyrics[2].ToString(), out var prevLastConsonants);
-                        phonemesArr.Add(
-                            new Phoneme {
-                                phoneme = $"{prevLastConsonants} {currentInitialConsonants}{currentVowel}",
-                            }
-                        ); 
-                        } else {
-                            phonemesArr.Add(
-                                new Phoneme {
-                                    phoneme = $"{currentInitialConsonants}{currentVowel}",
-                                }
-                            );
-                        }
-
-                    } else {
-                        // ㄱ ㄴ ㄷ ㄹ ㅁ ㅂ ㅅ ㅇ ㅈ ㅎ은 연속음으로 진행(1) 조건
-
-                        subsequentVowelLookup.TryGetValue(prevKoreanLyrics[1].ToString(), out var prevSubsequentVowel);
-                        phonemesArr.Add(
-                            new Phoneme {
-                                phoneme = $"{prevSubsequentVowel} {currentInitialConsonants}{currentVowel}",
-                            }
-                        );
-                    }
-                } else {
-                    // ㅋ ㅌ ㅍ ㅊ ㄲ ㄸ ㅃ ㅉ ㅆ는 CVVC로 진행(2) 조건
-                    if (cvvcInitialConsonantsTable.Contains(currentKoreanLyrics[0])) {
-                        phonemesArr.Add(
-                            new Phoneme {
-                                phoneme = $"{currentInitialConsonants}{currentVowel}",
-                            }
-                        );
-                    } else {
-                        subsequentVowelLookup.TryGetValue(prevKoreanLyrics[1].ToString(), out var prevSubsequentVowel);
-                        phonemesArr.Add(
-                            new Phoneme {
-                                phoneme = $"{prevSubsequentVowel} {currentInitialConsonants}{currentVowel}",
-                            }
-                        );
-                    }
-                }
             }
 
-            // 글자 뒷 부분
-            subsequentVowelLookup.TryGetValue(currentKoreanLyrics[1].ToString(), out var currentSubsequentVowel);
-            if (nextLyric == null) {
-                // 다음 글자 없음
-                if (currentKoreanLyrics[2] == '　') {
-                    // 현재 글자 종성 없음
+            if (nextLyric != null && nextLyric[0] >= '가' && nextLyric[0] <= '힣') {
+                // 뒷글자 있음
+                nextKoreanLyrics = SeparateHangul(nextLyric[0]);
 
-                    phonemesArr.Add(
-                        new Phoneme {
-                            phoneme = $"{currentSubsequentVowel} {(currentLyric.Length == 2 ? currentLyric[1].ToString() : "-")}",
-                            position = totalDuration - 15,
-                        }
-                    );
-                } else {
-                    // 현재 글자 종성 있음
-                    noNextLastConsonantsLookup.TryGetValue(currentKoreanLyrics[2].ToString(), out var currentLastConsonants);
+                TYPE_FLAG type = typeTable[lastConsonantsTable.IndexOf(currentKoreanLyrics[2]), initialConsonantsTable.IndexOf(nextKoreanLyrics[0])];
 
-                    if (vccLastConsonantsTable.Contains(currentKoreanLyrics[2])) {
-                        // 받침 ㄴ ㅇ ㄹ ㅁ 뒤에 ㅋ ㅌ ㅍ ㅊ ㄲ ㄸ ㅃ ㅉ ㅆ오면 VCC(3) 조건
+                initialConsonantLookup.TryGetValue(nextKoreanLyrics[0].ToString(), out var nextConsonants);
+                vcLastConsonantsLookup.TryGetValue(nextKoreanLyrics[0].ToString(), out var nextVCCConsonants);
+                vrcLastConsonantsLookup.TryGetValue(nextKoreanLyrics[0].ToString(), out var nextVRCConsonants);
+                subsequentVowelLookup.TryGetValue(currentKoreanLyrics[1].ToString(), out var currentSubsequentVowel);
+                lastConsonantsLookup.TryGetValue(currentKoreanLyrics[2].ToString(), out var currentLastConsonants);
+                vcLastConsonantsLookup.TryGetValue(currentKoreanLyrics[2].ToString(), out var currentVCLastConsonants);
 
+
+                switch (type) {
+                    case TYPE_FLAG.VCC_CV:
                         phonemesArr.Add(
-                            new Phoneme {
-                                phoneme = $"{currentSubsequentVowel}{currentLastConsonants} {(currentLyric.Length == 2 ? currentLyric[1].ToString() : "-")}",
-                                position = totalDuration - 15,
-                            }
-                        );
-                    } else {
+                                new Phoneme {
+                                    phoneme = $"{currentSubsequentVowel}{currentLastConsonants} {nextVCCConsonants}",
+                                    position = totalDuration - Math.Min(totalDuration / 3, 120)
+                                }
+                            );
 
-                        phonemesArr.Add(
-                            new Phoneme {
-                                phoneme = $"{currentSubsequentVowel} {currentLastConsonants}",
-                                position = totalDuration - vcLength,
-                            }
-                        );
-                    }
-                }
+                        break;
 
-            } else {
-                // 다음 글자 있음
-                if (nextLyric[0] >= '가' && nextLyric[0] <= '힣') {
-                    nextKoreanLyrics = SeparateHangul(nextLyric != null ? nextLyric[0] : '\0');
-                }
-
-                if (currentKoreanLyrics[2] == '　') {
-                    // 현재 글자 종성 없음
-                    // ㅋ ㅌ ㅍ ㅊ ㄲ ㄸ ㅃ ㅉ ㅆ는 CVVC로 진행(2) 조건
-                    if(cvvcInitialConsonantsTable.Contains(nextKoreanLyrics[0])) {
-                        nextExistLastLastConsonantsLookup.TryGetValue(nextKoreanLyrics[0].ToString(), out var currentLastConsonants);
-
-                        phonemesArr.Add(
-                            new Phoneme {
-                                phoneme = $"{currentSubsequentVowel} {currentLastConsonants}",
-                                position = totalDuration - vcLength,
-                            }
-                        );
-                    }
-                } else {
-                    // 현재 글자 종성 있음
-                    if (vccLastConsonantsTable.Contains(currentKoreanLyrics[2]) && cvvcInitialConsonantsTable.Contains(nextKoreanLyrics[0])) {
-                        // 받침 ㄴ ㅇ ㄹ ㅁ 뒤에 ㅋ ㅌ ㅍ ㅊ ㄲ ㄸ ㅃ ㅉ ㅆ오면 VCC(3) 조건
-                        nextExistSpecialLastConsonantsLookup.TryGetValue(nextKoreanLyrics[0].ToString(), out var currentLastConsonants);
-                        prevLastConsonantsExistsLookup.TryGetValue(currentKoreanLyrics[2].ToString(), out var currentSpecialLastConsonants);
-                        phonemesArr.Add(
-                            new Phoneme {
-                                phoneme = $"{currentSubsequentVowel}{currentSpecialLastConsonants} {currentLastConsonants}",
-                                position = totalDuration - vcLength,
-                            }
-                        );
-                    } else if (vcc2LastConsonantsTable.Contains(currentKoreanLyrics[2]) && vcc2SubInitialConsonantsTable.Contains(nextKoreanLyrics[0])) {
-                        // 받침 ㄱㅂ 뒤에 ㅅ ㅆ있으면 VCC(4) 조건
-                        nextExistSpecialCurrentLastConsonantsLookup.TryGetValue(currentKoreanLyrics[2].ToString(), out var currentLastConsonants);
-
-                        if (currentKoreanLyrics[2] == 'ㅆ') {
+                    case TYPE_FLAG.VCC_CV_ADDED_Y:
+                        if (YVowelsTable.IndexOf(nextKoreanLyrics[1]) > 0) {
                             phonemesArr.Add(
                                 new Phoneme {
-                                    phoneme = $"{currentSubsequentVowel} {"ss"}",
-                                    position = totalDuration - vcLength,
+                                    phoneme = $"{currentSubsequentVowel}{currentVCLastConsonants} sy",
+                                    position = totalDuration - Math.Min(totalDuration / 3, 120)
                                 }
                             );
                         } else {
                             phonemesArr.Add(
                                 new Phoneme {
-                                    phoneme = $"{currentSubsequentVowel}{currentLastConsonants} {"s"}",
-                                    position = totalDuration - vcLength,
+                                    phoneme = $"{currentSubsequentVowel}{currentVCLastConsonants} s",
+                                    position = totalDuration - Math.Min(totalDuration / 3, 120)
                                 }
                             );
                         }
                         
-                    } else {
-                        noNextLastConsonantsLookup.TryGetValue(currentKoreanLyrics[2].ToString(), out var currentLastConsonants);
+                        break;
+
+                    case TYPE_FLAG.VC_CCV:
+                        phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"{currentSubsequentVowel} {currentVCLastConsonants}",
+                                    position = totalDuration - Math.Min(totalDuration / 3, 120)
+                                }
+                            );
+
+                        break;
+
+                    case TYPE_FLAG.VC_CCV_ADDED_Y:
+                        if (YVowelsTable.IndexOf(nextKoreanLyrics[1]) > 0) {
+                            phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"{currentSubsequentVowel} {nextConsonants}y",
+                                    position = totalDuration - Math.Min(totalDuration / 3, 120)
+                                }
+                            );
+                        } else {
+                            phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"{currentSubsequentVowel} {currentVCLastConsonants}",
+                                    position = totalDuration - Math.Min(totalDuration / 3, 120)
+                                }
+                            );
+                        }
+
+                        break;
+
+                    case TYPE_FLAG.VC_NCV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentSubsequentVowel} {currentVCLastConsonants}",
+                                position = totalDuration - Math.Min(totalDuration / 3, 120)
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VC_NRCV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentSubsequentVowel} {currentVCLastConsonants}",
+                                position = totalDuration - Math.Min(totalDuration / 3, 120)
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VRC_NCV:
                         phonemesArr.Add(
                             new Phoneme {
                                 phoneme = $"{currentSubsequentVowel} {currentLastConsonants}",
-                                position = totalDuration - vcLength,
+                                position = totalDuration - Math.Min(totalDuration / 3, 120)
                             }
                         );
+
+                        break;
+
+                    case TYPE_FLAG.VC_CV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentSubsequentVowel} {currentVCLastConsonants}",
+                                position = totalDuration - Math.Min(totalDuration / 3, 120)
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VRC_CV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentSubsequentVowel} {nextVRCConsonants}",
+                                position = totalDuration - Math.Min(totalDuration / 4, 100)
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.VC_CV_ADDED_Y:
+                        if (YVowelsTable.IndexOf(nextKoreanLyrics[1]) > 0) {
+                            phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"{currentSubsequentVowel} {nextVCCConsonants}y",
+                                    position = totalDuration - Math.Min(totalDuration / 3, 120)
+                                }
+                            );
+                        } else {
+                            phonemesArr.Add(
+                                new Phoneme {
+                                    phoneme = $"{currentSubsequentVowel} {nextVCCConsonants}",
+                                    position = totalDuration - Math.Min(totalDuration / 3, 120)
+                                }
+                            );
+                        }
+
+                        break;
+
+                    case TYPE_FLAG.VC_RCV:
+                        phonemesArr.Add(
+                            new Phoneme {
+                                phoneme = $"{currentSubsequentVowel} {currentVCLastConsonants}",
+                                position = totalDuration - Math.Min(totalDuration / 3, 120)
+                            }
+                        );
+
+                        break;
+
+                    case TYPE_FLAG.CV:
+
+                        break;
+                };
+
+            } else {
+                // 뒷글자 없음
+                subsequentVowelLookup.TryGetValue(currentKoreanLyrics[1].ToString(), out var currentSubsequentVowel);
+                lastConsonantsLookup.TryGetValue(currentKoreanLyrics[2].ToString(), out var currentLastConsonants);
+
+                phonemesArr.Add(
+                    new Phoneme {
+                        phoneme = $"{currentSubsequentVowel} {currentLastConsonants}",
+                        position = totalDuration - 60
                     }
-                }
+                );
+
             }
 
             // 여기서 phonemes 바꿔줘야함

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -2,11 +2,11 @@
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-  <!--<system:String x:Key="context.note.copy">Copy note</system:String>-->
+  <system:String x:Key="context.note.copy">노트 복사</system:String>
   <system:String x:Key="context.note.delete">노트 삭제</system:String>
   <system:String x:Key="context.part.delete">파트 삭제</system:String>
   <system:String x:Key="context.part.rename">파트 이름 변경</system:String>
-  <!--<system:String x:Key="context.part.replaceaudio">Reselect audio file</system:String>-->
+  <system:String x:Key="context.part.replaceaudio">오디오 파일 재선택</system:String>
   <system:String x:Key="context.pitch.easein">시작 감속 곡선</system:String>
   <system:String x:Key="context.pitch.easeinout">시작/끝 감속 곡선</system:String>
   <system:String x:Key="context.pitch.easeout">끝 감속 곡선</system:String>
@@ -80,10 +80,10 @@
   <system:String x:Key="menu.edit.undo">실행 취소</system:String>
   <system:String x:Key="menu.file">파일</system:String>
   <system:String x:Key="menu.file.exit">나가기</system:String>
-  <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
-  <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
-  <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
-  <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->
+  <system:String x:Key="menu.file.exportaudio">오디오 내보내기</system:String>
+  <system:String x:Key="menu.file.exportmidi">Midi 내보내기</system:String>
+  <system:String x:Key="menu.file.exportmixdown">Wav 파일로 믹스다운</system:String>
+  <system:String x:Key="menu.file.exportproject">프로젝트 내보내기</system:String>
   <system:String x:Key="menu.file.exportust">Ust 파일 내보내기</system:String>
   <system:String x:Key="menu.file.exportustto">다른 이름으로 Ust 파일 내보내기</system:String>
   <system:String x:Key="menu.file.exportwav">Wav 파일 내보내기</system:String>
@@ -185,8 +185,8 @@
   <system:String x:Key="pianoroll.menu.notes.addtailrest">"R" 꼬리 추가</system:String>
   <system:String x:Key="pianoroll.menu.notes.clear.vibratos">비브라토 지우기</system:String>
   <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">렌더링 된 피치 로드</system:String>
-  <!--<system:String x:Key="pianoroll.menu.notes.octavedown">Move an octave down</system:String>-->
-  <!--<system:String x:Key="pianoroll.menu.notes.octaveup">Move an octave up</system:String>-->
+  <system:String x:Key="pianoroll.menu.notes.octavedown">옥타브를 아래로 내리기</system:String>
+  <system:String x:Key="pianoroll.menu.notes.octaveup">옥타브를 위로 올리기</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize15">1/128로 양자화</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize30">1/64로 양자화</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.exps">모든 표현 초기화</system:String>
@@ -224,7 +224,7 @@
   <system:String x:Key="prefs.advanced.resamplerlogging">리샘플러 로그</system:String>
   <system:String x:Key="prefs.advanced.resamplerlogging.warn">리샘플러 출력을 로그 파일에 저장합니다. 이 옵션을 사용하면 UI 및 렌더링 속도가 느려집니다.</system:String>
   <system:String x:Key="prefs.advanced.stable">안정된 버전</system:String>
-  <!--<system:String x:Key="prefs.advanced.vlabelerpath">Vlabeler Path</system:String>-->
+  <system:String x:Key="prefs.advanced.vlabelerpath">Vlabeler 경로</system:String>
   <system:String x:Key="prefs.appearance">외형</system:String>
   <system:String x:Key="prefs.appearance.lang">언어</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">피아노 롤에 다른 트랙의 노트 표시</system:String>
@@ -236,8 +236,8 @@
   <system:String x:Key="prefs.note.restart">참고: OpenUtau를 재시작해야 해당 항목이 적용됩니다.</system:String>
   <system:String x:Key="prefs.off">끔</system:String>
   <system:String x:Key="prefs.on">켬</system:String>
-  <!--<system:String x:Key="prefs.otoeditor">Oto Editor</system:String>-->
-  <!--<system:String x:Key="prefs.otoeditor.select">Default Oto Editor</system:String>-->
+  <system:String x:Key="prefs.otoeditor">원음 설정 에디터</system:String>
+  <system:String x:Key="prefs.otoeditor.select">기본 원음 설정 에디터</system:String>
   <system:String x:Key="prefs.paths">경로</system:String>
   <system:String x:Key="prefs.paths.addlsinger">추가적인 가수 폴더 경로</system:String>
   <system:String x:Key="prefs.paths.addlsinger.install">추가적인 가수 폴더 경로 설치</system:String>
@@ -270,24 +270,24 @@
   <system:String x:Key="prefs.rendering.resampler.note">
         참고 : 외부 엔진을 사용하려면, OpenUtau 설치 경로의 Resamplers 폴더에 엔진 DLL 또는 EXE 파일을 추가하고 환경 설정에서 선택하세요.
     </system:String>
-  <!--<system:String x:Key="prefs.rendering.threads.cpuwarn">
-    Warning: too many render threads may cause OpenUtau to run slowly.
-  </system:String>-->
-  <!--<system:String x:Key="prefs.rendering.threads.numthreads">Maximum Render Threads</system:String>-->
+  <system:String x:Key="prefs.rendering.threads.cpuwarn">
+    주의: 렌더 스레드가 많으면 OpenUtau가 느려질 수 있습니다.
+  </system:String>
+  <system:String x:Key="prefs.rendering.threads.numthreads">최대 렌더 스레드</system:String>
   <!--<system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>-->
 
   <system:String x:Key="progress.saved">프로젝트 저장됨. {0}</system:String>
   <system:String x:Key="progress.waitingrendering">렌더링 대기 중</system:String>
 
   <system:String x:Key="singers.caption">가수</system:String>
-  <!--<system:String x:Key="singers.editoto.editinvlabeler">Edit In vLabeler</system:String>-->
+  <system:String x:Key="singers.editoto.editinvlabeler">vLabeler에서 수정하기</system:String>
   <system:String x:Key="singers.editoto.gotosource">소스파일 열기</system:String>
-  <!--<system:String x:Key="singers.editoto.regenfrq">Regenerate FRQ</system:String>-->
-  <!--<system:String x:Key="singers.editoto.regenfrq.regenerating">Regenerating FRQ</system:String>-->
+  <system:String x:Key="singers.editoto.regenfrq">FRQ 재생성</system:String>
+  <system:String x:Key="singers.editoto.regenfrq.regenerating">FRQ를 재생성 하는 중</system:String>
   <system:String x:Key="singers.editoto.reset">Oto 초기화</system:String>
   <system:String x:Key="singers.editoto.save">Oto 저장</system:String>
-  <!--<system:String x:Key="singers.editoto.setvlabelerpath">Download vLabeler (1.0.0-beta1 or higher) from https://github.com/sdercolin/vlabeler and set vLabeler path in Preferences first!</system:String>-->
-  <!--<system:String x:Key="singers.errorreport">Generate Singer Error Report</system:String>-->
+  <system:String x:Key="singers.editoto.setvlabelerpath">https://github.com/sdercolin/vlabeler 에서 vLabeler(1.0.0-beta1 이상)를 다운로드 할 수 있습니다. 그리고 설정에서 vLabeler 경로를 지정해주세요.</system:String>
+  <system:String x:Key="singers.errorreport">가수 오류보고 생성</system:String>
   <system:String x:Key="singers.location">위치</system:String>
   <system:String x:Key="singers.otoview.moveleft">왼쪽으로 이동</system:String>
   <system:String x:Key="singers.otoview.moveright">오른쪽으로 이동</system:String>
@@ -364,5 +364,5 @@
 
   <system:String x:Key="warning">경고</system:String>
   <system:String x:Key="warning.asciipath">OpenUtau 홈 경로 "{0}"에 ASCII가 아닌 문자가 포함되어 있습니다. EXE 엔진이 작동하지 않을 수 있습니다.</system:String>
-  <!--<system:String x:Key="warning.renderer">No settings for this renderer.</system:String>-->
+  <system:String x:Key="warning.renderer">이 렌더러에 대한 설정이 없습니다.</system:String>
 </ResourceDictionary>


### PR DESCRIPTION
* Responding so that it can be used even when aliases other than Hangul, which had not previously worked, are placed before and after.
* Improving the structure that was difficult to modify the aliases of the interconsonant combination
* Added korean translation

* 이전에는 동작하지 않았던 한글 이외의 앨리어스가 전후로 배치된 경우에도 모두 사용할 수 있도록 대응
* 자음간의 상호 조합을 수정하기 어렵던 문제를 수정
* 한국어 번역 추가