### PR TITLE
Disable exceptions in error box on release build

### DIFF
--- a/OpenUtau/Views/MessageBox.axaml.cs
+++ b/OpenUtau/Views/MessageBox.axaml.cs
@@ -42,12 +42,16 @@ namespace OpenUtau.App.Views {
                 if (e is AggregateException ae) {
                     ae = ae.Flatten();
                     builder.AppendLine(ae.InnerExceptions.First().Message);
+#if DEBUG
                     builder.AppendLine();
                     builder.Append(ae.ToString());
+#endif
                 } else {
                     builder.AppendLine(e.Message);
+#if DEBUG
                     builder.AppendLine();
                     builder.Append(e.ToString());
+#endif
                 }
             }
             builder.AppendLine();


### PR DESCRIPTION
Tiny fix... Error messages currently offer too much detail, due to printing the stack trace into the message box. Users can't use any of this information to fix the errors besides the exception message. Added debug flags to the error box code so the release version won't show a stack trace.