### PR TITLE
fix "-," string in loading yaml files

### DIFF
--- a/OpenUtau.Core/OpenUtau.Core.csproj
+++ b/OpenUtau.Core/OpenUtau.Core.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="TinyPinyin.Net" Version="1.0.2" />
     <PackageReference Include="UTF.Unknown" Version="2.5.1" />
     <PackageReference Include="WanaKana-net" Version="1.0.0" />
-    <PackageReference Include="YamlDotNet" Version="12.0.1" />
+    <PackageReference Include="YamlDotNet" Version="12.3.1" />
     <PackageReference Include="NetMQ" Version="4.0.1.9" />
   </ItemGroup>
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/OpenUtau.Test/Core/USTx/UstxYamlTest.cs
+++ b/OpenUtau.Test/Core/USTx/UstxYamlTest.cs
@@ -80,6 +80,10 @@ phoneme_overrides: []
             yaml = Yaml.DefaultSerializer.Serialize(new UNote() { lyric = "true" });
             actual = Yaml.DefaultDeserializer.Deserialize<UNote>(yaml);
             Assert.Equal("true", actual.lyric);
+
+            yaml = Yaml.DefaultSerializer.Serialize(new UNote() { lyric = "-," });
+            actual = Yaml.DefaultDeserializer.Deserialize<UNote>(yaml);
+            Assert.Equal("-,", actual.lyric);
         }
     }
 }


### PR DESCRIPTION
Fixing a bug similar to https://github.com/stakira/OpenUtau/pull/576 . Input `-,` as lyric and save as an ustx file. OpenUtau will fail to load this file and says, "Invalid key indicator format".
* Updating YamlDotNet to 12.3.1
* "-," serializing and deserializing is added to test.