### PR TITLE
Let renderers provide expression suggestions

### DIFF
--- a/OpenUtau.Core/Classic/ClassicRenderer.cs
+++ b/OpenUtau.Core/Classic/ClassicRenderer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NAudio.Wave;
@@ -132,6 +133,26 @@ namespace OpenUtau.Classic {
             return null;
         }
 
+        public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {
+            var resamplerPath = renderSettings.Resampler.FilePath;
+            if (resamplerPath == null) {
+                return new UExpressionDescriptor[] { };
+            }
+            var resamplerManifestPath = Path.ChangeExtension(resamplerPath, ".yaml");
+            try {
+                return Yaml.DefaultDeserializer.Deserialize<ResamplerManifest>(
+                    File.ReadAllText(resamplerManifestPath, encoding:Encoding.UTF8)
+                    ).expressions.Values.ToArray();
+            } catch (Exception ex) {
+                Log.Error($"Failed loading suggested expressions from {resamplerManifestPath}: {ex}");
+            }
+            return new UExpressionDescriptor[] { };
+        }
+
         public override string ToString() => Renderers.CLASSIC;
+    }
+
+    public class ResamplerManifest {
+        public Dictionary<string,UExpressionDescriptor> expressions = new Dictionary<string, UExpressionDescriptor> { };
     }
 }

--- a/OpenUtau.Core/Classic/WorldlineRenderer.cs
+++ b/OpenUtau.Core/Classic/WorldlineRenderer.cs
@@ -123,6 +123,10 @@ namespace OpenUtau.Classic {
             return null;
         }
 
+        public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {
+            return new UExpressionDescriptor[] { };
+        }
+
         public override string ToString() => Renderers.WORLDLINER;
     }
 }

--- a/OpenUtau.Core/Enunu/EnunuRenderer.cs
+++ b/OpenUtau.Core/Enunu/EnunuRenderer.cs
@@ -228,6 +228,10 @@ namespace OpenUtau.Core.Enunu {
             return notes.ToArray();
         }
 
+        public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {
+            return new UExpressionDescriptor[] { };
+        }
+
         public override string ToString() => Renderers.ENUNU;
     }
 }

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -44,5 +44,6 @@ namespace OpenUtau.Core.Render {
         RenderResult Layout(RenderPhrase phrase);
         Task<RenderResult> Render(RenderPhrase phrase, Progress progress, CancellationTokenSource cancellation, bool isPreRender = false);
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase);
+        UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings);
     }
 }

--- a/OpenUtau.Core/Vogen/VogenRenderer.cs
+++ b/OpenUtau.Core/Vogen/VogenRenderer.cs
@@ -227,6 +227,10 @@ namespace OpenUtau.Core.Vogen {
             return result;
         }
 
+        public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {
+            return new UExpressionDescriptor[] { };
+        }
+
         public override string ToString() => Renderers.VOGEN;
     }
 }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -50,7 +50,7 @@
   <system:String x:Key="exps.caption">Expressions</system:String>
   <system:String x:Key="exps.defaultvalue">Default</system:String>
   <system:String x:Key="exps.flag">Resampler Flag</system:String>
-  <system:String x:Key="exps.getsuggestions">Get Suggestions</system:String>
+  <system:String x:Key="exps.getsuggestions">Add all expressions suggested by renderers</system:String>
   <system:String x:Key="exps.isflag">Is Resampler Flag</system:String>
   <system:String x:Key="exps.maxvalue">Max</system:String>
   <system:String x:Key="exps.minvalue">Min</system:String>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -50,6 +50,7 @@
   <system:String x:Key="exps.caption">Expressions</system:String>
   <system:String x:Key="exps.defaultvalue">Default</system:String>
   <system:String x:Key="exps.flag">Resampler Flag</system:String>
+  <system:String x:Key="exps.getsuggestions">Get Suggestions</system:String>
   <system:String x:Key="exps.isflag">Is Resampler Flag</system:String>
   <system:String x:Key="exps.maxvalue">Max</system:String>
   <system:String x:Key="exps.minvalue">Min</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -50,6 +50,7 @@
   <system:String x:Key="exps.caption">表情</system:String>
   <system:String x:Key="exps.defaultvalue">默认值</system:String>
   <system:String x:Key="exps.flag">重采样器flag</system:String>
+  <system:String x:Key="exps.getsuggestions">获取渲染器建议的表情</system:String>
   <system:String x:Key="exps.isflag">是否重采样器flag</system:String>
   <system:String x:Key="exps.maxvalue">最大值</system:String>
   <system:String x:Key="exps.minvalue">最小值</system:String>

--- a/OpenUtau/ViewModels/ExpressionsViewModel.cs
+++ b/OpenUtau/ViewModels/ExpressionsViewModel.cs
@@ -163,5 +163,23 @@ namespace OpenUtau.App.ViewModels {
                 expressionsSource.Remove(Expression);
             }
         }
+
+        public void GetSuggestions() {
+            foreach (var track in DocManager.Inst.Project.tracks) {
+                if (track.RendererSettings.Renderer == null) {
+                    continue;
+                }
+                var suggestions = track.RendererSettings.Renderer.GetSuggestedExpressions(track.Singer, track.RendererSettings);
+                if (suggestions == null) {
+                    continue;
+                }
+                foreach (var suggestion in suggestions) {
+                    //Add if not already in the list
+                    if (!expressionsSource.Any(builder => builder.Abbr == suggestion.abbr)) {
+                        expressionsSource.Add(new ExpressionBuilder(suggestion));
+                    }
+                }
+            }
+        }
     }
 }

--- a/OpenUtau/Views/ExpressionsDialog.axaml
+++ b/OpenUtau/Views/ExpressionsDialog.axaml
@@ -78,7 +78,11 @@
         <TextBlock Margin="140,24,0,4" Text="{DynamicResource exps.sepbycomma}"/>
       </Grid>
     </StackPanel>
-    <Button Margin="10" Width="80" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
+      <Button Margin="10" HorizontalAlignment="Right" VerticalAlignment="Bottom"
+            Content="{DynamicResource exps.getsuggestions}" Command="{Binding GetSuggestions}"/>
+      <Button Margin="10" Width="80" HorizontalAlignment="Right" VerticalAlignment="Bottom"
             Content="{DynamicResource exps.apply}" Click="ApplyButtonClicked"/>
+    </StackPanel>
   </Grid>
 </Window>


### PR DESCRIPTION
This is a developer-side feature for renderer developers to dynamically suggest expressions based on current singer and resampler settings. An example of this feature is implemented in CLASSIC renderer that reads expressions from a resampler manifest file located in the same folder with the resampler. 

<img width="453" alt="image" src="https://user-images.githubusercontent.com/54425948/219908027-853aa9a9-df76-4571-9a8a-534823fc4313.png">

Todos:

- ship some common resamplers' manifest files with openutau builds (editable by users and not being reseted on updates)
- support ENUNU flags (I don't know how ENUNU flag system works)
- remove resampler.exe specific flags from new project creation, because some users may never use resampler.exe