### PR TITLE
String sort localization / 字符串排序本地化

### DIFF
--- a/OpenUtau.Core/SingerManager.cs
+++ b/OpenUtau.Core/SingerManager.cs
@@ -34,7 +34,7 @@ namespace OpenUtau.Core {
                     .ToDictionary(g => g.Key, g => g.First());
                 SingerGroups = singers
                     .GroupBy(s => s.SingerType)
-                    .ToDictionary(s => s.Key, s => s.OrderBy(singer => singer.Name).ToList());
+                    .ToDictionary(s => s.Key, s => s.LocalizedOrderBy(singer => singer.Name).ToList());
                 stopWatch.Stop();
                 Log.Information($"Search all singers: {stopWatch.Elapsed}");
             } catch (Exception e) {

--- a/OpenUtau.Core/Util/LocalizedSort.cs
+++ b/OpenUtau.Core/Util/LocalizedSort.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace OpenUtau.Core.Util {
+
+    public class LocalizedComparer : IComparer<string> {
+        CultureInfo cultureInfo;
+        public LocalizedComparer(CultureInfo cultureInfo) {
+            this.cultureInfo = cultureInfo;
+        }
+
+        public int Compare(string x, string y) {
+            return cultureInfo.CompareInfo.Compare(x, y);
+        }
+    }
+    public static class LocalizedSort {
+        public static IEnumerable<T> LocalizedOrderBy<T>(this IEnumerable<T> source, Func<T, string> selector) {
+            var sortingOrder = Preferences.Default.SortingOrder;
+            if(sortingOrder == String.Empty) {
+                sortingOrder = Preferences.Default.Language;
+            }
+            var comparer = new LocalizedComparer(CultureInfo.GetCultureInfo(sortingOrder));
+            return source.OrderBy(selector, comparer);
+        }
+    }
+}

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -87,6 +87,7 @@ namespace OpenUtau.Core.Util {
             public bool PreRender = true;
             public int NumRenderThreads = 2;
             public string Language = string.Empty;
+            public string SortingOrder = string.Empty;
             public List<string> RecentFiles = new List<string>();
             public string SkipUpdate = string.Empty;
             public string AdditionalSingerPath = string.Empty;

--- a/OpenUtau.Plugin.Builtin/ENDeltaVer2Phonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaVer2Phonemizer.cs
@@ -63,31 +63,24 @@ namespace OpenUtau.Plugin.Builtin
             return new G2pFallbacks(g2ps.ToArray());
         }
 
-        protected override string[] GetSymbols(Note note)
-        {
+        protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
-            if (original == null)
-            {
+            if (original == null) {
                 return null;
             }
             List<string> modified = new List<string>();
             string[] diphthongs = new[] { "aI", "eI", "OI", "aU", "oU" };
-            foreach (string s in original)
-            {
-                if (diphthongs.Contains(s))
-                {
+            foreach (string s in original) {
+                if (diphthongs.Contains(s)) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
-                }
-                else
-                {
+                } else {
                     modified.Add(s);
                 }
             }
             return modified.ToArray();
         }
 
-        protected override List<string> ProcessSyllable(Syllable syllable)
-        {
+        protected override List<string> ProcessSyllable(Syllable syllable) {
             string prevV = syllable.prevV;
             string[] cc = syllable.cc;
             string v = syllable.v;
@@ -100,63 +93,26 @@ namespace OpenUtau.Plugin.Builtin
             if (syllable.IsStartingV) {
                 if (HasOto(rv, syllable.vowelTone)) {
                     basePhoneme = rv;
-                    if (rv.Contains("V") && !HasOto(rv, syllable.vowelTone) && HasOto($"- A", syllable.vowelTone)) {
-                        basePhoneme = $"- A";
-                    } else if (rv.Contains("E") && !HasOto(rv, syllable.vowelTone) && HasOto($"- e", syllable.vowelTone)) {
-                        basePhoneme = $"- e";
-                    } else if (rv.Contains("I") && !HasOto(rv, syllable.vowelTone) && HasOto($"- i", syllable.vowelTone)) {
-                        basePhoneme = $"- i";
-                    } else if (rv.Contains("o") && !HasOto(rv, syllable.vowelTone) && HasOto($"- O", syllable.vowelTone)) {
-                        basePhoneme = $"- O";
-                    } else if (rv.Contains("U") && !HasOto(rv, syllable.vowelTone) && HasOto($"- u", syllable.vowelTone)) {
-                        basePhoneme = $"- u";
-                    }
-                }
-                else {
+                } else if (!HasOto(rv, syllable.vowelTone)) {
+                    rv = ValidateAlias(rv);
+                    basePhoneme = rv;
+                } else {
                     basePhoneme = v;
-                    if (v.Contains("V") && !HasOto(v, syllable.vowelTone) && HasOto($"A", syllable.vowelTone)) {
-                        basePhoneme = $"A";
-                    } else if (v.Contains("E") && !HasOto(v, syllable.vowelTone) && HasOto($"e", syllable.vowelTone)) {
-                        basePhoneme = $"e";
-                    } else if (v.Contains("I") && !HasOto(v, syllable.vowelTone) && HasOto($"i", syllable.vowelTone)) {
-                        basePhoneme = $"i";
-                    } else if (v.Contains("o") && !HasOto(v, syllable.vowelTone) && HasOto($"O", syllable.vowelTone)) {
-                        basePhoneme = $"O";
-                    }else if (v.Contains("U") && !HasOto(v, syllable.vowelTone) && HasOto($"u", syllable.vowelTone)) {
-                        basePhoneme = $"u";
-                    }
                 }
             } else if (syllable.IsVV) {
+                var vv = $"{prevV} {v}";
                 if (!CanMakeAliasExtension(syllable)) {
-                    basePhoneme = $"{prevV} {v}";
-            } else {
-                // the previous alias will be extended
-                basePhoneme = null;
-            }
-                if (!HasOto($"{prevV} {v}", syllable.vowelTone)) {
-                    if (prevV == "V" && !HasOto(prevV, syllable.vowelTone)) {
-                        syllable.prevV = "A";
-                    } else if (v == "V" && !HasOto(v, syllable.vowelTone)) {
-                        syllable.v = "A";
-                    } else if (prevV == "E" && !HasOto(prevV, syllable.vowelTone)) {
-                        syllable.prevV = "e";
-                    } else if (v == "E" && !HasOto(v, syllable.vowelTone)) {
-                        syllable.v = "e";
-                    } else if (prevV == "I" && !HasOto(prevV, syllable.vowelTone)) {
-                        syllable.prevV = "i";
-                    } else if (v == "I" && !HasOto(v, syllable.vowelTone)) {
-                        syllable.v = "i";
-                    } else if (prevV == "o" && !HasOto(prevV, syllable.vowelTone)) {
-                        syllable.prevV = "O";
-                    } else if (v == "o" && !HasOto(v, syllable.vowelTone)) {
-                        syllable.v = "O";
-                    } else if (prevV == "U" && !HasOto(prevV, syllable.vowelTone)) {
-                        syllable.prevV = "u";
-                    } else if (v == "U" && !HasOto(v, syllable.vowelTone)) {
-                        syllable.v = "u";
-                    } else {
-                        basePhoneme = $"{v}";
-                    }   
+                    basePhoneme = vv;
+                    if (!HasOto(vv, syllable.vowelTone)) {
+                        vv = ValidateAlias(vv);
+                        basePhoneme = vv;
+                    }
+                } else {
+                    // the previous alias will be extended
+                    basePhoneme = null;
+                }
+                if (!HasOto(vv, syllable.vowelTone)) {
+                    basePhoneme = $"{v}";
                 }
             } else if (syllable.IsStartingCVWithOneConsonant) {
                 // TODO: move to config -CV or -C CV
@@ -164,33 +120,17 @@ namespace OpenUtau.Plugin.Builtin
                 var cv = $"{cc[0]}{v}";
                 if (HasOto(rcv, syllable.vowelTone)) {
                     basePhoneme = rcv;
-                } else if (v == "V" && !HasOto(rcv, syllable.vowelTone) && HasOto($"- {cc[0]}A", syllable.vowelTone)) {
-                    basePhoneme = $"- {cc[0]}A";
-                } else if (v == "E" && !HasOto(rcv, syllable.vowelTone) && HasOto($"- {cc[0]}e", syllable.vowelTone)) {
-                    basePhoneme = $"- {cc[0]}e";
-                } else if (v == "I" && !HasOto(rcv, syllable.vowelTone) && HasOto($"- {cc[0]}i", syllable.vowelTone)) {
-                    basePhoneme = $"- {cc[0]}i";
-                } else if (v == "o" && !HasOto(rcv, syllable.vowelTone) && HasOto($"- {cc[0]}O", syllable.vowelTone)) {
-                    basePhoneme = $"- {cc[0]}O";
-                } else if (v == "U" && !HasOto(rcv, syllable.vowelTone) && HasOto($"- {cc[0]}u", syllable.vowelTone)) {
-                    basePhoneme = $"- {cc[0]}u";
+                } else if (!HasOto(rcv, syllable.vowelTone)) {
+                    rcv = ValidateAlias(rcv);
+                    basePhoneme = rcv;
+                    if (!HasOto(ValidateAlias(rcv), syllable.vowelTone)) {
+                        basePhoneme = cv;
+                        if (consonants.Contains(cc[0])) {
+                            TryAddPhoneme(phonemes, syllable.tone, $"- {cc[0]}");
+                        }
+                    }
                 } else {
                     basePhoneme = cv;
-                    if (v == "V" && !HasOto(rcv, syllable.vowelTone) && !HasOto(cv, syllable.vowelTone) && HasOto($"{cc[0]}A", syllable.vowelTone)) {
-                        basePhoneme = $"{cc[0]}A";
-                    }
-                    else if (v == "E" && !HasOto(rcv, syllable.vowelTone) && !HasOto(cv, syllable.vowelTone) && HasOto($"{cc[0]}e", syllable.vowelTone)) {
-                        basePhoneme = $"{cc[0]}e";
-                    }
-                    else if (v == "I" && !HasOto(rcv, syllable.vowelTone) && !HasOto(cv, syllable.vowelTone) && HasOto($"{cc[0]}i", syllable.vowelTone)) {
-                        basePhoneme = $"{cc[0]}i";
-                    }
-                    else if (v == "o" && !HasOto(rcv, syllable.vowelTone) && !HasOto(cv, syllable.vowelTone) && HasOto($"{cc[0]}O", syllable.vowelTone)) {
-                        basePhoneme = $"{cc[0]}O";
-                    }
-                    else if (v == "U" && !HasOto(rcv, syllable.vowelTone) && !HasOto(cv, syllable.vowelTone) && HasOto($"{cc[0]}u", syllable.vowelTone)) {
-                        basePhoneme = $"{cc[0]}u";
-                    }
                     if (consonants.Contains(cc[0])) {
                         TryAddPhoneme(phonemes, syllable.tone, $"- {cc[0]}");
                     }
@@ -198,27 +138,25 @@ namespace OpenUtau.Plugin.Builtin
             } else if (syllable.IsStartingCVWithMoreThanOneConsonant) {
                 // try RCCV
                 var rccv = $"- {string.Join("", cc)}{v}";
+                var ucv = $"_{cc.Last()}{v}";
                 if (HasOto(rccv, syllable.vowelTone)) {
                     basePhoneme = rccv;
+                    if (!HasOto(rccv, syllable.vowelTone)) {
+                        rccv = ValidateAlias(rccv);
+                        basePhoneme = rccv;
+                    }
                 } else {
                     basePhoneme = $"{cc.Last()}{v}";
-                    if (!HasOto($"{cc.Last()}V", syllable.vowelTone) && HasOto($"{cc.Last()}A", syllable.vowelTone)) {
-                        basePhoneme = $"{cc.Last()}A";
-                    } else if (!HasOto($"{cc.Last()}E", syllable.vowelTone) && HasOto($"{cc.Last()}e", syllable.vowelTone)) {
-                        basePhoneme = $"{cc.Last()}e";
-                    } else if (!HasOto($"{cc.Last()}I", syllable.vowelTone) && HasOto($"{cc.Last()}i", syllable.vowelTone)) {
-                        basePhoneme = $"{cc.Last()}i";
-                    } else if (!HasOto($"{cc.Last()}o", syllable.vowelTone) && HasOto($"{cc.Last()}O", syllable.vowelTone)) {
-                        basePhoneme = $"{cc.Last()}O";
-                    } else if (!HasOto($"{cc.Last()}U", syllable.vowelTone) && HasOto($"{cc.Last()}u", syllable.vowelTone)) {
-                        basePhoneme = $"{cc.Last()}u";
-                    }
-                    if (HasOto($"_{cc.Last()}{v}", syllable.vowelTone)) {
-                        basePhoneme = $"_{cc.Last()}{v}";
+                    if (HasOto(ucv, syllable.vowelTone)) {
+                        basePhoneme = ucv;
+                        if (!HasOto(ucv, syllable.vowelTone)) {
+                            ucv = ValidateAlias(ucv);
+                            basePhoneme = ucv;
+                        }
                     }
                     // try RCC
                     for (var i = cc.Length; i > 1; i--) {
-                        if (TryAddPhoneme(phonemes, syllable.tone, $"- {string.Join("", cc.Take(i))}", $"{string.Join("", cc.Take(i))}")) {
+                        if (TryAddPhoneme(phonemes, syllable.tone, $"- {string.Join("", cc.Take(i))}")) {
                             firstC = i;
                             break;
                         }
@@ -229,10 +167,27 @@ namespace OpenUtau.Plugin.Builtin
                     // try CCV
                     for (var i = firstC; i < cc.Length - 1; i++) {
                         var ccv = string.Join("", cc.Skip(i)) + v;
+                        ccv = ValidateAlias(ccv);
                         if (HasOto(ccv, syllable.tone)) {
                             basePhoneme = ccv;
                             lastC = i;
+                            if (!HasOto(ccv, syllable.tone)) {
+                                ccv = ValidateAlias(ccv);
+                                basePhoneme = ccv;
+                                lastC = i;
+                                break;
+                            }
                             break;
+                        } else {
+                            basePhoneme = $"{cc.Last()}{v}";
+                            if (HasOto(ucv, syllable.vowelTone)) {
+                                basePhoneme = ucv;
+                                if (!HasOto(ucv, syllable.vowelTone)) {
+                                    ucv = ValidateAlias(ucv);
+                                    basePhoneme = ucv;
+                                }
+                                break;
+                            }
                         }
                     }
                 }
@@ -241,26 +196,19 @@ namespace OpenUtau.Plugin.Builtin
                 var vccv = $"{prevV} {string.Join("", cc)}{v}";
                 if (syllable.IsVCVWithOneConsonant && HasOto(vcv, syllable.vowelTone)) {
                     basePhoneme = vcv;
+                    if (!HasOto(vcv, syllable.vowelTone)) {
+                        vcv = ValidateAlias(vcv);
+                        basePhoneme = vcv;
+                    }
                 } else if (syllable.IsVCVWithMoreThanOneConsonant && HasOto(vccv, syllable.vowelTone)) {
                     basePhoneme = vccv;
-                } else if (prevV == "V" && !HasOto($"V {cc[0]}", syllable.vowelTone) && !HasOto(vcv, syllable.vowelTone) && !HasOto(vccv, syllable.vowelTone) && HasOto($"@ {cc[0]}", syllable.vowelTone)) {
-                    basePhoneme = $"{cc.Last()}{v}";
-                    phonemes.Add($"A {cc[0]}");
-                } else if (prevV == "E" && !HasOto($"E {cc[0]}", syllable.vowelTone) && !HasOto(vcv, syllable.vowelTone) && !HasOto(vccv, syllable.vowelTone) && HasOto($"e {cc[0]}", syllable.vowelTone)) {
-                    basePhoneme = $"{cc.Last()}{v}";
-                    phonemes.Add($"e {cc[0]}");
-                } else if (prevV == "I" && !HasOto($"I {cc[0]}", syllable.vowelTone) && !HasOto(vcv, syllable.vowelTone) && !HasOto(vccv, syllable.vowelTone) && HasOto($"i {cc[0]}", syllable.vowelTone)) {
-                    basePhoneme = $"{cc.Last()}{v}";
-                    phonemes.Add($"i {cc[0]}");
-                } else if (prevV == "o" && !HasOto($"o {cc[0]}", syllable.vowelTone) && !HasOto(vcv, syllable.vowelTone) && !HasOto(vccv, syllable.vowelTone) && HasOto($"O {cc[0]}", syllable.vowelTone)) {
-                    basePhoneme = $"{cc.Last()}{v}";
-                    phonemes.Add($"O {cc[0]}");
-                } else if (prevV == "U" && !HasOto($"U {cc[0]}", syllable.vowelTone) && !HasOto(vcv, syllable.vowelTone) && !HasOto(vccv, syllable.vowelTone) && HasOto($"u {cc[0]}", syllable.vowelTone)) {
-                    basePhoneme = $"{cc.Last()}{v}";
-                    phonemes.Add($"u {cc[0]}");
+                    if (!HasOto(vccv, syllable.vowelTone)) {
+                        vccv = ValidateAlias(vccv);
+                        basePhoneme = vccv;
+                    }
                 } else {
-                    // try CCV
                     basePhoneme = cc.Last() + v;
+                    // try CCV
                     if (cc.Length - firstC > 1) {
                         for (var i = firstC; i < cc.Length; i++) {
                             var ccv = $"{string.Join("", cc.Skip(i))}{v}";
@@ -277,30 +225,60 @@ namespace OpenUtau.Plugin.Builtin
                         }
                     }
                     // try vcc
-                    for (var i = lastC + 1; i >= 0; i--)
-                    {
+                    for (var i = lastC + 1; i >= 0; i--) {
+                        var vr = $"{prevV} -";
                         var vcc = $"{prevV} {string.Join("", cc.Take(i))}";
                         var vcc2 = $"{prevV}{string.Join(" ", cc.Take(2))}";
                         var vcc3 = $"{prevV}{string.Join(" ", cc.Take(i))}";
                         var cc1 = $"{string.Join(" ", cc.Take(2))}";
                         var cc2 = $"{string.Join("", cc.Take(2))}";
+                        var vc = $"{prevV} {cc[0]}";
                         if (i == 0) {
-                            phonemes.Add($"{prevV} -");
+                            phonemes.Add(vr);
+                            if (!HasOto(vr, syllable.tone)) {
+                                vr = ValidateAlias(vr);
+                                phonemes.Add(vr);
+                            }
                         } else if (HasOto(vcc, syllable.tone)) {
                             phonemes.Add(vcc);
                             firstC = i - 1;
+                            if (!HasOto(vcc, syllable.tone)) {
+                                vcc = ValidateAlias(vcc);
+                                phonemes.Add(vcc);
+                                firstC = i - 1;
+                                break;
+                            }
                             break;
                         } else if (HasOto(vcc2, syllable.tone) && !(HasOto(cc1, syllable.tone)) && !(HasOto(cc2, syllable.tone))) {
                             phonemes.Add(vcc2);
                             firstC = i - 2;
+                            if (!HasOto(vcc2, syllable.tone)) {
+                                vcc2 = ValidateAlias(vcc2);
+                                phonemes.Add(vcc2);
+                                firstC = i - 2;
+                                break;
+                            }
                             break;
                         } else if (HasOto(vcc3, syllable.tone)) {
                             phonemes.Add(vcc3);
                             firstC = i - 1;
+                            if (!HasOto(vcc3, syllable.tone)) {
+                                vcc3 = ValidateAlias(vcc3);
+                                phonemes.Add(vcc3);
+                                firstC = i - 1;
+                                break;
+                            }
+                            break;
+                        } else if (HasOto(vc, syllable.tone)) {
+                            phonemes.Add(vc);
+                            if (!HasOto(vc, syllable.tone)) {
+                                vc = ValidateAlias(vc);
+                                phonemes.Add(vc);
+                                break;
+                            }
                             break;
                         } else {
-                            phonemes.Add($"{prevV} {cc[0]}");
-                            break;
+                            continue;
                         }
                     }
                 }
@@ -308,33 +286,52 @@ namespace OpenUtau.Plugin.Builtin
             for (var i = firstC; i < lastC; i++) {
                 // we could use some CCV, so lastC is used
                 // we could use -CC so firstC is used
+                var rccv = $"- {string.Join("", cc)}{v}";
                 var cc1 = $"{string.Join("", cc.Skip(i))}";
                 var ccv = string.Join("", cc.Skip(i)) + v;
-                if (!HasOto($"- {string.Join("", cc)}{v}", syllable.vowelTone)) {
+                var ucv = $"_{cc.Last()}{v}";
+                if (!HasOto(rccv, syllable.vowelTone)) {
                     if (!HasOto(cc1, syllable.tone)) {
                         cc1 = $"{cc[i]}{cc[i + 1]}";
                     }
-                    if (!HasOto($"{string.Join("", cc.Skip(i))}", syllable.tone) && !HasOto($"{cc[i]}{cc[i + 1]}", syllable.tone)) {
+                    if (!HasOto(cc1, syllable.tone)) {
                         cc1 = $"{cc[i]} {cc[i + 1]}";
                     }
                     if (HasOto(ccv, syllable.vowelTone)) {
                         basePhoneme = ccv;
-                    } else if (HasOto($"_{cc.Last()}{v}", syllable.vowelTone) && HasOto(cc1, syllable.vowelTone) && !cc1.Contains($"{cc[i]} {cc[i + 1]}")) {
-                        basePhoneme = $"_{cc.Last()}{v}";
+                        if (!HasOto(ccv, syllable.vowelTone)) {
+                            ccv = ValidateAlias(ccv);
+                            basePhoneme = ccv;
+                        }
+                    } else if (HasOto(ucv, syllable.vowelTone) && HasOto(cc1, syllable.vowelTone) && !cc1.Contains($"{cc[i]} {cc[i + 1]}")) {
+                        basePhoneme = ucv;
+                        if (!HasOto(ucv, syllable.vowelTone)) {
+                            ucv = ValidateAlias(ucv);
+                            basePhoneme = ucv;
+                        }
                     }
                     if (i + 1 < lastC) {
                         var cc2 = $"{string.Join("", cc.Skip(i))}";
                         if (!HasOto(cc2, syllable.tone)) {
                             cc2 = $"{cc[i + 1]}{cc[i + 2]}";
                         }
-                        if (!HasOto($"{cc[i + 1]}{cc[i + 2]}", syllable.tone) && !HasOto($"{string.Join("", cc.Skip(i))}", syllable.tone)) {
+                        if (!HasOto(cc2, syllable.tone)) {
                             cc2 = $"{cc[i + 1]} {cc[i + 2]}";
                         }
                         if (HasOto(ccv, syllable.vowelTone)) {
                             basePhoneme = ccv;
-                        } else if (HasOto($"_{cc.Last()}{v}", syllable.vowelTone) && HasOto(cc2, syllable.vowelTone) && !cc2.Contains($"{cc[i + 1]} {cc[i + 2]}")) {
-                            basePhoneme = $"_{cc.Last()}{v}";
-                        } if (HasOto(cc1, syllable.tone) && HasOto(cc2, syllable.tone) && !cc1.Contains($"{string.Join("", cc.Skip(i))}")) {
+                            if (!HasOto(ccv, syllable.vowelTone)) {
+                                ccv = ValidateAlias(ccv);
+                                basePhoneme = ccv;
+                            }
+                        } else if (HasOto(ucv, syllable.vowelTone) && HasOto(cc2, syllable.vowelTone) && !cc2.Contains($"{cc[i + 1]} {cc[i + 2]}")) {
+                            basePhoneme = ucv;
+                            if (!HasOto(ucv, syllable.vowelTone)) {
+                                ucv = ValidateAlias(ucv);
+                                basePhoneme = ucv;
+                            }
+                        }
+                        if (HasOto(cc1, syllable.tone) && HasOto(cc2, syllable.tone) && !cc1.Contains($"{string.Join("", cc.Skip(i))}")) {
                             // like [V C1] [C1 C2] [C2 C3] [C3 ..]
                             phonemes.Add(cc1);
                         } else if (TryAddPhoneme(phonemes, syllable.tone, cc1)) {
@@ -351,21 +348,13 @@ namespace OpenUtau.Plugin.Builtin
                             }
                         } else if (affricates.Contains(cc[i])) {
                             // like [V C1] [C1] [C2 ..]
-                            TryAddPhoneme(phonemes, syllable.tone, cc[i], $"{cc[i]} -");
-                            //if (cc[i] == cc.Last() && !affricates.Contains(cc[i])) {
-                            //    phonemes.Remove(cc[i]);
-                            //    phonemes.Remove($"{cc[i]} -");
-                            //}
+                            TryAddPhoneme(phonemes, syllable.tone, cc[i], $"{cc[i]} -", $"{cc[i]}-");
                         }
                     } else {
                         // like [V C1] [C1 C2]  [C2 ..] or like [V C1] [C1 -] [C3 ..]
                         TryAddPhoneme(phonemes, syllable.tone, cc1);
                         if (affricates.Contains(cc[i]) && !HasOto(cc1, syllable.tone)) {
-                            TryAddPhoneme(phonemes, syllable.tone, cc[i], $"{cc[i]} -");
-                            //if (!affricates.Contains(cc[i]) && cc[i] == cc.Last()) {
-                            //    phonemes.Remove(cc[i]);
-                            //    phonemes.Remove($"{cc[i]} -");
-                            //}
+                            TryAddPhoneme(phonemes, syllable.tone, cc[i], $"{cc[i]} -", $"{cc[i]}-");
                         }
                     }
                 }
@@ -375,59 +364,31 @@ namespace OpenUtau.Plugin.Builtin
             return phonemes;
         }
 
-        protected override List<string> ProcessEnding(Ending ending)
-        {
+        protected override List<string> ProcessEnding(Ending ending) {
             string[] cc = ending.cc;
             string v = ending.prevV;
 
             var phonemes = new List<string>();
+            var vr = $"{v} -";
             if (ending.IsEndingV) {
-                 if (HasOto($"{v} -", ending.tone)) {
-                    phonemes.Add($"{v} -");
-                } else if (v == "V" && !HasOto($"{v} -", ending.tone) && HasOto($"A -", ending.tone)) {
-                    phonemes.Add($"A -");
-                } else if (v == "E" && !HasOto($"{v} -", ending.tone) && HasOto($"e -", ending.tone)) {
-                    phonemes.Add($"e -");
-                } else if (v == "I" && !HasOto($"{v} -", ending.tone) && HasOto($"i -", ending.tone)) {
-                    phonemes.Add($"i -");
-                } else if (v == "o" && !HasOto($"{v} -", ending.tone) && HasOto($"O -", ending.tone)) {
-                    phonemes.Add($"O -");
-                } else if (v == "U" && !HasOto($"{v} -", ending.tone) && HasOto($"u -", ending.tone)) {
-                    phonemes.Add($"u -");
-                } else {
-                    //continue as usual
-                }
+                TryAddPhoneme(phonemes, ending.tone, vr, ValidateAlias(vr));
             } else if (ending.IsEndingVCWithOneConsonant) {
+                var vc = $"{v} {cc[0]}";
                 var vcr = $"{v} {cc[0]}-";
                 if (HasOto(vcr, ending.tone)) {
                     phonemes.Add(vcr);
-                } else if (v == "V" && !HasOto(vcr, ending.tone) && HasOto($"A {cc[0]}-", ending.tone)) {
-                    phonemes.Add($"A {cc[0]}-");
-                } else if (v == "E" && !HasOto(vcr, ending.tone) && HasOto($"e {cc[0]}-", ending.tone)) {
-                    phonemes.Add($"e {cc[0]}-");
-                } else if (v == "I" && !HasOto(vcr, ending.tone) && HasOto($"i {cc[0]}-", ending.tone)) {
-                    phonemes.Add($"i {cc[0]}-");
-                } else if (v == "o" && !HasOto(vcr, ending.tone) && HasOto($"O {cc[0]}-", ending.tone)) {
-                    phonemes.Add($"O {cc[0]}-");
-                } else if (v == "U" && !HasOto(vcr, ending.tone) && HasOto($"u {cc[0]}-", ending.tone)) {
-                    phonemes.Add($"u {cc[0]}-");
+                } else if (!HasOto(vcr, ending.tone)) {
+                    vcr = ValidateAlias(vcr);
+                    phonemes.Add(vcr);
+                } else if (HasOto(vc, ending.tone)) {
+                    phonemes.Add(vc);
                 } else {
-                    phonemes.Add($"{v} {cc[0]}");
-                    if (v == "V" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"A {cc[0]}", ending.tone)) {
-                        v.Replace("V", "A");
-                    } else if (v == "E" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"e {cc[0]}", ending.tone)) {
-                        v.Replace("E", "e");
-                    } else if (v == "I" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"I {cc[0]}", ending.tone)) {
-                        v.Replace("I", "i");
-                    } else if (v == "o" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"O {cc[0]}", ending.tone)) {
-                        v.Replace("o", "O");
-                    } else if (v == "U" && !HasOto($"{v} {cc[0]}", ending.tone) && HasOto($"U {cc[0]}", ending.tone)) {
-                        v.Replace("U", "u");
-                    }
+                    vc = ValidateAlias(vc);
+                    phonemes.Add(vc);
                     if (affricates.Contains(cc[0])) {
-                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", cc[0]);
+                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", $"{cc[0]}-", cc[0]);
                     } else {
-                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -");
+                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", $"{cc[0]}-");
                     }
                 }
             } else {
@@ -435,17 +396,37 @@ namespace OpenUtau.Plugin.Builtin
                 var vcc2 = $"{v}{string.Join(" ", cc)}-";
                 var vcc3 = $"{v}{cc[0]} {cc[0 + 1]}-";
                 var vcc4 = $"{v}{cc[0]} {cc[0 + 1]}";
+                var vc = $"{v} {cc[0]}";
                 if (HasOto(vcc1, ending.tone)) {
                     phonemes.Add(vcc1);
+                    if (!HasOto(vcc1, ending.tone)) {
+                        vcc1 = ValidateAlias(vcc1);
+                        phonemes.Add(vcc1);
+                    }
                 } else if (HasOto(vcc2, ending.tone)) {
                     phonemes.Add(vcc2);
+                    if (!HasOto(vcc2, ending.tone)) {
+                        vcc2 = ValidateAlias(vcc2);
+                        phonemes.Add(vcc2);
+                    }
                 } else if (HasOto(vcc3, ending.tone)) {
                     phonemes.Add(vcc3);
+                    if (!HasOto(vcc3, ending.tone)) {
+                        vcc3 = ValidateAlias(vcc3);
+                        phonemes.Add(vcc3);
+                    }
                 } else {
                     if (HasOto(vcc4, ending.tone)) {
                         phonemes.Add(vcc4);
-                    } else if (!HasOto(vcc4, ending.tone)) {
-                        phonemes.Add($"{v} {cc[0]}");
+                        if (!HasOto(vcc4, ending.tone)) {
+                            vcc4 = ValidateAlias(vcc4);
+                            phonemes.Add(vcc4);
+                        }
+                    } else if (HasOto(vc, ending.tone)) {
+                        phonemes.Add(vc);
+                    } else {
+                        vc = ValidateAlias(vc);
+                        phonemes.Add(vc);
                     }
                     // all CCs except the first one are /C1C2/, the last one is /C1 C2-/
                     // but if there is no /C1C2/, we try /C1 C2-/, vise versa for the last one
@@ -454,7 +435,7 @@ namespace OpenUtau.Plugin.Builtin
                         if (!HasOto(cc1, ending.tone)) {
                             cc1 = $"{cc[i]}{cc[i + 1]}";
                         }
-                        if (!HasOto(cc1, ending.tone) && !HasOto($"{cc[i]}{cc[i + 1]}", ending.tone)) {
+                        if (!HasOto(cc1, ending.tone)) {
                             cc1 = $"{cc[i]} {cc[i + 1]}-";
                         }
                         if (i < cc.Length - 2) {
@@ -477,7 +458,7 @@ namespace OpenUtau.Plugin.Builtin
                                 } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}")) {
                                     // like [C1 C2][C3 ...]
                                     if (cc[i + 2] == cc.Last()) {
-                                        TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 2]} -");
+                                        TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 2]} -", $"{cc[i + 2]}-");
                                         i++;
                                     } else {
                                         continue;
@@ -487,47 +468,47 @@ namespace OpenUtau.Plugin.Builtin
                                 } else if (!cc.First().Contains(cc[i + 1]) || !cc.First().Contains(cc[i + 2])) {
                                     // like [C1][C2 ...]
                                     if (affricates.Contains(cc[i]) && (!HasOto(vcc4, ending.tone))) {
-                                        TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -");
+                                        TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -", $"{cc[i]}-");
                                     }
-                                    TryAddPhoneme(phonemes, ending.tone, cc[i + 1], $"{cc[i + 1]} -");
-                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 2]} -", cc[i + 2]);
+                                    TryAddPhoneme(phonemes, ending.tone, cc[i + 1], $"{cc[i + 1]} -", $"{cc[i + 1]}-");
+                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 2]} -", $"{cc[i + 2]}-", cc[i + 2]);
                                     i++;
                                 } else if (!cc.First().Contains(cc[i])) {
                                     // like [C1][C2 ...]
-                                    TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -");
+                                    TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -", $"{cc[i]}-");
                                     i++;
                                 }
                             }
                         } else {
                             if (!HasOto(vcc4, ending.tone)) {
                                 if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}-")) {
-                                // like [C1 C2-]
-                                i++;
-                            } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}")) {
-                                // like [C1C2][C2 -]
-                                if (affricates.Contains(cc[i + 1])) {
-                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
-                                } else {
-                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -");
-                                }
-                                i++;
-                            } else if (TryAddPhoneme(phonemes, ending.tone, cc1)) {
-                                // like [C1 C2][C2 -]
-                                if (affricates.Contains(cc[i + 1])) {
-                                   TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
-                                } else {
-                                   TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -");
-                                }
-                                i++;
-                            } else {
-                                // like [C1][C2 -]
-                                if (!HasOto(vcc4, ending.tone)) {
-                                    TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -");
-                                    if (!affricates.Contains(cc[0])) {
-                                        phonemes.Remove(cc[0]);
-                                    }
-                                    TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", cc[i + 1]);
+                                    // like [C1 C2-]
                                     i++;
+                                } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}")) {
+                                    // like [C1C2][C2 -]
+                                    if (affricates.Contains(cc[i + 1])) {
+                                        TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", $"{cc[i + 1]}-", cc[i + 1]);
+                                    } else {
+                                        TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", $"{cc[i + 1]}-");
+                                    }
+                                    i++;
+                                } else if (TryAddPhoneme(phonemes, ending.tone, cc1)) {
+                                    // like [C1 C2][C2 -]
+                                    if (affricates.Contains(cc[i + 1])) {
+                                        TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", $"{cc[i + 1]}-", cc[i + 1]);
+                                    } else {
+                                        TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", $"{cc[i + 1]}-");
+                                    }
+                                    i++;
+                                } else {
+                                    // like [C1][C2 -]
+                                    if (!HasOto(vcc4, ending.tone)) {
+                                        TryAddPhoneme(phonemes, ending.tone, cc[i], $"{cc[i]} -", $"{cc[i]}-");
+                                        if (!affricates.Contains(cc[0])) {
+                                            phonemes.Remove(cc[0]);
+                                        }
+                                        TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", $"{cc[i + 1]}-", cc[i + 1]);
+                                        i++;
                                     }
                                 }
                             }
@@ -573,7 +554,7 @@ namespace OpenUtau.Plugin.Builtin
                         if (!alias.StartsWith(c)) {
                             return base.GetTransitionBasicLengthMs();
                         }
-                    }   
+                    }
                 }
             }
 

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -233,6 +233,7 @@ Hold Ctrl to select</system:String>
   <system:String x:Key="prefs.appearance.lang">Language</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>
+  <system:String x:Key="prefs.appearance.sortorder">Singer sorting order</system:String>
   <system:String x:Key="prefs.appearance.theme">Theme</system:String>
   <system:String x:Key="prefs.appearance.theme.dark">Dark</system:String>
   <system:String x:Key="prefs.appearance.theme.light">Light</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -230,6 +230,7 @@
   <system:String x:Key="prefs.appearance.lang">语言</system:String>
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">在钢琴窗上显示歌手背景图</system:String>
+  <system:String x:Key="prefs.appearance.sortorder">歌手排序方式</system:String>
   <system:String x:Key="prefs.appearance.theme">主题</system:String>
   <system:String x:Key="prefs.appearance.theme.dark">暗</system:String>
   <system:String x:Key="prefs.appearance.theme.light">亮</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -111,8 +111,8 @@ namespace OpenUtau.App.ViewModels {
             SortingOrders = Languages.ToList();
             SortingOrders.Insert(1, CultureInfo.InvariantCulture);
             SortingOrder = string.IsNullOrEmpty(Preferences.Default.SortingOrder)
-                ? null
-                : Language;
+                ? Language
+                : CultureInfo.GetCultureInfo(Preferences.Default.SortingOrder);
             PreRender = Preferences.Default.PreRender ? 1 : 0;
             NumRenderThreads = Preferences.Default.NumRenderThreads;
             Theme = Preferences.Default.Theme;
@@ -174,7 +174,6 @@ namespace OpenUtau.App.ViewModels {
                 .Subscribe(so => {
                     Preferences.Default.SortingOrder = so?.Name ?? string.Empty;
                     Preferences.Save();
-                    App.SetLanguage(Preferences.Default.Language);
                 });
             this.WhenAnyValue(vm => vm.Theme)
                 .Subscribe(theme => {

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -50,6 +50,13 @@ namespace OpenUtau.App.ViewModels {
             get => language;
             set => this.RaiseAndSetIfChanged(ref language, value);
         }
+
+        public List<CultureInfo>? SortingOrders { get; }
+        public CultureInfo? SortingOrder {
+            get => sortingOrder;
+            set => this.RaiseAndSetIfChanged(ref sortingOrder, value);
+        }
+
         public class LyricsHelperOption {
             public readonly Type klass;
             public LyricsHelperOption(Type klass) {
@@ -69,6 +76,7 @@ namespace OpenUtau.App.ViewModels {
         private List<AudioOutputDevice>? audioOutputDevices;
         private AudioOutputDevice? audioOutputDevice;
         private CultureInfo? language;
+        private CultureInfo? sortingOrder;
 
         public PreferencesViewModel() {
             var audioOutput = PlaybackManager.Inst.AudioOutput;
@@ -100,6 +108,11 @@ namespace OpenUtau.App.ViewModels {
             Language = string.IsNullOrEmpty(Preferences.Default.Language)
                 ? null
                 : CultureInfo.GetCultureInfo(Preferences.Default.Language);
+            SortingOrders = Languages.ToList();
+            SortingOrders.Insert(1, CultureInfo.InvariantCulture);
+            SortingOrder = string.IsNullOrEmpty(Preferences.Default.SortingOrder)
+                ? null
+                : Language;
             PreRender = Preferences.Default.PreRender ? 1 : 0;
             NumRenderThreads = Preferences.Default.NumRenderThreads;
             Theme = Preferences.Default.Theme;
@@ -154,6 +167,12 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.Language)
                 .Subscribe(lang => {
                     Preferences.Default.Language = lang?.Name ?? string.Empty;
+                    Preferences.Save();
+                    App.SetLanguage(Preferences.Default.Language);
+                });
+            this.WhenAnyValue(vm => vm.SortingOrder)
+                .Subscribe(so => {
+                    Preferences.Default.SortingOrder = so?.Name ?? string.Empty;
                     Preferences.Save();
                     App.SetLanguage(Preferences.Default.Language);
                 });

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -167,7 +167,7 @@ namespace OpenUtau.App.ViewModels {
             items.AddRange(Preferences.Default.RecentSingers
                 .Select(id => SingerManager.Inst.Singers.Values.FirstOrDefault(singer => singer.Id == id))
                 .OfType<USinger>()
-                .OrderBy(singer => singer.Name)
+                .LocalizedOrderBy(singer => singer.Name)
                 .Select(singer => new MenuItemViewModel() {
                     Header = singer.Name,
                     Command = SelectSingerCommand,

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -106,6 +106,15 @@
               </ComboBox.ItemTemplate>
             </ComboBox>
             <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.note.restart}" FontSize="11"/>
+            <TextBlock Text="{DynamicResource prefs.appearance.sortorder}" />
+            <ComboBox HorizontalAlignment="Stretch" Items="{Binding SortingOrders}" SelectedItem="{Binding SortingOrder}">
+              <ComboBox.ItemTemplate>
+                <DataTemplate>
+                  <TextBlock Text="{Binding Converter={StaticResource cultureNameConverter}}"/>
+                </DataTemplate>
+              </ComboBox.ItemTemplate>
+            </ComboBox>
+            <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.note.restart}" FontSize="11"/>
             <TextBlock Margin="0,4,0,0" Text="{DynamicResource prefs.appearance.theme}" />
             <ComboBox HorizontalAlignment="Stretch" SelectedIndex="{Binding Theme}">
               <ComboBoxItem Content="{DynamicResource prefs.appearance.theme.light}"/>


### PR DESCRIPTION
After this change, users will be able to sort their voicebanks in a certain language, such as pinyin (zh-cn). This would be very convenient if the user have many voicebanks installed.
The sorting order can be different from the UI language. For example, If a Chinese user have a lot of Japanese voicebanks installed, he may want to sort his voicebanks in Japanese while seeing OpenUtau's UI in Chinese.