### PR TITLE
Time signature fix

### DIFF
--- a/OpenUtau.Core/Util/TimeAxis.cs
+++ b/OpenUtau.Core/Util/TimeAxis.cs
@@ -104,8 +104,8 @@ namespace OpenUtau.Core {
                 tempoSegments[i].tickEnd = tempoSegments[i + 1].tickPos;
             }
             for (var i = 0; i < tempoSegments.Count; ++i) {
-                tempoSegments[i].msPerTick = 60.0 * 1000.0 * tempoSegments[i].beatPerBar / (tempoSegments[i].bpm * 4 * project.resolution);
-                tempoSegments[i].ticksPerMs = tempoSegments[i].bpm * 4 * project.resolution / (60.0 * 1000.0 * tempoSegments[i].beatPerBar);
+                tempoSegments[i].msPerTick = 60.0 * 1000.0 / (tempoSegments[i].bpm * project.resolution);
+                tempoSegments[i].ticksPerMs = tempoSegments[i].bpm * project.resolution / (60.0 * 1000.0);
                 if (i > 0) {
                     tempoSegments[i].msPos = tempoSegments[i - 1].msPos + tempoSegments[i - 1].Ticks * tempoSegments[i - 1].msPerTick;
                     tempoSegments[i - 1].msEnd = tempoSegments[i].msPos;

--- a/OpenUtau.Test/Core/Util/TimeAxisTest.cs
+++ b/OpenUtau.Test/Core/Util/TimeAxisTest.cs
@@ -26,15 +26,15 @@ namespace OpenUtau.Core {
             Assert.Equal(2500, timeAxis.TickPosToMsPos(2400), 6);
             Assert.Equal(5000, timeAxis.TickPosToMsPos(4800), 6);
             Assert.Equal(9000, timeAxis.TickPosToMsPos(7200), 6);
-            Assert.Equal(20333.33333333, timeAxis.TickPosToMsPos(15960), 6);
-            Assert.Equal(35666.66666667, timeAxis.TickPosToMsPos(24000), 6);
+            Assert.Equal(21833.33333333, timeAxis.TickPosToMsPos(15960), 6);
+            Assert.Equal(37166.66666667, timeAxis.TickPosToMsPos(24000), 6);
 
             Assert.Equal(0, timeAxis.MsPosToTickPos(0));
             Assert.Equal(2400, timeAxis.MsPosToTickPos(2500));
             Assert.Equal(4800, timeAxis.MsPosToTickPos(5000));
             Assert.Equal(7200, timeAxis.MsPosToTickPos(9000));
-            Assert.Equal(15960, timeAxis.MsPosToTickPos(20333.33333333));
-            Assert.Equal(24000, timeAxis.MsPosToTickPos(35666.66666667));
+            Assert.Equal(15960, timeAxis.MsPosToTickPos(21833.33333333));
+            Assert.Equal(24000, timeAxis.MsPosToTickPos(37166.66666667));
         }
 
         [Fact]


### PR DESCRIPTION
Before this fix, the actual playing speed depends not only on the tempo but also the upper number of the time signature. After this fix, the actual playing speed only depends on the tempo, ignoring time signatures in speed calculations, which is consistent with the other music editing softwares, like UTAU, deepvocal and X Studio. 
This PR fixes #521