### PR TITLE
Add a phonetic hint remover

### DIFF
--- a/OpenUtau.Core/Editing/LyricBatchEdits.cs
+++ b/OpenUtau.Core/Editing/LyricBatchEdits.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using OpenUtau.Core.Ustx;
 using TinyPinyin;
 using WanaKanaNet;
@@ -84,6 +85,19 @@ namespace OpenUtau.Core.Editing {
 
         private bool ShouldRemove(char c) {
             return (c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z') && c != 'R' && c != 'r';
+        }
+    }
+
+    public class RemovePhoneticHint : SingleNoteLyricEdit {
+        static readonly Regex phoneticHintPattern = new Regex(@"\[(.*)\]");
+        public override string Name => "pianoroll.menu.lyrics.removephonetichint";
+        protected override string Transform(string lyric) {
+            var lrc = lyric;
+            lrc = phoneticHintPattern.Replace(lrc, match => "");
+            if (string.IsNullOrEmpty(lrc)) {
+                return lyric;
+            }
+            return lrc;
         }
     }
 

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -178,6 +178,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.hiraganatoromaji">Hiragana to Romaji</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.javcvtocv">Japanese VCV to CV</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.removelettersuffix">Remove Letter Suffix</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.removephonetichint">Remove Phonetic Hint</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">Remove Tone Suffix</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">Romaji to Hiragana</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">Note Defaults</system:String>

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -179,6 +179,7 @@ namespace OpenUtau.App.ViewModels {
                 new JapaneseVCVtoCV(),
                 new RemoveToneSuffix(),
                 new RemoveLetterSuffix(),
+                new RemovePhoneticHint(),
                 new DashToPlus(),
             }.Select(edit => new MenuItemViewModel() {
                 Header = ThemeManager.GetString(edit.Name),


### PR DESCRIPTION
Suggested in https://discord.com/channels/551606189386104834/1080759098741641267 . An lyric batch edit was added to remove all the phonetic hints from selected notes. This would be useful when I want to use an existing ustx on another VB type of the same language.
