### PR TITLE
fix classic renderer timing with bpm changes

### DIFF
--- a/OpenUtau.Core/Classic/ExeWavtool.cs
+++ b/OpenUtau.Core/Classic/ExeWavtool.cs
@@ -93,7 +93,7 @@ namespace OpenUtau.Classic {
 
         void WriteItem(StreamWriter writer, ResamplerItem item, int index, int total) {
             writer.WriteLine($"@set resamp={item.resampler.FilePath}");
-            writer.WriteLine($"@set params={item.volume} {item.modulation} !{item.phone.adjustedTempo} {Base64.Base64EncodeInt12(item.pitches)}");
+            writer.WriteLine($"@set params={item.volume} {item.modulation} !{item.tempo.ToString("G999")} {Base64.Base64EncodeInt12(item.pitches)}");
             writer.WriteLine($"@set flag=\"{item.GetFlagsString()}\"");
             writer.WriteLine($"@set env={GetEnvelope(item)}");
             writer.WriteLine($"@set stp={item.skipOver}");
@@ -101,7 +101,7 @@ namespace OpenUtau.Classic {
             string relOutputFile = Path.GetRelativePath(PathManager.Inst.CachePath, item.outputFile);
             writer.WriteLine($"@set temp=\"%cachedir%\\{relOutputFile}\"");
             string toneName = MusicMath.GetToneName(item.tone);
-            string dur = $"{item.phone.adjustedDuration}@{item.phone.adjustedTempo}{(item.durCorrection >= 0 ? "+" : "")}{item.durCorrection}";
+            string dur = $"{item.phone.adjustedDuration.ToString("G999")}@{item.phone.adjustedTempo.ToString("G999")}{(item.durCorrection >= 0 ? "+" : "")}{item.durCorrection}";
             string relInputTemp = Path.GetRelativePath(PathManager.Inst.CachePath, item.inputTemp);
             writer.WriteLine($"@echo {MakeProgressBar(index + 1, total)}");
             writer.WriteLine($"@call %helper% \"%oto%\\{relInputTemp}\" {toneName} {dur} {item.preutter} {item.offset} {item.durRequired} {item.consonant} {item.cutoff} {index}");

--- a/OpenUtau.Core/Classic/ExeWavtool.cs
+++ b/OpenUtau.Core/Classic/ExeWavtool.cs
@@ -101,7 +101,7 @@ namespace OpenUtau.Classic {
             string relOutputFile = Path.GetRelativePath(PathManager.Inst.CachePath, item.outputFile);
             writer.WriteLine($"@set temp=\"%cachedir%\\{relOutputFile}\"");
             string toneName = MusicMath.GetToneName(item.tone);
-            string dur = $"{item.phone.adjustedDuration.ToString("G999")}@{item.phone.adjustedTempo.ToString("G999")}{(item.durCorrection >= 0 ? "+" : "")}{item.durCorrection}";
+            string dur = $"{item.phone.duration.ToString("G999")}@{item.phone.adjustedTempo.ToString("G999")}{(item.durCorrection >= 0 ? "+" : "")}{item.durCorrection}";
             string relInputTemp = Path.GetRelativePath(PathManager.Inst.CachePath, item.inputTemp);
             writer.WriteLine($"@echo {MakeProgressBar(index + 1, total)}");
             writer.WriteLine($"@call %helper% \"%oto%\\{relInputTemp}\" {toneName} {dur} {item.preutter} {item.offset} {item.durRequired} {item.consonant} {item.cutoff} {index}");

--- a/OpenUtau.Core/Classic/ExeWavtool.cs
+++ b/OpenUtau.Core/Classic/ExeWavtool.cs
@@ -93,7 +93,7 @@ namespace OpenUtau.Classic {
 
         void WriteItem(StreamWriter writer, ResamplerItem item, int index, int total) {
             writer.WriteLine($"@set resamp={item.resampler.FilePath}");
-            writer.WriteLine($"@set params={item.volume} {item.modulation} !{item.tempo} {Base64.Base64EncodeInt12(item.pitches)}");
+            writer.WriteLine($"@set params={item.volume} {item.modulation} !{item.phone.adjustedTempo} {Base64.Base64EncodeInt12(item.pitches)}");
             writer.WriteLine($"@set flag=\"{item.GetFlagsString()}\"");
             writer.WriteLine($"@set env={GetEnvelope(item)}");
             writer.WriteLine($"@set stp={item.skipOver}");
@@ -101,7 +101,7 @@ namespace OpenUtau.Classic {
             string relOutputFile = Path.GetRelativePath(PathManager.Inst.CachePath, item.outputFile);
             writer.WriteLine($"@set temp=\"%cachedir%\\{relOutputFile}\"");
             string toneName = MusicMath.GetToneName(item.tone);
-            string dur = $"{item.phone.duration}@{item.phone.tempo}{(item.durCorrection >= 0 ? "+" : "")}{item.durCorrection}";
+            string dur = $"{item.phone.adjustedDuration}@{item.phone.adjustedTempo}{(item.durCorrection >= 0 ? "+" : "")}{item.durCorrection}";
             string relInputTemp = Path.GetRelativePath(PathManager.Inst.CachePath, item.inputTemp);
             writer.WriteLine($"@echo {MakeProgressBar(index + 1, total)}");
             writer.WriteLine($"@call %helper% \"%oto%\\{relInputTemp}\" {toneName} {dur} {item.preutter} {item.offset} {item.durRequired} {item.consonant} {item.cutoff} {index}");

--- a/OpenUtau.Core/Classic/ResamplerItem.cs
+++ b/OpenUtau.Core/Classic/ResamplerItem.cs
@@ -71,7 +71,7 @@ namespace OpenUtau.Classic {
 
             double pitchCountMs = (phone.positionMs + phone.envelope[4].X) - (phone.positionMs - pitchLeadingMs);
             int pitchCount = (int)Math.Ceiling(MusicMath.TempoMsToTick(tempo, pitchCountMs) / 5.0);
-
+            pitchCount = Math.Max(pitchCount, 0);
             pitches = new int[pitchCount];
 
             double phoneStartMs = phone.positionMs - pitchLeadingMs;

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -85,7 +85,7 @@ namespace OpenUtau.Core.Render {
             tempo = tempos[0].bpm;
             adjustedTempo = tempos.Skip(1).Aggregate(tempo, (finalTempo, uTempo) => finalTempo * uTempo.bpm); // todo: optimize, maybe with LCM?
 
-            adjustedDuration = tempos.Length > 1 ? (int)((tempos[1].position - (part.position + phoneme.position)) * (adjustedTempo / tempo)) : duration;
+            adjustedDuration = tempos.Length > 1 ? ((tempos[1].position - (part.position + phoneme.position)) * (adjustedTempo / tempo)) : duration;
             for (var i = 1; i < tempos.Length; i++) {
                 int tempoChangeLength;
                 if (i + 1 < tempos.Length) {

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -80,22 +80,24 @@ namespace OpenUtau.Core.Render {
 
             this.phoneme = phoneme.phoneme;
             tone = note.tone;
-            tempos = project.timeAxis.TemposBetweenTicks(part.position + phoneme.position, part.position + phoneme.End);
-            tempo = tempos[0].bpm;
+            tempos = project.timeAxis.TemposBetweenTicks(part.position + phoneme.position - leading, part.position + phoneme.End);
+            UTempo[] noteTempos = project.timeAxis.TemposBetweenTicks(part.position + phoneme.position, part.position + phoneme.End);
+            tempo = noteTempos[0].bpm;
 
             double actualTickDuration = 0;
-            for (int i = 0; i < tempos.Length; i++) {
-                int tempoStart = Math.Max(part.position + phoneme.position, tempos[i].position);
-                int tempoEnd = i + 1 < tempos.Length ? tempos[i + 1].position : part.position + phoneme.End;
+            for (int i = 0; i < noteTempos.Length; i++) {
+                int tempoStart = Math.Max(part.position + phoneme.position, noteTempos[i].position);
+                int tempoEnd = i + 1 < noteTempos.Length ? noteTempos[i + 1].position : part.position + phoneme.End;
                 int tempoLength = tempoEnd - tempoStart;
-                actualTickDuration += (double)(tempoLength * (tempo / tempos[i].bpm));
+                actualTickDuration += (double)(tempoLength * (tempo / noteTempos[i].bpm));
             }
 
-            adjustedTempo = (duration / actualTickDuration) * tempo;
+            adjustedTempo = duration / actualTickDuration * tempo;
 
             preutterMs = phoneme.preutter;
             overlapMs = phoneme.overlap;
             durCorrectionMs = phoneme.preutter - phoneme.tailIntrude + phoneme.tailOverlap;
+
 
             resampler = track.RendererSettings.resampler;
             int eng = (int)phoneme.GetExpression(project, track, Format.Ustx.ENG).Item1;

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -121,6 +121,7 @@ namespace OpenUtau.Core.Render {
             using (var stream = new MemoryStream()) {
                 using (var writer = new BinaryWriter(stream)) {
                     writer.Write(adjustedTempo);
+                    writer.Write(duration);
                     writer.Write(phoneme ?? string.Empty);
                     writer.Write(tone);
 

--- a/OpenUtau.Core/Util/MusicMath.cs
+++ b/OpenUtau.Core/Util/MusicMath.cs
@@ -189,5 +189,13 @@ namespace OpenUtau.Core {
                 div *= 2;
             }
         }
+
+        public static double TempoMsToTick(double tempo, double ms) {
+            return (tempo * 480 * ms) / (60.0 * 1000.0);
+        }
+
+        public static double TempoTickToMs(double tempo, int tick) {
+            return (60.0 * 1000.0 * tick) / (tempo * 480);
+        }
     }
 }

--- a/OpenUtau.Core/Util/TimeAxis.cs
+++ b/OpenUtau.Core/Util/TimeAxis.cs
@@ -160,6 +160,14 @@ namespace OpenUtau.Core {
             }
         }
 
+        public UTempo[] TemposBetweenTicks(int start, int end) {
+            var list = tempoSegments
+                .Where(tempo => start < tempo.tickEnd && tempo.tickPos < end)
+                .Select(tempo => new UTempo { position = tempo.tickPos, bpm = tempo.bpm })
+                .ToArray();
+            return list;
+        }
+
         public UTimeSignature TimeSignatureAtTick(int tick) {
             var segment = timeSigSegments.First(seg => seg.tickPos == tick || seg.tickEnd > tick); // TODO: optimize
             return new UTimeSignature {


### PR DESCRIPTION
fixes timing issues with the classic renderer with bpm changes

- note duration is now correct when changing bpm mid note
- pitches are now timed correctly when changing bpm mid note

