### PR TITLE
ONNX: support directML and CoreML

### DIFF
--- a/OpenUtau.Core/OpenUtau.Core.csproj
+++ b/OpenUtau.Core/OpenUtau.Core.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="K4os.Hash.xxHash" Version="1.0.7" />
     <PackageReference Include="Melanchall.DryWetMidi" Version="6.1.2" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.12.1" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.13.1" />
     <PackageReference Include="NAudio.Core" Version="2.0.0" />
     <PackageReference Include="NAudio.Midi" Version="2.0.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
@@ -28,6 +29,7 @@
     <PackageReference Include="TinyPinyin.Net" Version="1.0.2" />
     <PackageReference Include="ToolGood.Words.Pinyin" Version="3.1.0" />
     <PackageReference Include="UTF.Unknown" Version="2.5.1" />
+    <PackageReference Include="Vortice.DXGI" Version="2.2.0" />
     <PackageReference Include="WanaKana-net" Version="1.0.0" />
     <PackageReference Include="YamlDotNet" Version="12.3.1" />
     <PackageReference Include="NetMQ" Version="4.0.1.9" />

--- a/OpenUtau.Core/Util/Onnx.cs
+++ b/OpenUtau.Core/Util/Onnx.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ML.OnnxRuntime;
+using OpenUtau.Core.Util;
+using Vortice.DXGI;
+
+namespace OpenUtau.Core {
+    public class GpuInfo {
+        public int deviceId;
+        public string description = "";
+
+        override public string ToString() {
+            return $"[{deviceId}] {description}";
+        }
+    }
+
+    public class Onnx {
+        public static List<string> getRunnerOptions() {
+            if (OS.IsWindows()) {
+                return new List<string> {
+                "cpu",
+                "directml"
+                };
+            } else if (OS.IsMacOS()) {
+                return new List<string> {
+                "cpu",
+                "coreml"
+                };
+            }
+            return new List<string> {
+                "cpu"
+            };
+        }
+
+        public static List<GpuInfo> getGpuInfo() {
+            List<GpuInfo> gpuList = new List<GpuInfo>();
+            if (OS.IsWindows()) {
+                DXGI.CreateDXGIFactory1(out IDXGIFactory1 factory);
+                for(int deviceId = 0; deviceId < 32; deviceId++) {
+                    factory.EnumAdapters1(deviceId, out IDXGIAdapter1 adapterOut);
+                    if(adapterOut is null) {
+                        break;
+                    }
+                    gpuList.Add(new GpuInfo {
+                        deviceId = deviceId,
+                        description = adapterOut.Description.Description
+                    }) ;
+                }
+            }
+            if (gpuList.Count == 0) {
+                gpuList.Add(new GpuInfo {
+                    deviceId = 0,
+                });
+            }
+            return gpuList;
+        }
+
+        public static InferenceSession getInferenceSession(byte[] model) {
+            SessionOptions options = new SessionOptions();
+            List<string> runnerOptions = getRunnerOptions();
+            string runner = Preferences.Default.OnnxRunner;
+            if (String.IsNullOrEmpty(runner)) {
+                runner = runnerOptions[0];
+            }
+            if (!(runnerOptions.Contains(runner))) {
+                runner = "cpu";
+            }
+            switch(runner){
+                case "directml":
+                    options.AppendExecutionProvider_DML(Preferences.Default.OnnxGpu);
+                    break;
+                case "coreml":
+                    options.AppendExecutionProvider_CoreML(CoreMLFlags.COREML_FLAG_ENABLE_ON_SUBGRAPH);
+                    break;
+            }
+            return new InferenceSession(model,options);
+        }
+    }
+}

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -86,6 +86,8 @@ namespace OpenUtau.Core.Util {
             public int Theme;
             public bool PreRender = true;
             public int NumRenderThreads = 2;
+            public string OnnxRunner = string.Empty;
+            public int OnnxGpu = 0;
             public string Language = string.Empty;
             public string SortingOrder = string.Empty;
             public List<string> RecentFiles = new List<string>();

--- a/OpenUtau.Core/Vogen/VogenRenderer.cs
+++ b/OpenUtau.Core/Vogen/VogenRenderer.cs
@@ -145,7 +145,7 @@ namespace OpenUtau.Core.Vogen {
                 new DenseTensor<string>(phonemes.ToArray(), new int[] { phonemes.Count })));
             inputs.Add(NamedOnnxValue.CreateFromTensor("phDurs",
                 new DenseTensor<long>(phDurs.ToArray(), new int[] { phonemes.Count })));
-            using (var session = new InferenceSession(Data.VogenRes.f0_man)) {
+            using (var session = Onnx.getInferenceSession(Data.VogenRes.f0_man)) {
                 using var outputs = session.Run(inputs);
                 var f0Out = outputs.First().AsTensor<float>();
                 var f0Path = Path.Join(PathManager.Inst.CachePath, $"vog-{phrase.hash:x16}-f0.npy");
@@ -169,7 +169,7 @@ namespace OpenUtau.Core.Vogen {
                 new DenseTensor<float>(breAmp, new int[] { 1, f0.Length })));
             double[,] sp;
             double[,] ap;
-            using (var session = new InferenceSession(singer.model)) {
+            using (var session = Onnx.getInferenceSession(singer.model)) {
                 using var outputs = session.Run(inputs);
                 var mgc = outputs.First().AsTensor<float>().Select(f => (double)f).ToArray();
                 var bap = outputs.Last().AsTensor<float>().Select(f => (double)f).ToArray();

--- a/OpenUtau/OpenUtau.csproj
+++ b/OpenUtau/OpenUtau.csproj
@@ -64,7 +64,10 @@
   <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x86'">
     <None Include="..\runtimes\win-x86\native\**" CopyToOutputDirectory="PreserveNewest" LinkBase="." />
   </ItemGroup>
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx.10.14-x64'">
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+    <None Include="..\runtimes\osx\native\**" CopyToOutputDirectory="PreserveNewest" LinkBase="." />
+  </ItemGroup>
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
     <None Include="..\runtimes\osx\native\**" CopyToOutputDirectory="PreserveNewest" LinkBase="." />
   </ItemGroup>
   <ItemGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -265,6 +265,8 @@ Hold Ctrl to select</system:String>
   <system:String x:Key="prefs.playback.lockstarttime.on">Move cursor back to where you started playing</system:String>
   <system:String x:Key="prefs.playback.test">Test</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>
+  <system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>
+  <system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>
   <system:String x:Key="prefs.rendering.prerender">Pre-render</system:String>
   <system:String x:Key="prefs.rendering.resampler">Resampler</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -261,6 +261,8 @@
   <system:String x:Key="prefs.playback.lockstarttime.on">将播放标记移回开始播放处</system:String>
   <system:String x:Key="prefs.playback.test">测试</system:String>
   <system:String x:Key="prefs.rendering">渲染</system:String>
+  <system:String x:Key="prefs.rendering.onnxrunner">机器学习运行器</system:String>
+  <system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">相位修正</system:String>
   <system:String x:Key="prefs.rendering.prerender">预渲染</system:String>
   <system:String x:Key="prefs.rendering.resampler">重采样器</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -32,6 +32,10 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int InstallToAdditionalSingersPath { get; set; }
         [Reactive] public int PreRender { get; set; }
         [Reactive] public int NumRenderThreads { get; set; }
+        public List<string> OnnxRunnerOptions { get; set; }
+        [Reactive] public string OnnxRunner { get; set; }
+        public List<GpuInfo> OnnxGpuOptions { get; set; }
+        [Reactive] public GpuInfo OnnxGpu { get; set; }
         [Reactive] public bool HighThreads { get; set; }
         [Reactive] public int Theme { get; set; }
         [Reactive] public int ShowPortrait { get; set; }
@@ -115,6 +119,11 @@ namespace OpenUtau.App.ViewModels {
                 : CultureInfo.GetCultureInfo(Preferences.Default.SortingOrder);
             PreRender = Preferences.Default.PreRender ? 1 : 0;
             NumRenderThreads = Preferences.Default.NumRenderThreads;
+            OnnxRunnerOptions = Onnx.getRunnerOptions();
+            OnnxRunner = String.IsNullOrEmpty(Preferences.Default.OnnxRunner)?
+               OnnxRunnerOptions[0] : Preferences.Default.OnnxRunner;
+            OnnxGpuOptions = Onnx.getGpuInfo();
+            OnnxGpu = OnnxGpuOptions.FirstOrDefault(x => x.deviceId == Preferences.Default.OnnxGpu, OnnxGpuOptions[0]);
             Theme = Preferences.Default.Theme;
             ShowPortrait = Preferences.Default.ShowPortrait ? 1 : 0;
             ShowGhostNotes = Preferences.Default.ShowGhostNotes ? 1 : 0;
@@ -211,6 +220,16 @@ namespace OpenUtau.App.ViewModels {
                 .Subscribe(index => {
                     Preferences.Default.NumRenderThreads = index;
                     HighThreads = index > SafeMaxThreadCount ? true : false;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.OnnxRunner)
+                .Subscribe(index => {
+                    Preferences.Default.OnnxRunner = index;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.OnnxGpu)
+                .Subscribe(index => {
+                    Preferences.Default.OnnxGpu = index.deviceId;
                     Preferences.Save();
                 });
         }

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -93,6 +93,12 @@
             </Grid>
             <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.rendering.threads.cpuwarn}" FontWeight="Bold"
                        Foreground="Red" Margin="0,0,0,4" IsVisible="{Binding HighThreads}" FontSize="11"/>
+            <TextBlock Text="{DynamicResource prefs.rendering.onnxrunner}" />
+            <ComboBox HorizontalAlignment="Stretch"  Items="{Binding OnnxRunnerOptions}" SelectedItem="{Binding OnnxRunner}"/>
+            <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.note.restart}" FontSize="11"/>
+            <TextBlock Text="{DynamicResource prefs.rendering.onnxgpu}" />
+            <ComboBox HorizontalAlignment="Stretch"  Items="{Binding OnnxGpuOptions}" SelectedItem="{Binding OnnxGpu}"/>
+            <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.note.restart}" FontSize="11"/>
           </StackPanel>
         </HeaderedContentControl>
         <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.appearance}">


### PR DESCRIPTION
Support ONNX inferencing with directML and CoreML for vogen renderer

Note: Don't use directML or CoreML for g2p and phonemizers. They should be CPU-only. Because these runtimes may sometimes fail to work, and phonemizers can't show error dialog. CPU's performance is good enough for phonemizers.

---

添加了ONNX directML和CoreML支持，用于vogen渲染器

注意：g2p和音素器请不要使用directML和CoreML，而是仅使用CPU运行。因为directML和CoreML可能在某些情况下无法运行，而音素器不会弹窗报错。CPU的性能足够用于音素器。