### PR TITLE
add .vscode folder into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,4 @@ OpenUtau.Test/Usts/*
 *.dmg
 appcast.*.xml
 *.tar.gz
+.vscode/


### PR DESCRIPTION
Visual Studio Code creates a .vscode folder when debugging, like jetbrain's .idea and visual studio's .vs folder. 