### PR TITLE
ONNX DirectML: fix unable to find an entry point

### DIFF
--- a/OpenUtau.Core/OpenUtau.Core.csproj
+++ b/OpenUtau.Core/OpenUtau.Core.csproj
@@ -12,8 +12,6 @@
     <PackageReference Include="Concentus.OggFile" Version="1.0.4" />
     <PackageReference Include="K4os.Hash.xxHash" Version="1.0.8" />
     <PackageReference Include="Melanchall.DryWetMidi" Version="6.1.4" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.14.1" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.14.1" />
     <PackageReference Include="NAudio.Core" Version="2.0.0" />
     <PackageReference Include="NAudio.Midi" Version="2.0.1" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
@@ -36,6 +34,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">
     <PackageReference Include="NAudio" Version="2.0.1" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.14.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'false'">
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.14.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Analysis\Crepe\Resources.Designer.cs">


### PR DESCRIPTION
on windows, only use Microsoft.ML.OnnxRuntime.DirectML. Microsoft.ML.OnnxRuntime is removed.
