### PR TITLE
Japanese X-SAMPA CVVC Phonemizerを作成

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
@@ -259,7 +259,6 @@ namespace OpenUtau.Plugin.Builtin {
                 var nextAttr = nextNeighbour.Value.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
                 if (singer.TryGetMappedOto(nextLyric, nextNeighbour.Value.tone + nextAttr.toneShift, nextAttr.voiceColor, out var oto)) {
                     // If overlap is a negative value, vcLength is longer than Preutter
-                    // The length of the VC should change depending on the next note's vel, but that has not been implemented yet.
                     if (oto.Overlap < 0) {
                         vcLength = MsToTick(oto.Preutter - oto.Overlap);
                     } else {

--- a/OpenUtau.Plugin.Builtin/JapaneseXSampaCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseXSampaCVVCPhonemizer.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenUtau.Api;
+using OpenUtau.Core.Ustx;
+using Serilog;
+
+namespace OpenUtau.Plugin.Builtin {
+    // Japanese X-SAMPA CVVC Phonemizer is a modification of Japanese CVVC Phonemizer on 2023/4/11.
+
+    [Phonemizer("Japanese X-SAMPA CVVC Phonemizer", "JA X-SAMPA CVVC", "Maiko",language:"JA")]
+    public class JapaneseXsampaCVVCPhonemizer : Phonemizer {
+        static readonly string[] plainVowels = new string[] {"あ","い","う","え","お","を","ん","ン"};
+        static readonly string[] nonVowels = new string[]{"息","吸","R","-","k","k'","g","g'",
+                                                           "s","S","z","Z","t","tS","t'","ts",
+                                                           "d","d'","n","J","h","C","p\\","b",
+                                                           "b'","p","p'","m","m'","j","r","4",
+                                                           "4'","w","v","ng","l","・","B", "H",
+        };
+
+        static readonly string[] vowels = new string[] {
+            "a=ぁ,あ,か,が,さ,ざ,た,だ,な,は,ば,ぱ,ま,ゃ,や,ら,わ,ァ,ア,カ,ガ,サ,ザ,タ,ダ,ナ,ハ,バ,パ,マ,ャ,ヤ,ラ,ワ",
+            "e=ぇ,え,け,げ,せ,ぜ,て,で,ね,へ,べ,ぺ,め,れ,ゑ,ェ,エ,ケ,ゲ,セ,ゼ,テ,デ,ネ,ヘ,ベ,ペ,メ,レ,ヱ",
+            "i=ぃ,い,き,ぎ,し,じ,ち,ぢ,に,ひ,び,ぴ,み,り,ゐ,ィ,イ,キ,ギ,シ,ジ,チ,ヂ,ニ,ヒ,ビ,ピ,ミ,リ,ヰ",
+            "o=ぉ,お,こ,ご,そ,ぞ,と,ど,の,ほ,ぼ,ぽ,も,ょ,よ,ろ,を,ォ,オ,コ,ゴ,ソ,ゾ,ト,ド,ノ,ホ,ボ,ポ,モ,ョ,ヨ,ロ,ヲ",
+            "n=ん",
+            "u=ぅ,う,く,ぐ,す,ず,つ,づ,ぬ,ふ,ぶ,ぷ,む,ゅ,ゆ,る,ゥ,ウ,ク,グ,ス,ズ,ツ,ヅ,ヌ,フ,ブ,プ,ム,ュ,ユ,ル,ヴ",
+            "N=ン",
+            "・=・",
+        };
+
+        static readonly string[] consonants = new string[] {
+            "tS=ち,ちぇ,ちゃ,ちゅ,ちょ",
+            "g'=ぎ,ぎぇ,ぎゃ,ぎゅ,ぎょ",
+            "ts=つ,つぁ,つぃ,つぇ,つぉ",
+            "p'=ぴ,ぴぇ,ぴゃ,ぴゅ,ぴょ",
+            "4'=り,りぇ,りゃ,りゅ,りょ",
+            "l'=リ,リェ,リャ,リュ,リョ",
+            "J=に,にぇ,にゃ,にゅ,にょ",
+            "4=ら,る,るぃ,れ,ろ",
+            "C=ひ,ひぇ,ひゃ,ひゅ,ひょ",
+            "d'=でぃ,でぇ,でゃ,でゅ,でょ",
+            "b'=び,びぇ,びゃ,びゅ,びょ",
+            "b=ば,ぶ,ぶぃ,べ,ぼ",
+            "d=だ,で,ど,どぃ,どぅ",
+            "g=が,ぐ,ぐぃ,げ,ご",
+            "p\\=ふ,ふぁ,ふぃ,ふぇ,ふぉ",
+            "h=は,はぃ,へ,ほ,ほぅ",
+            "k=か,く,くぃ,け,こ",
+            "Z=じ,じぇ,じゃ,じゅ,じょ,ぢ,ぢぇ,ぢゃ,ぢゅ,ぢょ",
+            "m=ま,む,むぃ,め,も",
+            "n=な,ぬ,ぬぃ,ね,の",
+            "p=ぱ,ぷ,ぷぃ,ぺ,ぽ",
+            "s=さ,す,すぃ,せ,そ",
+            "S=し,しぇ,しゃ,しゅ,しょ",
+            "t=た,て,と,とぃ,とぅ,てぃ,てぇ,てゃ,てゅ,てょ",
+            "v=ヴ,ヴぁ,ヴぃ,ヴぅ,ヴぇ,ヴぉ",
+            "k'=き,きぇ,きゃ,きゅ,きょ",
+            "w=うぃ,うぅ,うぇ,うぉ,わ,ゐ,ゑ,を,ヰ,ヱ",
+            "j=いぃ,いぇ,や,ゆ,よ",
+            "z=ざ,ず,ずぃ,ぜ,ぞ",
+            "dz=づ,づぃ",
+            "m'=み,みぇ,みゃ,みゅ,みょ",
+            "ng=ガ,ギ,グ,ゲ,ゴ,ギェ,ギャ,ギュ,ギョ,カ゜,キ゜,ク゜,ケ゜,コ゜,キ゜ェ,キ゜ャ,キ゜ュ,キ゜ョ",
+            "l=ラ,ル,レ,ロ",
+            "・=・あ,・い,・う,・え,・お,・ん,・を,・ン",
+        };
+
+        // in case voicebank is missing certain symbols
+        static readonly string[] substitution = new string[] {
+            "t',tS,ts=t", "Z,d'=d", "g'=g", "k'=k", "p'=p", "J=n", "4'=4", "C,p\\=h", "b',v=b", "dz=z", "l=4", "l'=l"
+        };
+
+        static readonly Dictionary<string, string> vowelLookup;
+        static readonly Dictionary<string, string> consonantLookup;
+        static readonly Dictionary<string, string> substituteLookup;
+
+        static JapaneseXsampaCVVCPhonemizer() {
+            vowelLookup = vowels.ToList()
+                .SelectMany(line => {
+                    var parts = line.Split('=');
+                    return parts[1].Split(',').Select(cv => (cv, parts[0]));
+                })
+                .ToDictionary(t => t.Item1, t => t.Item2);
+            consonantLookup = consonants.ToList()
+                .SelectMany(line => {
+                    var parts = line.Split('=');
+                    return parts[1].Split(',').Select(cv => (cv, parts[0]));
+                })
+                .ToDictionary(t => t.Item1, t => t.Item2);
+            substituteLookup = substitution.ToList()
+                .SelectMany(line => {
+                    var parts = line.Split('=');
+                    return parts[0].Split(',').Select(orig => (orig, parts[1]));
+                })
+                .ToDictionary(t => t.Item1, t => t.Item2);
+        }
+
+        // Store singer in field, will try reading presamp.ini later
+        private USinger singer;
+        public override void SetSinger(USinger singer) => this.singer = singer;
+
+        // make it quicker to check multiple oto occurrences at once rather than spamming if else if
+        private bool checkOtoUntilHit(string[] input, Note note, out UOto oto){
+            oto = default;
+
+            var attr0 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+            var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
+
+            foreach (string test in input){
+                if (singer.TryGetMappedOto(test, note.tone + attr0.toneShift, attr0.voiceColor, out oto)){
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // can probably be cleaned up more but i have work in the morning. have fun.
+        public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
+            var note = notes[0];
+            var currentUnicode = ToUnicodeElements(note.lyric);
+            var currentLyric = note.lyric;
+            var cfLyric = $"* {currentLyric}";
+            var attr0 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+            var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
+
+            if (prevNeighbour == null) {
+                // Use "- V" or "- CV" if present in voicebank
+                var initial = $"- {currentLyric}";
+                string[] tests = new string[] {initial, currentLyric};
+                // try [- XX] before trying plain lyric
+                if (checkOtoUntilHit(tests, note, out var oto)){
+                    currentLyric = oto.Alias;
+                }
+            } else if (plainVowels.Contains(currentLyric) || nonVowels.Contains(currentLyric)) {
+                var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
+                // Current note is VV
+                if (vowelLookup.TryGetValue(prevUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
+                    var vowLyric = $"{vow} {currentLyric}";
+                    // try vowlyric before cflyric, if both fail try currentlyric
+                    string[] tests = new string[] {vowLyric, cfLyric, currentLyric};
+                    if (checkOtoUntilHit(tests, note, out var oto)){
+                        currentLyric = oto.Alias;
+                    }
+                }
+            } else {
+                string[] tests = new string[] {currentLyric};
+                if (checkOtoUntilHit(tests, note, out var oto)){
+                    currentLyric = oto.Alias;
+                }
+            }
+
+            if (nextNeighbour != null) {
+
+                var nextUnicode = ToUnicodeElements(nextNeighbour?.lyric);
+                var nextLyric = string.Join("", nextUnicode);
+
+                // Check if next note is a vowel and does not require VC
+                if (nextUnicode.Count < 2 && plainVowels.Contains(nextUnicode.FirstOrDefault() ?? string.Empty)) {
+                    return new Result {
+                        phonemes = new Phoneme[] {
+                            new Phoneme() {
+                                phoneme = currentLyric,
+                            }
+                        },
+                    };
+                }
+
+                // Insert VC before next neighbor
+                // Get vowel from current note
+                var vowel = "";
+                if (vowelLookup.TryGetValue(currentUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
+                    vowel = vow;
+                }
+
+                // Get consonant from next note
+                var consonant = "";
+                if (consonantLookup.TryGetValue(nextUnicode.FirstOrDefault() ?? string.Empty, out var con)
+                    || nextUnicode.Count >= 2 && consonantLookup.TryGetValue(string.Join("", nextUnicode.Take(2)), out con)) {
+                    consonant = con;
+                }
+
+
+                if (consonant == "") {
+                    return new Result {
+                        phonemes = new Phoneme[] {
+                            new Phoneme() {
+                                phoneme = currentLyric,
+                            }
+                        },
+                    };
+                }
+
+                var vcPhoneme = $"{vowel} {consonant}";
+                var vcPhonemes = new string[] {vcPhoneme, ""};
+                // find potential substitute symbol
+                if (substituteLookup.TryGetValue(consonant ?? string.Empty, out con)){
+                        vcPhonemes[1] = $"{vowel} {con}";
+                }
+                //if (singer.TryGetMappedOto(vcPhoneme, note.tone + attr0.toneShift, attr0.voiceColor, out var oto1)) {
+                if (checkOtoUntilHit(vcPhonemes, note, out var oto1)) {
+                    vcPhoneme = oto1.Alias;
+                } else {
+                    return new Result {
+                        phonemes = new Phoneme[] {
+                            new Phoneme() {
+                                phoneme = currentLyric,
+                            }
+                        },
+                    };
+                }
+
+                int totalDuration = notes.Sum(n => n.duration);
+                int vcLength = 120;
+                var nextAttr = nextNeighbour.Value.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+                if (singer.TryGetMappedOto(nextLyric, nextNeighbour.Value.tone + nextAttr.toneShift, nextAttr.voiceColor, out var oto)) {
+                    vcLength = MsToTick(oto.Preutter);
+                }
+                vcLength = Math.Min(totalDuration / 2, vcLength);
+
+                return new Result {
+                    phonemes = new Phoneme[] {
+                        new Phoneme() {
+                            phoneme = currentLyric,
+                        },
+                        new Phoneme() {
+                            phoneme = vcPhoneme,
+                            position = totalDuration - vcLength,
+                        }
+                    },
+                };
+            }
+
+            // No next neighbor
+            return new Result {
+                phonemes = new Phoneme[] {
+                    new Phoneme {
+                        phoneme = currentLyric,
+                    }
+                },
+            };
+        }
+    }
+}


### PR DESCRIPTION
* Sorry, please don't merge yet as I will try to fix a few more things.

Japanese CVVC Phonemizerを複製してJapanese X-SAMPA CVVC Phonemizerを作成。X-SAMPA表記のJP CVVCに対応

Japanese CVVC Phonemizerを、CVVCとVCVが混ざっている場合にVCVを優先するよう変更。
CVのOverlapがマイナス値のとき、VCの長さを伸ばすよう変更（presamp準拠の動作）
次のノートのVelによってVCの長さが変わるよう変更
[a R]の直後は[- CV]を使うよう変更
* これらはまだJapanese X-SAMPA CVVC Phonemizerに反映されていません