### PR TITLE
Fix disappearing notes on plugin execution

### DIFF
--- a/OpenUtau.Core/Classic/Ust.cs
+++ b/OpenUtau.Core/Classic/Ust.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -169,7 +169,12 @@ namespace OpenUtau.Classic {
         }
 
         private static void ParseNote(UNote note, int lastNotePos, int lastNoteEnd, List<IniLine> iniLines, out float? noteTempo) {
-            var ustNote = new UstNote();
+            var ustNote = new UstNote {
+                lyric = note.lyric,
+                position = note.position,
+                duration = note.duration,
+                noteNum = note.tone
+            };
             ustNote.Parse(lastNotePos, lastNoteEnd, iniLines, out noteTempo);
             note.lyric = ustNote.lyric;
             note.position = ustNote.position;


### PR DESCRIPTION
- Any missing values after the plugin runs will use the existing block values. 
  - Because the plugin sometimes returns only some blocks.
  - Value is Lyric, Position, Duration, Tone. (Where null was setting)
- Create a simple unit test.

Other values are either already supported or not supported yet.
not supported value is need to fix separately. (ex. flags)
But I think many plugins work with this fix.


