### PR TITLE
Defaults to paging instead of scrolling

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -102,7 +102,7 @@ namespace OpenUtau.Core.Util {
             public bool PreferPortAudio = false;
             public double PlayPosMarkerMargin = 0.9;
             public int LockStartTime = 0;
-            public int PlaybackAutoScroll = 1;
+            public int PlaybackAutoScroll = 2;
             public bool ReverseLogOrder = true;
             public bool ShowPortrait = true;
             public bool ShowGhostNotes = true;


### PR DESCRIPTION
Before this change, OpenUtau defaults to scrolling which looks laggy, and it isn't that useful in tuning because users have to focus on moving notes. This PR changes the default behaviour to paging.