### PR TITLE
[ES VCCV] Add stop consonant/affricate CC ValidateAlias

### DIFF
--- a/OpenUtau.Plugin.Builtin/SpanishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SpanishVCCVPhonemizer.cs
@@ -306,6 +306,9 @@ namespace OpenUtau.Plugin.Builtin {
             foreach (var consonant in new[] { "U" }) {
                 alias = alias.Replace("U", "w");
             }
+            foreach (var CC in new[] { " k", " p", " ch" }) {
+                alias = alias.Replace(CC, " t");
+            }
             foreach (var consonant in new[] { "b" }) {
                 alias = alias.Replace("b", "B");
             }


### PR DESCRIPTION
Uses ``t`` as a CC fallback when ``p``, ``k``, and/or ``ch`` are not present.