### PR TITLE
Flag filter based on resampler manifests

### DIFF
--- a/OpenUtau.Core/Classic/ClassicRenderer.cs
+++ b/OpenUtau.Core/Classic/ClassicRenderer.cs
@@ -134,25 +134,13 @@ namespace OpenUtau.Classic {
         }
 
         public UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings) {
-            var resamplerPath = renderSettings.Resampler.FilePath;
-            if (resamplerPath == null) {
+            var manifest= renderSettings.Resampler.Manifest;
+            if (manifest == null) {
                 return new UExpressionDescriptor[] { };
             }
-            var resamplerManifestPath = Path.ChangeExtension(resamplerPath, ".yaml");
-            try {
-                return Yaml.DefaultDeserializer.Deserialize<ResamplerManifest>(
-                    File.ReadAllText(resamplerManifestPath, encoding:Encoding.UTF8)
-                    ).expressions.Values.ToArray();
-            } catch (Exception ex) {
-                Log.Error($"Failed loading suggested expressions from {resamplerManifestPath}: {ex}");
-            }
-            return new UExpressionDescriptor[] { };
+            return manifest.expressions.Values.ToArray();
         }
 
         public override string ToString() => Renderers.CLASSIC;
-    }
-
-    public class ResamplerManifest {
-        public Dictionary<string,UExpressionDescriptor> expressions = new Dictionary<string, UExpressionDescriptor> { };
     }
 }

--- a/OpenUtau.Core/Classic/ExeResampler.cs
+++ b/OpenUtau.Core/Classic/ExeResampler.cs
@@ -7,6 +7,7 @@ using NAudio.Wave;
 using OpenUtau.Core;
 using OpenUtau.Core.Format;
 using OpenUtau.Core.Util;
+using OpenUtau.Core.Ustx;
 using Serilog;
 
 namespace OpenUtau.Classic {
@@ -75,6 +76,13 @@ namespace OpenUtau.Classic {
             }
             int mode = (7 << 6) | (5 << 3) | 5;
             chmod(FilePath, mode);
+        }
+
+        public bool SupportsFlag(string abbr) {
+            if(Manifest == null || !Manifest.expressionFilter){
+                return true;
+            }
+            return Manifest.expressions.ContainsKey(abbr);
         }
 
         public override string ToString() => _name;

--- a/OpenUtau.Core/Classic/ExeResampler.cs
+++ b/OpenUtau.Core/Classic/ExeResampler.cs
@@ -14,8 +14,24 @@ namespace OpenUtau.Classic {
         public string Name { get; private set; }
         public string FilePath { get; private set; }
         public bool isLegalPlugin => _isLegalPlugin;
+        public ResamplerManifest Manifest { get; private set; }
         readonly string _name;
         readonly bool _isLegalPlugin = false;
+
+
+        public ResamplerManifest LoadManifest() {
+            try {
+                var ManifestPath = Path.ChangeExtension(FilePath, ".yaml");
+                if (!File.Exists(ManifestPath)) {
+                    //TODO: Write Resampler Manifests shipped by OpenUtau
+                    return new ResamplerManifest();
+                }
+                return ResamplerManifest.Load(ManifestPath);
+            } catch (Exception ex) {
+                Log.Error($"Failed loading resampler manifest for {_name}: {ex}");
+                return new ResamplerManifest();
+            }
+        }
 
         public ExeResampler(string filePath, string basePath) {
             if (File.Exists(filePath)) {
@@ -23,6 +39,8 @@ namespace OpenUtau.Classic {
                 _name = Path.GetRelativePath(basePath, filePath);
                 _isLegalPlugin = true;
             }
+            //Load Resampler Manifest
+            Manifest = LoadManifest();
         }
 
         public float[] DoResampler(ResamplerItem args, ILogger logger) {

--- a/OpenUtau.Core/Classic/IResampler.cs
+++ b/OpenUtau.Core/Classic/IResampler.cs
@@ -6,5 +6,6 @@ namespace OpenUtau.Classic {
         float[] DoResampler(ResamplerItem args, ILogger logger);
         string DoResamplerReturnsFile(ResamplerItem args, ILogger logger);
         void CheckPermissions();
+        ResamplerManifest Manifest {  get; }
     }
 }

--- a/OpenUtau.Core/Classic/IResampler.cs
+++ b/OpenUtau.Core/Classic/IResampler.cs
@@ -1,4 +1,5 @@
-﻿using Serilog;
+﻿using OpenUtau.Core.Ustx;
+using Serilog;
 
 namespace OpenUtau.Classic {
     public interface IResampler {
@@ -7,5 +8,6 @@ namespace OpenUtau.Classic {
         string DoResamplerReturnsFile(ResamplerItem args, ILogger logger);
         void CheckPermissions();
         ResamplerManifest Manifest {  get; }
+        bool SupportsFlag(string abbr);
     }
 }

--- a/OpenUtau.Core/Classic/ResamplerItem.cs
+++ b/OpenUtau.Core/Classic/ResamplerItem.cs
@@ -21,7 +21,7 @@ namespace OpenUtau.Classic {
         public string outputFile;
         public int tone;
 
-        public Tuple<string, int?>[] flags;
+        public Tuple<string, int?, string>[] flags;//flag, value, abbr
         public int velocity;
         public int volume;
         public int modulation;
@@ -49,7 +49,7 @@ namespace OpenUtau.Classic {
             inputTemp = VoicebankFiles.Inst.GetSourceTempPath(phrase.singer.Id, phone.oto, ".wav");
             tone = phone.tone;
 
-            flags = phone.flags;
+            flags = phone.flags.Where(flag=>resampler.SupportsFlag(flag.Item3)).ToArray();
             velocity = (int)(phone.velocity * 100);
             volume = (int)(phone.volume * 100);
             modulation = (int)(phone.modulation * 100);

--- a/OpenUtau.Core/Classic/ResamplerManifest.cs
+++ b/OpenUtau.Core/Classic/ResamplerManifest.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+
+namespace OpenUtau.Classic {
+    public class ResamplerManifest {
+        public Dictionary<string, UExpressionDescriptor> expressions = new Dictionary<string, UExpressionDescriptor> { };
+        public bool expressionFilter = false;
+
+        public ResamplerManifest() { }
+
+        public static ResamplerManifest Load(string path) {
+            return Yaml.DefaultDeserializer.Deserialize<ResamplerManifest>(
+                File.ReadAllText(path, encoding: Encoding.UTF8)
+                );
+        }
+    }
+}

--- a/OpenUtau.Core/Classic/UstNote.cs
+++ b/OpenUtau.Core/Classic/UstNote.cs
@@ -141,7 +141,7 @@ namespace OpenUtau.Classic {
             }
         }
 
-        string FlagsToString(Tuple<string, int?>[] flags) {
+        string FlagsToString(Tuple<string, int?, string>[] flags) {
             var builder = new StringBuilder();
             foreach (var flag in flags) {
                 builder.Append(flag.Item1);

--- a/OpenUtau.Core/Classic/WorldlineResampler.cs
+++ b/OpenUtau.Core/Classic/WorldlineResampler.cs
@@ -31,6 +31,8 @@ namespace OpenUtau.Classic {
 
         public void CheckPermissions() { }
 
+        public ResamplerManifest Manifest { get; } = new ResamplerManifest();
+
         public override string ToString() => name;
     }
 }

--- a/OpenUtau.Core/Classic/WorldlineResampler.cs
+++ b/OpenUtau.Core/Classic/WorldlineResampler.cs
@@ -3,6 +3,7 @@ using NAudio.Wave;
 using OpenUtau.Core;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.SignalChain;
+using OpenUtau.Core.Ustx;
 using Serilog;
 
 namespace OpenUtau.Classic {
@@ -31,7 +32,12 @@ namespace OpenUtau.Classic {
 
         public void CheckPermissions() { }
 
+        //TODO: A list of flags supported by worldline resampler
         public ResamplerManifest Manifest { get; } = new ResamplerManifest();
+
+        public bool SupportsFlag(string abbr) {
+            return true;
+        }
 
         public override string ToString() => name;
     }

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -58,7 +58,7 @@ namespace OpenUtau.Core.Render {
         public readonly double durCorrectionMs;
         public readonly string resampler;
         public readonly double adjustedTempo;
-        public readonly Tuple<string, int?>[] flags;
+        public readonly Tuple<string, int?, string>[] flags;// flag, value, abbr. Abbr is kept here for flag filtering.
         public readonly string suffix;
         public readonly float volume;
         public readonly float velocity;

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using YamlDotNet.Serialization;
+using OpenUtau.Core.Render;
 
 namespace OpenUtau.Core.Ustx {
     public class UPhoneme {
@@ -199,19 +200,19 @@ namespace OpenUtau.Core.Ustx {
             }
         }
 
-        public Tuple<string, int?>[] GetResamplerFlags(UProject project, UTrack track) {
-            var flags = new List<Tuple<string, int?>>();
+        public Tuple<string, int?, string>[] GetResamplerFlags(UProject project, UTrack track) {
+            var flags = new List<Tuple<string, int?, string>>();
             foreach (var descriptor in project.expressions.Values) {
                 if (descriptor.type == UExpressionType.Numerical) {
                     if (!string.IsNullOrEmpty(descriptor.flag)) {
                         int value = (int)GetExpression(project, track, descriptor.abbr).Item1;
-                        flags.Add(Tuple.Create<string, int?>(descriptor.flag, value));
+                        flags.Add(Tuple.Create<string, int?, string>(descriptor.flag, value, descriptor.abbr));
                     }
                 }
                 if (descriptor.type == UExpressionType.Options) {
                     if (descriptor.isFlag) {
                         int value = (int)GetExpression(project, track, descriptor.abbr).Item1;
-                        flags.Add(Tuple.Create<string, int?>(descriptor.options[value], null));
+                        flags.Add(Tuple.Create<string, int?, string>(descriptor.options[value], null, descriptor.abbr));
                     }
                 }
             }


### PR DESCRIPTION
Many resamplers are unable to parse flags correctly when there are moresampler-specific flags, because most resamplers only use single-character flags, but moresampler uses multi-character flags, such as "Mt", "Me", "Mb". To solve this issue, we can pass only the supported flags (specified in resampler manifest) into the resampler.

This filter uses the abbr of flags to check if it is supported, because a flag char could function differently on different resamplers. It is off by default to avoid breaking existing ustx files. To enable this filter, add this line into the resampler manifest:
```
expression_filter: true
```

![image](https://github.com/stakira/OpenUtau/assets/54425948/ea519a68-2ae5-49ae-ba2e-0b114e8336bd)

Full resampler manifest example (tn_fnds.yaml):
```
expression_filter: True
expressions:
  amp:
    abbr: amp
    default_value: 0
    flag: A
    is_flag: true
    max: 100
    min: -100
    name: Amplitude Modulation
    type: Numerical
  bre:
    abbr: bre
    default_value: 0
    flag: B
    is_flag: true
    max: 100
    min: 50
    name: Breath
    type: Numerical
  bri:
    abbr: bri
    default_value: 0
    flag: O
    is_flag: true
    max: 100
    min: 0
    name: Brightness
    type: Numerical
  fstr:
    abbr: fstr
    is_flag: true
    name: Force Stretch
    options:
    - ''
    - e
    - Me
    type: Options
  gen:
    abbr: gen
    default_value: 0
    flag: g
    is_flag: true
    max: 100
    min: -100
    name: Gender
    type: Numerical
  pit:
    abbr: pit
    default_value: 0
    flag: t
    is_flag: true
    max: 1200
    min: -1200
    name: Pitch deviation (flag)
    type: Numerical
```