### PR TITLE
fix en-US language saving and loading

### DIFF
--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -61,6 +61,8 @@ namespace OpenUtau.App {
                 Current.Resources.MergedDictionaries.Remove(resDict);
                 Current.Resources.MergedDictionaries.Add(resDict);
                 var langName = resDict.Source.OriginalString.Replace("/Strings/Strings", "").Replace(".", "").Replace("axaml", "");
+                if (langName == "") 
+                    langName = language;
                 if (Core.Util.Preferences.Default.Language != langName) {
                     Core.Util.Preferences.Default.Language = langName;
                     Core.Util.Preferences.Save();

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -60,7 +60,7 @@ namespace OpenUtau.App {
             if (resDict != null) {
                 Current.Resources.MergedDictionaries.Remove(resDict);
                 Current.Resources.MergedDictionaries.Add(resDict);
-                var langName = resDict.Source.OriginalString.Replace("/Strings/Strings.", "").Replace(".axaml", "");
+                var langName = resDict.Source.OriginalString.Replace("/Strings/Strings", "").Replace(".", "").Replace("axaml", "");
                 if (Core.Util.Preferences.Default.Language != langName) {
                     Core.Util.Preferences.Default.Language = langName;
                     Core.Util.Preferences.Save();


### PR DESCRIPTION
fixes a crash when opening preferences caused by en-US loading as "axaml" instead of "en-US"

also fixes singers appearing to not load due to en-US not loading as a valid sort order