### PR TITLE
[JA CVVC] Add alternate support

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
@@ -106,8 +106,10 @@ namespace OpenUtau.Plugin.Builtin {
             var attr0 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
             var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
 
-            foreach (string test in input){
-                if (singer.TryGetMappedOto(test, note.tone + attr0.toneShift, attr0.voiceColor, out oto)){
+            foreach (string test in input) {
+                if (singer.TryGetMappedOto(test + attr0.alternate, note.tone + attr0.toneShift, attr0.voiceColor, out oto)) {
+                    return true;
+                } else if (singer.TryGetMappedOto(test, note.tone + attr0.toneShift, attr0.voiceColor, out oto)) {
                     return true;
                 }
             }


### PR DESCRIPTION
This time, there should be no issue with null alternates. When the alternate is null, it will instead return the mapped note without alternate.
**Example:** if ``[a あ2]`` does not exist, ``[a あ]`` will be returned.