### PR TITLE
[ZH CVV Phonemizer] Use new mapping style + voice color support + "yan" vowel fix + "_un" ending alternative

### DIFF
--- a/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
@@ -34,9 +34,6 @@ namespace OpenUtau.Plugin.Builtin {
 
         // Simply stores the singer in a field.
         public override void SetSinger(USinger singer) => this.singer = singer;
-        
-        // Legacy mapping. Might adjust later to new mapping style.
-		public override bool LegacyMapping => true;
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             // The overall logic is:
@@ -44,6 +41,7 @@ namespace OpenUtau.Plugin.Builtin {
             // 2. Lookup the trailing sound in vowel table: "uang" -> "_ang".
             // 3. Split the total duration and returns "duang" and "_ang".
             var lyric = notes[0].lyric;
+            var note = notes[0];
             string consonant = string.Empty;
             string vowel = string.Empty;
             if (lyric.Length > 2 && cSet.Contains(lyric.Substring(0, 2))) {
@@ -62,6 +60,16 @@ namespace OpenUtau.Plugin.Builtin {
                 vowel = "v" + vowel.Substring(1);
             }
             string phoneme0 = lyric;
+            // Get color
+            string color = string.Empty;
+            int toneShift = 0;
+            int? alt = null;
+            if (note.phonemeAttributes != null) {
+                var attr = note.phonemeAttributes.FirstOrDefault(attr => attr.index == 0);
+                color = attr.voiceColor;
+                toneShift = attr.toneShift;
+                alt = attr.alternate;
+            }
             // We will need to split the total duration for phonemes, so we compute it here.
             int totalDuration = notes.Sum(n => n.duration);
             // Lookup the vowel split table. For example, "uang" will match "_ang".
@@ -71,6 +79,17 @@ namespace OpenUtau.Plugin.Builtin {
                 int length1 = 120;
                 if (length1 > totalDuration / 2) {
                     length1 = totalDuration / 2;
+                }
+                if (singer.TryGetMappedOto(phoneme0 + alt, note.tone + toneShift, color, out var otoAlt0)) {
+                    phoneme0 = otoAlt0.Alias;
+                } else if (singer.TryGetMappedOto(phoneme0, note.tone + toneShift, color, out var oto)) {
+                    phoneme0 = oto.Alias;
+                }
+
+                if (singer.TryGetMappedOto(phoneme1 + alt, note.tone + toneShift, color, out var otoAlt1)) {
+                    phoneme1 = otoAlt1.Alias;
+                } else if (singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto)) {
+                    phoneme1 = oto.Alias;
                 }
                 return new Result {
                     phonemes = new Phoneme[] {
@@ -84,6 +103,11 @@ namespace OpenUtau.Plugin.Builtin {
                     },
                 };
             }
+            if (singer.TryGetMappedOto(phoneme0 + alt, note.tone + toneShift, color, out var otoAlt)) {
+                phoneme0 = otoAlt.Alias;
+            } else if (singer.TryGetMappedOto(phoneme0, note.tone + toneShift, color, out var oto)) {
+                phoneme0 = oto.Alias;
+            }
             // Not spliting is needed. Return as is.
             return new Result {
                 phonemes = new Phoneme[] {
@@ -95,3 +119,4 @@ namespace OpenUtau.Plugin.Builtin {
         }
     }
 }
+

--- a/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
@@ -59,6 +59,10 @@ namespace OpenUtau.Plugin.Builtin {
             if ((vowel == "un" || vowel == "uan") && (consonant == "j" || consonant == "q" || consonant == "x" || consonant == "y")) {
                 vowel = "v" + vowel.Substring(1);
             }
+
+            if ((vowel == "an") && (consonant == "y")) {
+                vowel = "ian";
+            }
             string phoneme0 = lyric;
             // Get color
             string color = string.Empty;
@@ -130,4 +134,3 @@ namespace OpenUtau.Plugin.Builtin {
         }
     }
 }
-

--- a/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
@@ -67,12 +67,10 @@ namespace OpenUtau.Plugin.Builtin {
             // Get color
             string color = string.Empty;
             int toneShift = 0;
-            int? alt = null;
             if (note.phonemeAttributes != null) {
                 var attr = note.phonemeAttributes.FirstOrDefault(attr => attr.index == 0);
                 color = attr.voiceColor;
                 toneShift = attr.toneShift;
-                alt = attr.alternate;
             }
             // We will need to split the total duration for phonemes, so we compute it here.
             int totalDuration = notes.Sum(n => n.duration);
@@ -84,26 +82,18 @@ namespace OpenUtau.Plugin.Builtin {
                 if (length1 > totalDuration / 2) {
                     length1 = totalDuration / 2;
                 }
-                if (singer.TryGetMappedOto(phoneme0 + alt, note.tone + toneShift, color, out var otoAlt0)) {
-                    phoneme0 = otoAlt0.Alias;
-                } else if (singer.TryGetMappedOto(phoneme0, note.tone + toneShift, color, out var oto)) {
-                    phoneme0 = oto.Alias;
+                if (singer.TryGetMappedOto(phoneme0, note.tone + toneShift, color, out var oto0)) {
+                    phoneme0 = oto0.Alias;
                 }
 
-                if (singer.TryGetMappedOto(phoneme1 + alt, note.tone + toneShift, color, out var otoAlt1)) {
-                    phoneme1 = otoAlt1.Alias;
-                } else if (singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto)) {
-                    phoneme1 = oto.Alias;
-                }
-
-                if (phoneme1.Contains("_un") && !singer.TryGetMappedOto(phoneme1 + alt, note.tone + toneShift, color, out var otoAlt2)) {
-                    phoneme1 = "_en";
-                } else if (phoneme1.Contains("_un") && !singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto0)) {
-                    phoneme1 = "_en";
-                } else if (phoneme1.Contains("_un") && singer.TryGetMappedOto(phoneme1 + alt, note.tone + toneShift, color, out var oto1)) {
+                if (singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto1)) {
                     phoneme1 = oto1.Alias;
-                } else if (phoneme1.Contains("_un") && singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto)) {
-                    phoneme1 = oto.Alias;
+                }
+
+                if (phoneme1.Contains("_un") && !singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto2)) {
+                    phoneme1 = "_en";
+                } else if (phoneme1.Contains("_un") && singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto3)) {
+                    phoneme1 = oto3.Alias;
                 }
 
                 return new Result {
@@ -118,9 +108,7 @@ namespace OpenUtau.Plugin.Builtin {
                     },
                 };
             }
-            if (singer.TryGetMappedOto(phoneme0 + alt, note.tone + toneShift, color, out var otoAlt)) {
-                phoneme0 = otoAlt.Alias;
-            } else if (singer.TryGetMappedOto(phoneme0, note.tone + toneShift, color, out var oto)) {
+            if (singer.TryGetMappedOto(phoneme0, note.tone + toneShift, color, out var oto)) {
                 phoneme0 = oto.Alias;
             }
             // Not spliting is needed. Return as is.

--- a/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core;
@@ -91,6 +91,17 @@ namespace OpenUtau.Plugin.Builtin {
                 } else if (singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto)) {
                     phoneme1 = oto.Alias;
                 }
+
+                if (phoneme1.Contains("_un") && !singer.TryGetMappedOto(phoneme1 + alt, note.tone + toneShift, color, out var otoAlt2)) {
+                    phoneme1 = "_en";
+                } else if (phoneme1.Contains("_un") && !singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto0)) {
+                    phoneme1 = "_en";
+                } else if (phoneme1.Contains("_un") && singer.TryGetMappedOto(phoneme1 + alt, note.tone + toneShift, color, out var oto1)) {
+                    phoneme1 = oto1.Alias;
+                } else if (phoneme1.Contains("_un") && singer.TryGetMappedOto(phoneme1, note.tone + toneShift, color, out var oto)) {
+                    phoneme1 = oto.Alias;
+                }
+
                 return new Result {
                     phonemes = new Phoneme[] {
                         new Phoneme() {


### PR DESCRIPTION
- Use new mapping style instead of legacy mapping;
- Add voice color support;
- "yan" vowel fix (it should use ``[_en2]`` instead);
- If ``[_un]`` does not exist in the oto, use ``[_en]`` instead.

I've removed alternate support for now, due to some issues.