### PR TITLE
Pitch Baking: fix PITD erasing region misplaced, process the whole part by default

### DIFF
--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -332,6 +332,7 @@ namespace OpenUtau.Core.Editing {
         * Wikipedia: https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm
         * Implementation reference: https://rosettacode.org/wiki/Ramer-Douglas-Peucker_line_simplification
         * */
+        //perpendicularDistance is replaced with deltaY, because the units of X and Y are different. 
         List<Point> simplifyShape(List<Point> pointList, Double epsilon) {
             if (pointList.Count <= 2) {
                 return pointList;
@@ -476,7 +477,8 @@ namespace OpenUtau.Core.Editing {
                 }
             }
             docManager.StartUndoGroup(true);
-            foreach(var note in selectedNotes) {
+            //Apply pitch points to notes
+            foreach(var note in notes) {
                 if (pitchPointsPerNote.TryGetValue(note.position, out var tickRangeAndPitch)) {
                     var pitch = tickRangeAndPitch.Item3;
                     docManager.ExecuteCmd(new ResetPitchPointsCommand(part, note));
@@ -492,17 +494,20 @@ namespace OpenUtau.Core.Editing {
                     
                 }
             }
-            foreach(var note in selectedNotes) {
+            //Erase PITD curve that has been converted to pitch points
+            foreach(var note in notes) {
                 if (pitchPointsPerNote.TryGetValue(note.position, out var tickRangeAndPitch)) {
+                    var start = tickRangeAndPitch.Item1 - part.position;
+                    var end = tickRangeAndPitch.Item2 - part.position;
                     docManager.ExecuteCmd(new SetCurveCommand(project, part, Format.Ustx.PITD, 
-                        tickRangeAndPitch.Item1, 0, 
-                        tickRangeAndPitch.Item1, 0));
+                        start, 0, 
+                        start, 0));
                     docManager.ExecuteCmd(new SetCurveCommand(project, part, Format.Ustx.PITD, 
-                        tickRangeAndPitch.Item2, 0, 
-                        tickRangeAndPitch.Item2, 0));
+                        end, 0, 
+                        end, 0));
                     docManager.ExecuteCmd(new SetCurveCommand(project, part, Format.Ustx.PITD, 
-                        tickRangeAndPitch.Item1, 0, 
-                        tickRangeAndPitch.Item2, 0));
+                        start, 0, 
+                        end, 0));
                 }
             }
             docManager.EndUndoGroup();


### PR DESCRIPTION
1. Before this fix, if the starting position of the part isn't 0, PITD would be erased at the wrong position:
![image](https://github.com/stakira/OpenUtau/assets/54425948/e2671534-abdb-4e4b-810f-bfa3b48976dd)
After this fix:
![image](https://github.com/stakira/OpenUtau/assets/54425948/25173335-e97e-4a78-a32e-ad43f33a69b7)

2. After this fix, if no note is selected when running pitch baking, the whole part will be processed. This behaviour is consistent with the other editing macros.
3. Each note is guaranteed to have at least two points to avoid bugs when the pitch is constant.