### PR TITLE
[KO CVC] "ch" VC fix (romaja/mixed VC)

### DIFF
--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -545,7 +545,7 @@ namespace OpenUtau.Plugin.Builtin {
                         if ((!isAlphaCon(consonant))) { consonant = con; }
                     } else if (nextExist && nextHangeul) {
                         consonant = TNLconsonant;
-                    }
+                    } else if (nextLyric.StartsWith("ch")) { consonant = "ch"; }
 
                     if (!nextHangeul) {
                         VC = TCLplainvowel + " " + consonant;

--- a/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVCPhonemizer.cs
@@ -788,7 +788,7 @@ namespace OpenUtau.Plugin.Builtin {
                     if ((!isAlphaCon(consonant))) { consonant = con; }
                 } else if (nextExist && nextHangeul) {
                     consonant = TNLconsonant;
-                }
+                } else if (nextLyric.StartsWith("ch")) { consonant = "ch"; }
 
                 if (consonant == "") {
                     return new Result {


### PR DESCRIPTION
For some reason, whenever a romaja syllable starts with "ch", VC notes do not grab the "ch", instead returning nothing. Other consonants were unaffected.