### PR TITLE
drag and drop to install .dll phonemizers, .exe resamplers and wavtools

### DIFF
--- a/OpenUtau.Core/Api/PhonemizerInstaller.cs
+++ b/OpenUtau.Core/Api/PhonemizerInstaller.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace OpenUtau.Core.Api
+{
+    public class PhonemizerInstaller
+    {
+        public static void Install(string filePath) {
+            string fileName = Path.GetFileName(filePath);
+            string destName = Path.Combine(PathManager.Inst.PluginsPath, fileName);
+            File.Copy(filePath, destName, true);
+            new Task(() => {
+                DocManager.Inst.ExecuteCmd(new SingersChangedNotification());
+                DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Installed {fileName}"));
+            }).Start(DocManager.Inst.MainScheduler);
+        }
+    }
+}

--- a/OpenUtau.Core/Classic/ExeInstaller.cs
+++ b/OpenUtau.Core/Classic/ExeInstaller.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using OpenUtau;
+using OpenUtau.Core;
+
+namespace Classic {
+    public enum ExeType { resampler, wavtool }
+    public class ExeInstaller {
+        public static void Install(string filePath, ExeType exeType) {
+            string fileName = Path.GetFileName(filePath);
+
+            string destPath = exeType == ExeType.wavtool
+                ? PathManager.Inst.WavtoolsPath
+                : PathManager.Inst.ResamplersPath;
+            string destName = Path.Combine(destPath, fileName);
+            File.Copy(filePath, destName, true);
+            
+            if (OS.IsMacOS()) {
+                //reference: https://github.com/stakira/OpenUtau/wiki/Resamplers-and-Wavtools#macos
+                string MacWrapper = $"RELPATH=\"{fileName}\"\r\n\r\nABSPATH=$(cd \"$(dirname \"$0\")\"; pwd -P)\r\nABSPATH=\"$ABSPATH/$RELPATH\"\r\nif [[ ! -x \"$ABSPATH\" ]]\r\nthen\r\n    chmod +x \"$ABSPATH\"\r\nfi\r\nexec /usr/local/bin/wine32on64 \"$ABSPATH\" \"$@\"";
+                File.WriteAllText(Path.ChangeExtension(destName, ".sh"), MacWrapper, new UTF8Encoding(false));
+            } else if (OS.IsLinux()) {
+                //reference: https://github.com/stakira/OpenUtau/wiki/Resamplers-and-Wavtools#linux
+                string LinuxWrapper = $"#!/bin/bash\r\nLANG=\"ja_JP.UTF8\" wine \"{destName}\" \"${{@,-1}}\"";
+                File.WriteAllText(Path.ChangeExtension(destName, null), LinuxWrapper, new UTF8Encoding(false));
+            }
+
+            new Task(() => {
+                DocManager.Inst.ExecuteCmd(new SingersChangedNotification());
+                DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Installed {fileName}"));
+            }).Start(DocManager.Inst.MainScheduler);
+        }
+    }
+}

--- a/OpenUtau/ViewModels/ExeSetupViewModel.cs
+++ b/OpenUtau/ViewModels/ExeSetupViewModel.cs
@@ -1,0 +1,19 @@
+﻿using ReactiveUI.Fody.Helpers;
+
+namespace OpenUtau.App.ViewModels {
+    public class ExeSetupViewModel : ViewModelBase {
+        public string filePath;
+        [Reactive] public string message { get; set; }
+        public ExeSetupViewModel(string filePath) {
+            this.filePath = filePath;
+            message = "installing " + filePath;
+            if (OS.IsMacOS()) {
+                message += "To use exe resamplers or wavtools on MacOS, please install wine32on64 using following commands:\n"
+                    + "brew tap gcenx/wine\n"
+                    + "brew install --cask --no-quarantine wine-crossover";
+            }else if(OS.IsLinux()) {
+                message += "To use exe resamplers or wavtools on Linux, please install wine from https://www.winehq.org/";
+            }
+        }
+    }
+}

--- a/OpenUtau/Views/ExeSetupDialog.axaml
+++ b/OpenUtau/Views/ExeSetupDialog.axaml
@@ -1,0 +1,28 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" Width="400" Height="200"
+        x:Class="OpenUtau.Views.ExeSetupDialog"
+        Title="ExeSetupDialog">
+  <Grid Margin="{Binding $parent.WindowDecorationMargin}">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="*"/>
+      <RowDefinition Height="50"/>
+    </Grid.RowDefinitions>
+    <TextBlock Margin="20" Grid.Row="0" HorizontalAlignment="Center" VerticalAlignment="Center" Name="Text" TextWrapping="Wrap" MaxWidth="560" Text="{Binding message}"/>
+    <StackPanel Grid.Row="1" HorizontalAlignment="Center" Orientation="Horizontal" Name="Buttons">
+      <StackPanel.Styles>
+        <Style Selector="Button">
+          <Setter Property="Margin" Value="15,0,15,0"/>
+          <Setter Property="MinWidth" Value="80"/>
+        </Style>
+        <Style Selector="Button TextBlock">
+          <Setter Property="TextAlignment" Value="Center"/>
+        </Style>
+      </StackPanel.Styles>
+      <Button Click="InstallAsResampler">Install as resampler</Button>
+      <Button Click="InstallAsWavtool">Install as wavtool</Button>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/OpenUtau/Views/ExeSetupDialog.axaml
+++ b/OpenUtau/Views/ExeSetupDialog.axaml
@@ -3,8 +3,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" Width="400" Height="200"
-        x:Class="OpenUtau.Views.ExeSetupDialog"
-        Title="ExeSetupDialog">
+        x:Class="OpenUtau.App.Views.ExeSetupDialog"
+        Title="Installing exe">
   <Grid Margin="{Binding $parent.WindowDecorationMargin}">
     <Grid.RowDefinitions>
       <RowDefinition Height="*"/>

--- a/OpenUtau/Views/ExeSetupDialog.axaml.cs
+++ b/OpenUtau/Views/ExeSetupDialog.axaml.cs
@@ -5,7 +5,7 @@ using Avalonia.Markup.Xaml;
 using Classic;
 using OpenUtau.App.ViewModels;
 
-namespace OpenUtau.Views {
+namespace OpenUtau.App.Views {
     public partial class ExeSetupDialog : Window {
         public ExeSetupDialog() {
             InitializeComponent();

--- a/OpenUtau/Views/ExeSetupDialog.axaml.cs
+++ b/OpenUtau/Views/ExeSetupDialog.axaml.cs
@@ -1,0 +1,40 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Classic;
+using OpenUtau.App.ViewModels;
+
+namespace OpenUtau.Views {
+    public partial class ExeSetupDialog : Window {
+        public ExeSetupDialog() {
+            InitializeComponent();
+#if DEBUG
+            this.AttachDevTools();
+#endif
+            
+        }
+
+        private void InitializeComponent() {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        public void InstallAsResampler(object sender, RoutedEventArgs arg) {
+            var viewModel = DataContext as ExeSetupViewModel;
+            if (viewModel == null) {
+                return;
+            }
+            ExeInstaller.Install(viewModel.filePath, ExeType.resampler);
+            Close();
+        }
+
+        public void InstallAsWavtool(object sender, RoutedEventArgs arg) {
+            var viewModel = DataContext as ExeSetupViewModel;
+            if (viewModel == null) {
+                return;
+            }
+            ExeInstaller.Install(viewModel.filePath, ExeType.wavtool);
+            Close();
+        }
+    }
+}

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -21,6 +21,7 @@ using OpenUtau.Classic;
 using OpenUtau.Core;
 using OpenUtau.Core.Format;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Views;
 using ReactiveUI;
 using Serilog;
 using Point = Avalonia.Point;
@@ -726,6 +727,16 @@ namespace OpenUtau.App.Views {
                 }
             } else if (ext == Core.Vogen.VogenSingerInstaller.FileExt) {
                 Core.Vogen.VogenSingerInstaller.Install(file);
+            } else if (ext == ".dll") {
+                Core.Api.PhonemizerInstaller.Install(file);
+            } else if (ext == ".exe") {
+                var setup = new ExeSetupDialog() {
+                    DataContext = new ExeSetupViewModel(file)
+                };
+                _ = setup.ShowDialog(this);
+                if (setup.Position.Y < 0) {
+                    setup.Position = setup.Position.WithY(0);
+                }
             } else if (ext == ".mp3" || ext == ".wav" || ext == ".ogg" || ext == ".flac") {
                 try {
                     viewModel.ImportAudio(file);

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -21,7 +21,6 @@ using OpenUtau.Classic;
 using OpenUtau.Core;
 using OpenUtau.Core.Format;
 using OpenUtau.Core.Ustx;
-using OpenUtau.Views;
 using ReactiveUI;
 using Serilog;
 using Point = Avalonia.Point;


### PR DESCRIPTION
After this PR, users will be able to install .dll phonemizers, .exe resamplers and wavtools by dragging it into openutau.

<img width="704" alt="image" src="https://github.com/stakira/OpenUtau/assets/54425948/1fffee4f-3626-43ab-b4db-d7c7b3b32f47">

TODO: The installer automatically creates wine wrapper scripts when installing EXEs on Mac and Linux. I refered to https://github.com/stakira/OpenUtau/wiki/Resamplers-and-Wavtools#macos when developing, but I don't have a mac or linux device so I'm not sure if it works. Does anyone want to test it out?