### PR TITLE
Add support for Classic Ust Flags

### DIFF
--- a/OpenUtau.Core/Classic/Flags/UstFlag.cs
+++ b/OpenUtau.Core/Classic/Flags/UstFlag.cs
@@ -1,0 +1,14 @@
+﻿
+using System;
+
+namespace OpenUtau.Classic.Flags {
+    public class UstFlag {
+        public readonly string Key;
+        public readonly int Value;
+
+        public UstFlag(string key, int value) {
+            Key = key ?? throw new ArgumentNullException(nameof(key));
+            Value = value;
+        }
+    }
+}

--- a/OpenUtau.Core/Classic/Flags/UstFlagParser.cs
+++ b/OpenUtau.Core/Classic/Flags/UstFlagParser.cs
@@ -1,0 +1,64 @@
+﻿
+using System;
+using System.Collections.Generic;
+
+namespace OpenUtau.Classic.Flags {
+    public class UstFlagParser {
+        public IList<UstFlag> Parse(string text) {
+            List<UstFlag> flags = new List<UstFlag>();
+
+            int currentIndex = 0;
+            while (currentIndex < text.Length) {
+                string key = ExtractKey(text, ref currentIndex);
+                int value = ExtractValue(text, ref currentIndex);
+                flags.Add(new UstFlag(key, value));
+            }
+            return flags;
+        }
+
+        private string ExtractKey(string text, ref int currentIndex) {
+            string key = string.Empty;
+
+            if (IsSingleCharacterFlag(text[currentIndex])) {
+                key += text[currentIndex];
+                currentIndex++;
+                return key;
+            }
+            while (currentIndex < text.Length && Char.IsLetter(text[currentIndex])) {
+                key += text[currentIndex];
+                currentIndex++;
+            }
+            return key;
+        }
+
+        private int ExtractValue(string text, ref int currentIndex) {
+            if (currentIndex >= text.Length) {
+                return 0;
+            }
+            int value = 0;
+            bool negative = IsNegative(text[currentIndex], ref currentIndex);
+
+            while (currentIndex < text.Length && Char.IsDigit(text[currentIndex])) {
+                value = (value * 10) + (text[currentIndex] - '0');
+                currentIndex++;
+            }
+            return negative ? -value : value;
+        }
+
+        private bool IsNegative(char input, ref int currentIndex) {
+            if (input == '-') {
+                currentIndex++;
+                return true;
+            }
+            if (input == '+') {
+                currentIndex++;
+            }
+            return false;
+        }
+
+        private bool IsSingleCharacterFlag(char input) {
+            var patterns = new HashSet<char> { 'N' };
+            return patterns.Contains(input);
+        }
+    }
+}

--- a/OpenUtau.Core/Classic/Ust.cs
+++ b/OpenUtau.Core/Classic/Ust.cs
@@ -4,9 +4,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using OpenUtau.Classic.Flags;
 using OpenUtau.Core;
 using OpenUtau.Core.Format;
 using OpenUtau.Core.Ustx;
+using SharpCompress;
 
 namespace OpenUtau.Classic {
 
@@ -102,7 +104,7 @@ namespace OpenUtau.Classic {
                         default:
                             if (int.TryParse(header.Substring(2, header.Length - 3), out var noteIndex)) {
                                 var note = project.CreateNote();
-                                ParseNote(note, lastNotePos, lastNoteEnd, block.lines, out var noteTempo);
+                                ParseNote(note, lastNotePos, lastNoteEnd, block.lines, out var noteTempo, project.expressions);
                                 lastNotePos = note.position;
                                 lastNoteEnd = note.End;
                                 if (note.lyric.ToLowerInvariant() != "r") {
@@ -168,7 +170,7 @@ namespace OpenUtau.Classic {
             }
         }
 
-        private static void ParseNote(UNote note, int lastNotePos, int lastNoteEnd, List<IniLine> iniLines, out float? noteTempo) {
+        private static void ParseNote(UNote note, int lastNotePos, int lastNoteEnd, List<IniLine> iniLines, out float? noteTempo, Dictionary<string, UExpressionDescriptor> expressions) {
             var ustNote = new UstNote {
                 lyric = note.lyric,
                 position = note.position,
@@ -189,12 +191,31 @@ namespace OpenUtau.Classic {
             if (ustNote.modulation != null) {
                 SetExpression(note, Ustx.MOD, 0, ustNote.modulation.Value);
             }
+            if (ustNote.flags != null) {
+                SetFlags(note, ustNote.flags, 0, expressions);
+            }
             if (ustNote.pitch != null) {
                 note.pitch = ustNote.pitch;
             }
             if (ustNote.vibrato != null) {
                 note.vibrato = ustNote.vibrato;
             }
+        }
+
+        private static void SetFlags(UNote note, string flags, int index, Dictionary<string, UExpressionDescriptor> expressions) {
+            var parser = new UstFlagParser();
+            var list = parser.Parse(flags);
+            list.ForEach((flag) => {
+                var abbr = FindAbbrFromFlagKey(expressions, flag);
+                if (abbr != String.Empty) {
+                    SetExpression(note, abbr, index, flag.Value);
+                }
+            });
+        }
+
+        private static string FindAbbrFromFlagKey(Dictionary<string, UExpressionDescriptor> expressions, UstFlag flag) {
+            var exp = expressions.FirstOrDefault(exp => exp.Value.flag == flag.Key);
+            return exp.Value != null ? exp.Value.abbr : String.Empty;
         }
 
         private static void SetExpression(UNote note, string abbr, int index, float value) {
@@ -384,7 +405,7 @@ namespace OpenUtau.Classic {
                         case "[#INSERT]":
                             if (index <= sequence.Count) {
                                 var newNote = project.CreateNote();
-                                ParseNote(newNote, 0, 0, block.lines, out var _);
+                                ParseNote(newNote, 0, 0, block.lines, out var _, project.expressions);
                                 newNote.AfterLoad(project, project.tracks[part.trackNo], part);
                                 sequence.Insert(index, newNote);
                                 toAdd.Add(newNote);
@@ -401,7 +422,7 @@ namespace OpenUtau.Classic {
                             if (index < sequence.Count) {
                                 toRemove.Add(sequence[index]);
                                 var newNote = sequence[index].Clone();
-                                ParseNote(newNote, 0, 0, block.lines, out var _);
+                                ParseNote(newNote, 0, 0, block.lines, out var _, project.expressions);
                                 newNote.AfterLoad(project, project.tracks[part.trackNo], part);
                                 sequence[index] = newNote;
                                 toAdd.Add(newNote);

--- a/OpenUtau.Core/Classic/UstNote.cs
+++ b/OpenUtau.Core/Classic/UstNote.cs
@@ -223,6 +223,9 @@ namespace OpenUtau.Classic {
                             noteTempo = floatValue;
                         }
                         break;
+                    case "Flags":
+                        flags = parts[1];
+                        break;
                     default:
                         break;
                 }

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -179,7 +179,9 @@ namespace OpenUtau.Core.Ustx {
         }
 
         public void SetExpression(UProject project, UTrack track, string abbr, float value) {
-            track.TryGetExpression(project, abbr, out var descriptor);
+            if (!track.TryGetExpression(project, abbr, out var descriptor)) {
+                return;
+            }
             var note = Parent.Extends ?? Parent;
             if (descriptor.defaultValue == value) {
                 note.phonemeExpressions.RemoveAll(

--- a/OpenUtau.Test/Classic/Flags/UstFlagParserTest.cs
+++ b/OpenUtau.Test/Classic/Flags/UstFlagParserTest.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+
+namespace OpenUtau.Classic.Flags {
+    public class UstFlagParserTest {
+        [Fact]
+        public void ParseTest() {
+            // FIXME: no value flag support only "N"
+            var given = "g-10Ny20Y30Mt40";
+
+            // then
+            var parser = new UstFlagParser(); 
+            var result = parser.Parse(given);
+
+            // when
+            Assert.Equal("g", result[0].Key);
+            Assert.Equal(-10, result[0].Value);
+            Assert.Equal("N", result[1].Key);
+            Assert.Equal(0, result[1].Value);
+            Assert.Equal("y", result[2].Key);
+            Assert.Equal(20, result[2].Value);
+            Assert.Equal("Y", result[3].Key);
+            Assert.Equal(30, result[3].Value);
+            Assert.Equal("Mt", result[4].Key);
+            Assert.Equal(40, result[4].Value);
+        }
+    }
+}

--- a/OpenUtau.Test/Classic/PluginRunnerTest.cs
+++ b/OpenUtau.Test/Classic/PluginRunnerTest.cs
@@ -52,7 +52,7 @@ namespace OpenUtau.Classic {
                 first.lyric = "ka";
                 first.duration = 20;
                 first.position = 10;
-                before.Next =first;
+                before.Next = first;
 
                 var second = UNote.Create();
                 second.lyric = "r";
@@ -92,7 +92,8 @@ namespace OpenUtau.Classic {
                 return (writer, text) => {
                     // reserved text assertion
                     var cacheDir = PathManager.Inst.CachePath;
-                    Assert.Equal($@"[#SETTING]
+                    // OSによって出力される改行コードが異なる。
+                    var expected = $@"[#SETTING]
 Tempo=120
 Tracks=1
 CacheDir={cacheDir}
@@ -127,7 +128,12 @@ Length=60
 Lyric=ha
 NoteNum=0
 PreUtterance=
-", text);
+";
+                    // Different line feed code for each OS
+                    var eol = Environment.NewLine;
+                    expected = expected.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", eol);
+                
+                    Assert.Equal(expected, text);
                     writer.Write(text);
                 };
             }

--- a/OpenUtau.Test/Classic/PluginRunnerTest.cs
+++ b/OpenUtau.Test/Classic/PluginRunnerTest.cs
@@ -13,6 +13,13 @@ namespace OpenUtau.Classic {
 
     public class PluginRunnerTest {
 
+        public PluginRunnerTest() {
+            // When Cache directory is nothing in UnitTest
+            if (!Directory.Exists(PathManager.Inst.CachePath)) {
+                Directory.CreateDirectory(PathManager.Inst.CachePath);
+            }
+        }
+
         class ExecuteTestData : IEnumerable<object[]> {
             private readonly List<object[]> testData = new();
 

--- a/OpenUtau.Test/Classic/PluginRunnerTest.cs
+++ b/OpenUtau.Test/Classic/PluginRunnerTest.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Text;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
-using SharpGen.Runtime.Win32;
 using Xunit;
 using static OpenUtau.Classic.PluginRunner;
 

--- a/OpenUtau.Test/Classic/PluginRunnerTest.cs
+++ b/OpenUtau.Test/Classic/PluginRunnerTest.cs
@@ -91,11 +91,11 @@ namespace OpenUtau.Classic {
             private static Action<StreamWriter, string> DoNothingResponse() {
                 return (writer, text) => {
                     // reserved text assertion
-                    var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+                    var cacheDir = PathManager.Inst.CachePath;
                     Assert.Equal($@"[#SETTING]
 Tempo=120
 Tracks=1
-CacheDir={baseDir}Cache
+CacheDir={cacheDir}
 Mode2=True
 [#PREV]
 Length=10

--- a/OpenUtau.Test/Classic/PluginRunnerTest.cs
+++ b/OpenUtau.Test/Classic/PluginRunnerTest.cs
@@ -84,7 +84,6 @@ namespace OpenUtau.Classic {
             private static Action<StreamWriter, string> DoNothingResponse() {
                 return (writer, text) => {
                     // reserved text assertion
-                    File.WriteAllText("Cache/test.test", text);
                     var baseDir = AppDomain.CurrentDomain.BaseDirectory;
                     Assert.Equal($@"[#SETTING]
 Tempo=120


### PR DESCRIPTION
- Read Flags value when open Ust or run Plugin.

This PR includes https://github.com/stakira/OpenUtau/pull/705
I think merging this PR will work.

Combined with the nice fix https://github.com/stakira/OpenUtau/pull/686 we can support classic renderer flags by defining a manifest.


There are some issues with this fix that are not resolved at this time.
- Single character and no value flag support only "N" (because I don't know all flag...)
  - We can do that by adding a flag to `UstFlagParser.IsSingleCharacterFlag`
  - Or we might be able to tell from the manifest.(But I think it is necessary to think about dependencies)
- Adding argument expressions of type `Dictionary<string, UExpressionDescriptor>` 
  - I think it would be better to change this type to some class. However, it is using as is to minimize the influence range.