### PR TITLE
Fix exp selection changes when reloading part

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -965,7 +965,9 @@ namespace OpenUtau.App.Views {
                 // Workaround for new window losing focus.
                 openPianoRollWindow = true;
                 int tick = viewModel.TracksViewModel.PointToTick(e.GetPosition(canvas));
+                string[] pianorollCache = pianoRollWindow.CacheExpressions();
                 DocManager.Inst.ExecuteCmd(new LoadPartNotification(partControl.part, DocManager.Inst.Project, tick));
+                pianoRollWindow.LoadCacheExpressions(pianorollCache);
             }
         }
 

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1277,5 +1277,40 @@ namespace OpenUtau.App.Views {
             }
             return false;
         }
+
+        public string[] CacheExpressions() {
+            NotesViewModel vm = (DataContext as PianoRollViewModel)!.NotesViewModel;
+            return new string[] { vm.SecondaryKey, vm.PrimaryKey };
+        }
+        public void LoadCacheExpressions(string[] cache) {
+            foreach (string key in cache) {
+
+                UExpressionDescriptor exp = (expSelector1.DataContext as ExpSelectorViewModel).Descriptor;
+                if (exp != null && exp.abbr == key) {
+                    expSelector1.SelectExp();
+                    continue;
+                }
+                exp = (expSelector2.DataContext as ExpSelectorViewModel).Descriptor;
+                if (exp != null && exp.abbr == key) {
+                    expSelector2.SelectExp();
+                    continue;
+                }
+                exp = (expSelector3.DataContext as ExpSelectorViewModel).Descriptor;
+                if (exp != null && exp.abbr == key) {
+                    expSelector3.SelectExp();
+                    continue;
+                }
+                exp = (expSelector4.DataContext as ExpSelectorViewModel).Descriptor;
+                if (exp != null && exp.abbr == key) {
+                    expSelector4.SelectExp();
+                    continue;
+                }
+                exp = (expSelector5.DataContext as ExpSelectorViewModel).Descriptor;
+                if (exp != null && exp.abbr == key) {
+                    expSelector5.SelectExp();
+                    continue;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Fixed that exp selected in the piano roll window is reselected when reloading the part

This is a somewhat forceful solution. Perhaps there is a better way.