### PR TITLE
[Breaking change to simpleEnunu] Refactor singer type detection

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankConfig.cs
+++ b/OpenUtau.Core/Classic/VoicebankConfig.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
 using YamlDotNet.Serialization;
 
 namespace OpenUtau.Classic {
@@ -48,6 +49,7 @@ namespace OpenUtau.Classic {
         public string Web;
         public string Version;
         public string DefaultPhonemizer;
+        public USingerType? SingerType = null;
         public SymbolSet SymbolSet { get; set; }
         public Subbank[] Subbanks { get; set; }
 

--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -79,6 +79,21 @@ namespace OpenUtau.Classic {
             }
         }
 
+        public static bool IsEnunuSinger(string dir){
+            var enuconfigFile = Path.Combine(dir, kEnuconfigYaml);
+            if (File.Exists(enuconfigFile)) {
+                return true;
+            }
+            return false;
+        }
+
+        public static USingerType DetectSingerType(string dir){
+            if(IsEnunuSinger(dir)){
+                return USingerType.Enunu;
+            }
+            return USingerType.Classic;
+        }
+
         public static void LoadInfo(Voicebank voicebank, string filePath, string basePath) {
             var dir = Path.GetDirectoryName(filePath);
             var yamlFile = Path.Combine(dir, kCharYaml);
@@ -92,19 +107,17 @@ namespace OpenUtau.Classic {
                     Log.Error(e, $"Failed to load yaml {yamlFile}");
                 }
             }
-            string[] modelPaths = new string[] { dir, dir + @"\model" };
-            foreach (string modelPath in modelPaths) {
-                if (File.Exists(Path.Join(modelPath, kConfigYaml))) {
-                    voicebank.SingerType = USingerType.Enunu;
-                }
+
+            //Singer type
+            //If singer type is declared in character.yaml use it
+            //If not, detect singer type
+            //SimpleEnunu voicebanks (and any upcoming new singer type) should declare their type in character.yaml
+            if(bankConfig != null && bankConfig.SingerType != null){
+                voicebank.SingerType = bankConfig.SingerType.Value;
+            } else {
+                voicebank.SingerType = DetectSingerType(dir);
             }
-            var enuconfigFile = Path.Combine(dir, kEnuconfigYaml);
-            if (File.Exists(enuconfigFile)) {
-                voicebank.SingerType = USingerType.Enunu;
-            }else if(voicebank.SingerType != USingerType.Enunu)
-            {
-                voicebank.SingerType = USingerType.Classic;
-            }
+
             Encoding encoding = Encoding.GetEncoding("shift_jis");
             if (!string.IsNullOrEmpty(bankConfig?.TextFileEncoding)) {
                 encoding = Encoding.GetEncoding(bankConfig.TextFileEncoding);


### PR DESCRIPTION
In OpenUtau.Core/Classic/VoicebankLoader.cs, openutau currently detects voicebank types (classic, enunu, simpleEnunu or my diffsinger) by checking the existance of engine config files, like enuconfig.yaml. This "passive detection" strategy may mess up when more voicebank types are supported.
* A new key, `singer_type` is added into character.yaml to let voicebanks declare their type. It can be `Enunu` or `Classic`.
* SimpleEnunu is removed from singer type detection, as its voicebank structure need to be regulated.
* SimpleEnunu voicebanks (and any upcoming newer singer type) should declare their voicebank types in character.yaml.

I am making this change since there aren't too many enunu voicebanks distributed now, and this change won't cause a broad incompatibility. SimpleEnunu voicebank developers should add a line to their character.yaml:
```
singer_type: Enunu
```