### PR TITLE
Add a dialog when installing .dll phonemizers

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -31,6 +31,8 @@
   <system:String x:Key="dialogs.exitsave.message">The current project contains unsaved changes. Do you want to save it?</system:String>
   <system:String x:Key="dialogs.export.caption">Export</system:String>
   <system:String x:Key="dialogs.export.savefirst">Save project file first</system:String>
+  <system:String x:Key="dialogs.installdll.caption">Installing phonemizer</system:String>
+  <system:String x:Key="dialogs.installdll.message">Installing </system:String>
   <system:String x:Key="dialogs.messagebox.cancel">Cancel</system:String>
   <system:String x:Key="dialogs.messagebox.no">No</system:String>
   <system:String x:Key="dialogs.messagebox.ok">Ok</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -31,6 +31,8 @@
   <system:String x:Key="dialogs.exitsave.message">当前工程有未保存改动。是否保存？</system:String>
   <system:String x:Key="dialogs.export.caption">导出</system:String>
   <system:String x:Key="dialogs.export.savefirst">请先保存工程文件</system:String>
+  <system:String x:Key="dialogs.installdll.caption">安装音素器</system:String>
+  <system:String x:Key="dialogs.installdll.message">安装 </system:String>
   <system:String x:Key="dialogs.messagebox.cancel">取消</system:String>
   <system:String x:Key="dialogs.messagebox.no">否</system:String>
   <system:String x:Key="dialogs.messagebox.ok">好</system:String>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -665,7 +665,14 @@ namespace OpenUtau.App.Views {
             } else if (ext == Core.Vogen.VogenSingerInstaller.FileExt) {
                 Core.Vogen.VogenSingerInstaller.Install(file);
             } else if (ext == ".dll") {
-                Core.Api.PhonemizerInstaller.Install(file);
+                var result = await MessageBox.Show(
+                    this,
+                    ThemeManager.GetString("dialogs.installdll.message")+file,
+                    ThemeManager.GetString("dialogs.installdll.caption"),
+                    MessageBox.MessageBoxButtons.OkCancel);
+                if(result == MessageBox.MessageBoxResult.Ok){                
+                    Core.Api.PhonemizerInstaller.Install(file);
+                }
             } else if (ext == ".exe") {
                 var setup = new ExeSetupDialog() {
                     DataContext = new ExeSetupViewModel(file)


### PR DESCRIPTION
Added a dialog when installing .dll phonemizers because hackers can disguise .dll as .ustx
<img width="707" alt="image" src="https://github.com/stakira/OpenUtau/assets/54425948/9f8aa988-0338-4f1d-92aa-ce7435b9b75a">

Here is an example for this kind of attack. The filename is actually "xtsu.dll" with a unicode reverse char at the beginning
![image](https://github.com/stakira/OpenUtau/assets/54425948/d9d48afc-8ac6-4198-bcc7-bb4c78efea70)
[dll_pretending_to_be_an_ustx.zip](https://github.com/stakira/OpenUtau/files/11777586/dll_pretending_to_be_an_ustx.zip)

