### PR TITLE
Prevent erosion of Windows theme color

### DIFF
--- a/OpenUtau/Colors/DarkTheme.axaml
+++ b/OpenUtau/Colors/DarkTheme.axaml
@@ -16,6 +16,12 @@
   <Color x:Key="BorderColor">#707070</Color>
   <Color x:Key="BorderColorPointerOver">#B0B0B0</Color>
 
+  <Color x:Key="SystemAccentColor">#4EA6EA</Color>
+  <!-- PointerOver -->
+  <Color x:Key="SystemAccentColorLight1">#4EA6EA</Color>
+  <!-- Pressed -->
+  <Color x:Key="SystemAccentColorDark1">#4EA6EA</Color>
+
   <Color x:Key="NeutralAccentColor">#808080</Color>
   <Color x:Key="NeutralAccentColorPointerOver">#A0A0A0</Color>
   <Color x:Key="AccentColor1">#4EA6EA</Color>

--- a/OpenUtau/Colors/LightTheme.axaml
+++ b/OpenUtau/Colors/LightTheme.axaml
@@ -16,6 +16,12 @@
   <Color x:Key="BorderColor">#707070</Color>
   <Color x:Key="BorderColorPointerOver">#B0B0B0</Color>
 
+  <Color x:Key="SystemAccentColor">#4EA6EA</Color>
+  <!-- PointerOver -->
+  <Color x:Key="SystemAccentColorLight1">#4EA6EA</Color>
+  <!-- Pressed -->
+  <Color x:Key="SystemAccentColorDark1">#4EA6EA</Color>
+
   <Color x:Key="NeutralAccentColor">#ADA1B3</Color>
   <Color x:Key="NeutralAccentColorPointerOver">#948A99</Color>
   <Color x:Key="AccentColor1">#4EA6EA</Color>


### PR DESCRIPTION
- Add "SystemAccentColor" in Dark/Light Theme
For the pointer over and pressed colors, the same colors are specified for now, but please change them appropriately.

They will no longer be affected by Windows theme colors :
- The color of the slider when moused over
- Text box borders
- Color of toggle switches

Verified OS : Win10