### PR TITLE
[JA Presamp/CVVC] Fix voice color fallback bug

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
@@ -118,6 +118,9 @@ namespace OpenUtau.Plugin.Builtin {
                 if (otos.Any(oto => (oto.Color ?? string.Empty) == color)) {
                     oto = otos.Find(oto => (oto.Color ?? string.Empty) == color);
                     return true;
+                } else if (otos.Any(oto => (oto.Color ?? string.Empty) != color)) {
+                    oto = otos.Find(oto => (oto.Color ?? string.Empty) != color);
+                    return true;
                 } else {
                     return false;
                 }

--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -289,6 +289,9 @@ namespace OpenUtau.Plugin.Builtin {
             if (otos.Count > 0) {
                 if (otos.Any(oto => (oto.Color ?? string.Empty) == color)) {
                     oto = otos.Find(oto => (oto.Color ?? string.Empty) == color);
+                    return true;
+                } else if (otos.Any(oto => (oto.Color ?? string.Empty) != color)) {
+                    oto = otos.Find(oto => (oto.Color ?? string.Empty) != color);
                     return true;
                 } else {
                     return false;


### PR DESCRIPTION
There was a bug in both of these phonemizers where, if an append voice color contains the same suffix as on the main voice color, the voice color would fall back to having no suffix on that particular pitch. Now it will fall back on the main voice color instead, as intended.