### PR TITLE
Let users choose which file types to remember in "Open Recent"

### DIFF
--- a/OpenUtau.Core/Format/MidiWriter.cs
+++ b/OpenUtau.Core/Format/MidiWriter.cs
@@ -43,6 +43,7 @@ namespace OpenUtau.Core.Format {
         static public UProject LoadProject(string file) {
             UProject project = new UProject();
             Ustx.AddDefaultExpressions(project);
+            project.FilePath = file;
             // Detects lyric encoding
             Encoding lyricEncoding = Encoding.UTF8;
             var encodingDetector = new EncodingDetector();

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -38,6 +38,33 @@ namespace OpenUtau.Core.Util {
             Save();
         }
 
+        public static void AddRecentFileIfEnabled(string filePath){
+            //Users can choose adding .ust, .vsqx and .mid files to recent files or not
+            string ext = Path.GetExtension(filePath);
+            switch(ext){
+                case ".ustx":
+                    AddRecentFile(filePath);
+                    break;
+                case ".mid":
+                    if(Preferences.Default.RememberMid){
+                        AddRecentFile(filePath);
+                    }
+                    break;
+                case ".ust":
+                    if(Preferences.Default.RememberUst){
+                        AddRecentFile(filePath);
+                    }
+                    break;
+                case ".vsqx":
+                    if(Preferences.Default.RememberVsqx){
+                        AddRecentFile(filePath);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
         public static void AddRecentFile(string filePath) {
             if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath)) {
                 return;
@@ -120,6 +147,9 @@ namespace OpenUtau.Core.Util {
             public int OtoEditor = 0;
             public string VLabelerPath = string.Empty;
             public bool Beta = false;
+            public bool RememberMid = false;
+            public bool RememberUst = true;
+            public bool RememberVsqx = true;
         }
     }
 }

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -46,6 +46,7 @@ namespace OpenUtau.Core.Util {
                     AddRecentFile(filePath);
                     break;
                 case ".mid":
+                case ".midi":
                     if(Preferences.Default.RememberMid){
                         AddRecentFile(filePath);
                     }

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -66,7 +66,7 @@ namespace OpenUtau.Core.Util {
             }
         }
 
-        public static void AddRecentFile(string filePath) {
+        private static void AddRecentFile(string filePath) {
             if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath)) {
                 return;
             }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -244,6 +244,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.advanced.beta">Beta</system:String>
   <system:String x:Key="prefs.advanced.lyricshelper">Lyrics Helper</system:String>
   <system:String x:Key="prefs.advanced.lyricshelper.brackets">Lyrics Helper Adds Brackets</system:String>
+  <system:String x:Key="prefs.advanced.rememberfiletypes">Remember these file types in &quot;Open Recent&quot;</system:String>
   <system:String x:Key="prefs.advanced.resamplerlogging">Resampler Logging</system:String>
   <system:String x:Key="prefs.advanced.resamplerlogging.warn">Stores resampler output in log files. This option slows down UI and rendering.</system:String>
   <system:String x:Key="prefs.advanced.stable">Stable</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -244,6 +244,7 @@
   <system:String x:Key="prefs.advanced.beta">Beta测试版</system:String>
   <!--<system:String x:Key="prefs.advanced.lyricshelper">Lyrics Helper</system:String>-->
   <!--<system:String x:Key="prefs.advanced.lyricshelper.brackets">Lyrics Helper Adds Brackets</system:String>-->
+  <system:String x:Key="prefs.advanced.rememberfiletypes">在&quot;最近打开&quot;中记住以下文件格式</system:String>
   <system:String x:Key="prefs.advanced.resamplerlogging">重采样器日志</system:String>
   <system:String x:Key="prefs.advanced.resamplerlogging.warn">在日志文件中保存重采样器输出。这个选项会使UI和渲染性能下降。</system:String>
   <system:String x:Key="prefs.advanced.stable">稳定版</system:String>

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -257,9 +257,9 @@ namespace OpenUtau.App.ViewModels {
                     ProgressText = progressBarNotification.Info;
                 });
             } else if (cmd is LoadProjectNotification loadProject) {
-                Core.Util.Preferences.AddRecentFile(loadProject.project.FilePath);
+                Core.Util.Preferences.AddRecentFileIfEnabled(loadProject.project.FilePath);
             } else if (cmd is SaveProjectNotification saveProject) {
-                Core.Util.Preferences.AddRecentFile(saveProject.Path);
+                Core.Util.Preferences.AddRecentFileIfEnabled(saveProject.Path);
             }
             this.RaisePropertyChanged(nameof(Title));
         }

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -78,6 +78,9 @@ namespace OpenUtau.App.ViewModels {
                 .ToList();
         [Reactive] public LyricsHelperOption? LyricsHelper { get; set; }
         [Reactive] public int LyricsHelperBrackets { get; set; }
+        [Reactive] public bool RememberMid{ get; set; }
+        [Reactive] public bool RememberUst{ get; set; }
+        [Reactive] public bool RememberVsqx{ get; set; }
 
         private List<AudioOutputDevice>? audioOutputDevices;
         private AudioOutputDevice? audioOutputDevice;
@@ -127,6 +130,9 @@ namespace OpenUtau.App.ViewModels {
             LyricsHelper = LyricsHelpers.FirstOrDefault(option => option.klass.Equals(ActiveLyricsHelper.Inst.GetPreferred()));
             LyricsHelperBrackets = Preferences.Default.LyricsHelperBrackets ? 1 : 0;
             OtoEditor = Preferences.Default.OtoEditor;
+            RememberMid = Preferences.Default.RememberMid;
+            RememberUst = Preferences.Default.RememberUst;
+            RememberVsqx = Preferences.Default.RememberVsqx;
 
             this.WhenAnyValue(vm => vm.AudioOutputDevice)
                 .WhereNotNull()
@@ -232,6 +238,21 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.OnnxGpu)
                 .Subscribe(index => {
                     Preferences.Default.OnnxGpu = index.deviceId;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.RememberMid)
+                .Subscribe(index => {
+                    Preferences.Default.RememberMid = index;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.RememberUst)
+                .Subscribe(index => {
+                    Preferences.Default.RememberUst = index;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.RememberVsqx)
+                .Subscribe(index => {
+                    Preferences.Default.RememberVsqx = index;
                     Preferences.Save();
                 });
         }

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -172,6 +172,15 @@
               <ComboBoxItem Content="{DynamicResource prefs.off}"/>
               <ComboBoxItem Content="{DynamicResource prefs.on}"/>
             </ComboBox>
+            <TextBlock Text="{DynamicResource prefs.advanced.rememberfiletypes}" />
+            <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="25,25,25" VerticalAlignment="Center">
+              <CheckBox IsChecked="{Binding RememberMid}" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"/>
+              <TextBlock Text=" .mid" Grid.Column="1" Grid.Row="0" VerticalAlignment="Center"/>
+              <CheckBox IsChecked="{Binding RememberUst}" Grid.Column="0" Grid.Row="1" VerticalAlignment="Center"/>
+              <TextBlock Text=" .ust" Grid.Column="1" Grid.Row="1" VerticalAlignment="Center"/>
+              <CheckBox IsChecked="{Binding RememberVsqx}" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center"/>
+              <TextBlock Text=" .vsqx" Grid.Column="1" Grid.Row="2" VerticalAlignment="Center"/>
+            </Grid>
           </StackPanel>
         </HeaderedContentControl>
       </StackPanel>


### PR DESCRIPTION
Before this change, openutau remembers all the .ust and .vsqx files imported in "Open Recent". However, they are not the native file type of OpenUtau. After I imported them, I always immediately save them to .ustx and never open the original .ust or .vsqx again in OpenUtau. So here I add an option to disable remembering them in "Open Recent".

The default behaviour is unchanged: Remembering .ust and .vsqx but not remembering .mid

<img width="377" alt="image" src="https://github.com/stakira/OpenUtau/assets/54425948/543dffa2-e6b3-4ed4-8a6b-80c00ce22f8c">
