### PR TITLE
Fix wordline-R stop on pitch snaps

### DIFF
--- a/OpenUtau.Core/Util/MusicMath.cs
+++ b/OpenUtau.Core/Util/MusicMath.cs
@@ -88,7 +88,12 @@ namespace OpenUtau.Core {
             }
         }
 
+        const double ep = 0.001;
+
         public static double SinEasingInOut(double x0, double x1, double y0, double y1, double x) {
+            if(x1 - x0 < ep){
+                return y1;
+            }
             return y0 + (y1 - y0) * (1 - Math.Cos((x - x0) / (x1 - x0) * Math.PI)) / 2;
         }
 
@@ -97,6 +102,9 @@ namespace OpenUtau.Core {
         }
 
         public static double SinEasingIn(double x0, double x1, double y0, double y1, double x) {
+            if(x1 - x0 < ep){
+                return y1;
+            }
             return y0 + (y1 - y0) * (1 - Math.Cos((x - x0) / (x1 - x0) * Math.PI / 2));
         }
 
@@ -105,6 +113,9 @@ namespace OpenUtau.Core {
         }
 
         public static double SinEasingOut(double x0, double x1, double y0, double y1, double x) {
+            if(x1 - x0 < ep){
+                return y1;
+            }
             return y0 + (y1 - y0) * Math.Sin((x - x0) / (x1 - x0) * Math.PI / 2);
         }
 
@@ -113,6 +124,9 @@ namespace OpenUtau.Core {
         }
 
         public static double Linear(double x0, double x1, double y0, double y1, double x) {
+            if(x1 - x0 < ep){
+                return y1;
+            }
             return y0 + (y1 - y0) * (x - x0) / (x1 - x0);
         }
 


### PR DESCRIPTION
Before fix: 
![image](https://github.com/stakira/OpenUtau/assets/54425948/9b50d1f9-b741-4e25-b957-8b0c9e2009d5)
![image](https://github.com/stakira/OpenUtau/assets/54425948/8bd4cc01-0c7d-4ba8-b33b-43f2472d757e)


After fix:
<img width="520" alt="image" src="https://github.com/stakira/OpenUtau/assets/54425948/03349f85-81f0-4e30-8509-cf82bc56ee4c">
![1](https://github.com/stakira/OpenUtau/assets/54425948/9a3d8ac4-a5df-44a3-bcf6-355bb6fa6f98)
