### PR TITLE
Fix voice color resetting

### DIFF
--- a/OpenUtau.Core/Ustx/UExpression.cs
+++ b/OpenUtau.Core/Ustx/UExpression.cs
@@ -77,8 +77,8 @@ namespace OpenUtau.Core.Ustx {
         public string abbr;
         public float value {
             get => _value;
-            set => _value = descriptor == null
-                ? value
+            set => _value = descriptor == null ? value
+                : abbr == Format.Ustx.CLR ? value
                 : Math.Min(descriptor.max, Math.Max(descriptor.min, value));
         }
 


### PR DESCRIPTION
In the UExpression class, minimum and maximum values of voice color are no longer checked.
This prevents the colors to reset when duplicating tracks or using legacy plugins.