### PR TITLE
Fix a bug when creating a new project

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -808,7 +808,7 @@ namespace OpenUtau.App.ViewModels {
         }
 
         bool IsExpSupported(string expKey) {
-            if (Project == null || Part == null) {
+            if (Project == null || Part == null || Project.tracks.Count > Part.trackNo) {
                 return true;
             }
             var track = Project.tracks[Part.trackNo];


### PR DESCRIPTION
When loading exp in the piano roll window, the number of tracks and trackNo are now checked for discrepancies.
This prevents an exception from occurring when trying to reference a track that does not exist when creating a new project with multiple tracks and parts already present.