### PR TITLE
Ignore SearchTerms exception when loading singers

### DIFF
--- a/OpenUtau.Core/Classic/ClassicSinger.cs
+++ b/OpenUtau.Core/Classic/ClassicSinger.cs
@@ -135,7 +135,9 @@ namespace OpenUtau.Classic {
                     .ToList()
                     .ForEach(oto => {
                         oto.SearchTerms.Add(oto.Alias.ToLowerInvariant().Replace(" ", ""));
-                        oto.SearchTerms.Add(WanaKana.ToRomaji(oto.Alias).ToLowerInvariant().Replace(" ", ""));
+                        try {
+                            oto.SearchTerms.Add(WanaKana.ToRomaji(oto.Alias).ToLowerInvariant().Replace(" ", ""));
+                        } catch { }
                     });
             });
         }


### PR DESCRIPTION
When oto contains characters that cannot be used (such as \), an exception occurs when creating SearchTerms, but this can be ignored for practical use, so try-catch is used to ignore it.