### PR TITLE
fix unable to import midi in "import tracks"

### DIFF
--- a/OpenUtau.Core/Format/Formats.cs
+++ b/OpenUtau.Core/Format/Formats.cs
@@ -85,6 +85,9 @@ namespace OpenUtau.Core.Format {
                     case ProjectFormats.Ust:
                         loaded = Ust.Load(new[] { file });
                         break;
+                    case ProjectFormats.Midi:
+                        loaded = MidiWriter.LoadProject(file);
+                        break;
                     default:
                         throw new FileFormatException("Unknown file format");
                 }


### PR DESCRIPTION
Before this fix, when I click "file→import tracks", and choose a midi file, openutau will throw an error:
<img width="704" alt="image" src="https://github.com/stakira/OpenUtau/assets/54425948/ed78737c-66c5-44d6-9391-601a36a10d45">
