### PR TITLE
Show a dialog when editing macros throw an error

### DIFF
--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -137,7 +137,11 @@ namespace OpenUtau.App.ViewModels {
 
             noteBatchEditCommand = ReactiveCommand.Create<BatchEdit>(edit => {
                 if (NotesViewModel.Part != null) {
-                    edit.Run(NotesViewModel.Project, NotesViewModel.Part, NotesViewModel.Selection.ToList(), DocManager.Inst);
+                    try{
+                        edit.Run(NotesViewModel.Project, NotesViewModel.Part, NotesViewModel.Selection.ToList(), DocManager.Inst);
+                    }catch(System.Exception e){
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("Failed to run editing macro",e));
+                    }
                 }
             });
             NoteBatchEdits.AddRange(new List<BatchEdit>() {


### PR DESCRIPTION
Before this change, the errors from editing macros are ignored. After this change, openutau shows a dialog when the editing macro runs into an error.