### PR TITLE
Support ufdata import

### DIFF
--- a/OpenUtau.Core/Format/Formats.cs
+++ b/OpenUtau.Core/Format/Formats.cs
@@ -4,7 +4,7 @@ using OpenUtau.Classic;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core.Format {
-    public enum ProjectFormats { Unknown, Vsq3, Vsq4, Ust, Ustx, Midi };
+    public enum ProjectFormats { Unknown, Vsq3, Vsq4, Ust, Ustx, Midi, Ufdata };
 
     public static class Formats {
         const string ustMatch = "[#SETTING]";
@@ -13,6 +13,7 @@ namespace OpenUtau.Core.Format {
         const string vsq3Match = VSQx.vsq3NameSpace;
         const string vsq4Match = VSQx.vsq4NameSpace;
         const string midiMatch = "MThd";
+        const string ufdataMatch = "\"formatVersion\":";
 
         public static ProjectFormats DetectProjectFormat(string file) {
             var lines = new List<string>();
@@ -32,6 +33,8 @@ namespace OpenUtau.Core.Format {
                 return ProjectFormats.Vsq4;
             } else if (contents.Contains(midiMatch)) {
                 return ProjectFormats.Midi;
+            } else if (contents.Contains(ufdataMatch)) {
+                return ProjectFormats.Ufdata;
             } else {
                 return ProjectFormats.Unknown;
             }
@@ -56,6 +59,9 @@ namespace OpenUtau.Core.Format {
                     break;
                 case ProjectFormats.Midi:
                     project = MidiWriter.LoadProject(files[0]);
+                    break;
+                case ProjectFormats.Ufdata:
+                    project = Ufdata.Load(files[0]);
                     break;
                 default:
                     throw new FileFormatException("Unknown file format");

--- a/OpenUtau.Core/Format/Ufdata.cs
+++ b/OpenUtau.Core/Format/Ufdata.cs
@@ -1,0 +1,139 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+using OpenUtau.Core.Ustx;
+
+//reference: https://github.com/sdercolin/utaformatix-data/blob/main/lib/csharp/UtaFormatix.Data
+
+namespace OpenUtau.Core.Format
+{
+    /// <summary>Note model.</summary>
+    ///
+    /// <param name="key">Semitone value of the note's key (Center C = 60).</param>
+    /// <param name="tickOn">Tick position of the note's start.</param>
+    /// <param name="tickOff">Tick position of the note's end.</param>
+    /// <param name="lyric">Lyric of the note.</param>
+    /// <param name="phoneme">Phoneme of the note (if available).</param>
+    public struct UfNote{
+        public int key;
+        public int tickOn;
+        public int tickOff;
+        public string lyric;
+        public string? phoneme;
+    }
+
+    /// <summary>Pitch data model. 
+    /// Only points with changed values are included.</summary>
+    ///
+    /// <param name="ticks">Tick positions of the data points.</param>
+    /// <param name="values">Semitone values of the data points.
+    /// Items could be `null` only when [isAbsolute] is true.
+    /// In this case, it represents the end of the previous value's lasting.</param>
+    /// <param name="isAbsolute">True if the semitone value is absolute,
+    /// otherwise it's relative to the note's key.</param>
+    public struct UfPitch{
+        public int[] ticks;
+        public double?[] values;
+        public bool isAbsolute;
+    }
+
+    /// <summary>Tempo label model.</summary>
+    ///
+    /// <param name="tickPosition">Tick position of the tempo label.</param>
+    /// <param name="bpm">Tempo in beats-per-minute.</param>
+    public struct UfTempo{
+        public int tickPosition;
+        public double bpm;
+    }
+
+    /// <summary>Time signature model.</summary>
+    ///
+    /// <param name="measurePosition">Measure (bar) position of the time signature.</param>
+    /// <param name="numerator">Beats per measure.</param>
+    /// <param name="denominator">Note value per beat.</param>
+    public struct UfTimeSignature{
+        public int measurePosition; 
+        public int numerator; 
+        public int denominator;
+    }
+
+    /// <summary>Track model.</summary>
+    ///
+    /// <param name="name">Track name.</param>
+    /// <param name="notes">Notes in the track.</param>
+    /// <param name="pitch">Pitch data bound to the track (if any).</param>
+    public struct UfTrack{
+        public string name; 
+        public UfNote[] notes; 
+        public UfPitch? pitch;
+    }
+
+    /// <summary>Project model.</summary>
+    ///
+    /// <param name="name">Project name.</param>
+    /// <param name="tracks">List of track models in the project.</param>
+    /// <param name="timeSignatures">List of time signatures in the project.</param>
+    /// <param name="tempos">List of tempo labels in the project.</param>
+    /// <param name="measurePrefix">Count of measure prefixes (measures that cannot
+    /// contain notes, restricted by some editors).</param>
+    public struct UfProject{
+        public string name; 
+        public UfTrack[] tracks; 
+        public UfTimeSignature[]? timeSignatures; 
+        public UfTempo[] tempos; 
+        public int measurePrefix;
+    }
+
+    public struct UfFile{
+        public UfProject project;
+        public int formatVersion;
+    }
+
+    public static class Ufdata
+    {
+
+        public static UProject Load(string file){
+            UProject project = new UProject();
+            Ustx.AddDefaultExpressions(project);
+            project.FilePath = file;
+
+            var ufProject = JsonConvert.DeserializeObject<UfFile>(File.ReadAllText(file,Encoding.UTF8)).project;
+            
+            //parse tempo
+            project.tempos=ufProject.tempos
+                .Select(t => new UTempo(t.tickPosition, t.bpm))
+                .ToList();
+            //parse timeSignature
+            project.timeSignatures=ufProject.timeSignatures
+                .Select(t => new UTimeSignature(t.measurePosition, t.numerator, t.denominator))
+                .ToList();
+            //parse tracks
+            foreach(var ufTrack in ufProject.tracks){
+                //ignore empty tracks
+                if(ufTrack.notes.Length==0){
+                    continue;
+                }
+                var track = new UTrack(project);
+                var part = new UVoicePart();
+                part.name = ufTrack.name;
+                part.trackNo = project.tracks.Count - 1;
+                part.position = 0;
+                foreach(var ufNote in ufTrack.notes){
+                    var note = project.CreateNote(
+                        ufNote.key,
+                        ufNote.tickOn,
+                        ufNote.tickOff - ufNote.tickOn
+                    );
+                    note.lyric = ufNote.lyric;
+                    part.notes.Add(note);
+                }
+                part.Duration = ufTrack.notes[^1].tickOff;
+                project.parts.Add(part);
+            }
+            project.ValidateFull();
+            return project;
+        }
+    }
+}

--- a/OpenUtau/FilePicker.cs
+++ b/OpenUtau/FilePicker.cs
@@ -6,7 +6,7 @@ using Avalonia.Platform.Storage;
 namespace OpenUtau.App {
     internal class FilePicker {
         public static FilePickerFileType ProjectFiles { get; } = new("Project Files") {
-            Patterns = new[] { "*.ustx", "*.vsqx", "*.ust", "*.mid", "*.midi" },
+            Patterns = new[] { "*.ustx", "*.vsqx", "*.ust", "*.mid", "*.midi", "*.ufdata" },
         };
         public static FilePickerFileType USTX { get; } = new("USTX") {
             Patterns = new[] { "*.ustx" },
@@ -19,6 +19,9 @@ namespace OpenUtau.App {
         };
         public static FilePickerFileType MIDI { get; } = new("MIDI") {
             Patterns = new[] { "*.mid", "*.midi" },
+        };
+        public static FilePickerFileType UFDATA { get; } = new("UFDATA") {
+            Patterns = new[] { "*.ufdata" },
         };
         public static FilePickerFileType AudioFiles { get; } = new("Audio Files") {
             Patterns = new[] { "*.wav", "*.mp3", "*.ogg", "*.opus", "*.flac" },

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -179,7 +179,8 @@ namespace OpenUtau.App.Views {
                 FilePicker.USTX,
                 FilePicker.VSQX,
                 FilePicker.UST,
-                FilePicker.MIDI);
+                FilePicker.MIDI,
+                FilePicker.UFDATA);
             if (files == null || files.Length == 0) {
                 return;
             }
@@ -663,7 +664,7 @@ namespace OpenUtau.App.Views {
             }
             string file = storageItem.Path.LocalPath;
             var ext = System.IO.Path.GetExtension(file);
-            if (ext == ".ustx" || ext == ".ust" || ext == ".vsqx") {
+            if (ext == ".ustx" || ext == ".ust" || ext == ".vsqx" || ext==".ufdata") {
                 if (!DocManager.Inst.ChangesSaved && !await AskIfSaveAndContinue()) {
                     return;
                 }


### PR DESCRIPTION
Ufdata is an interchange format for singing synthesis applications defined by Utaformatix. After this PR, openutau will be able to import ufdata files.