### PR TITLE
Fix Note properties(RE) and Add Vibrato drift

### DIFF
--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -310,6 +310,30 @@ namespace OpenUtau.Core {
         }
     }
 
+    public class VibratoDriftCommand : VibratoCommand {
+        readonly UNote note;
+        readonly float newDrift;
+        readonly float oldDrift;
+        public VibratoDriftCommand(UVoicePart part, UNote note, float drift) : base(part, note) {
+            this.note = note;
+            newDrift = drift;
+            oldDrift = note.vibrato.drift;
+        }
+        public override string ToString() {
+            return "Change vibrato drift";
+        }
+        public override void Execute() {
+            lock (Part) {
+                note.vibrato.drift = newDrift;
+            }
+        }
+        public override void Unexecute() {
+            lock (Part) {
+                note.vibrato.drift = oldDrift;
+            }
+        }
+    }
+
     public class PhonemeOffsetCommand : NoteCommand {
         readonly UNote note;
         readonly int index;

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -224,6 +224,7 @@ namespace OpenUtau.Core.Editing {
                 docManager.ExecuteCmd(new VibratoFadeInCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoIn));
                 docManager.ExecuteCmd(new VibratoFadeOutCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoOut));
                 docManager.ExecuteCmd(new VibratoShiftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoShift));
+                docManager.ExecuteCmd(new VibratoDriftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoDrift));
                 if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) {
                     docManager.ExecuteCmd(new VibratoLengthCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoLength));
                 } else {

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -268,8 +268,7 @@ namespace OpenUtau.Core.Ustx {
             float nOut = length / 100f * @out / 100f;
             float nOutPos = 1f - nOut;
             float t = (nPos - nStart) / nPeriod + shift / 100f;
-            float y = (float)Math.Sin(2 * Math.PI * t) * depth;
-            y += depth / 100 * drift;
+            float y = (float)Math.Sin(2 * Math.PI * t) * depth + (depth / 100 * drift);
             if (nPos < nStart) {
                 y = 0;
             } else if (nPos < nInPos) {

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -211,7 +211,8 @@ namespace OpenUtau.Core.Ustx {
         float _out = NotePresets.Default.DefaultVibrato.VibratoOut;
         // Shift percentage of period length.
         float _shift = NotePresets.Default.DefaultVibrato.VibratoShift;
-        float _drift;
+        // Shift the whole vibrato up and down
+        float _drift = NotePresets.Default.DefaultVibrato.VibratoDrift;
 
         public float length { get => _length; set => _length = Math.Max(0, Math.Min(100, value)); }
         public float period { get => _period; set => _period = Math.Max(5, Math.Min(500, value)); }
@@ -268,6 +269,7 @@ namespace OpenUtau.Core.Ustx {
             float nOutPos = 1f - nOut;
             float t = (nPos - nStart) / nPeriod + shift / 100f;
             float y = (float)Math.Sin(2 * Math.PI * t) * depth;
+            y += depth / 100 * drift;
             if (nPos < nStart) {
                 y = 0;
             } else if (nPos < nInPos) {

--- a/OpenUtau.Core/Util/NotePresets.cs
+++ b/OpenUtau.Core/Util/NotePresets.cs
@@ -46,10 +46,10 @@ namespace OpenUtau.Core.Util {
                 new PortamentoPreset("Snap", 2, -1),
             });
             Default.VibratoPresets.AddRange(new List<VibratoPreset> {
-                new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0),
-                new VibratoPreset("UTAU Default", 65, 180, 35, 20, 20, 0),
-                new VibratoPreset("UTAU Strong", 65, 210, 55, 25, 25, 0),
-                new VibratoPreset("UTAU Weak", 65, 165, 20, 25, 25, 0)
+                new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0, 0),
+                new VibratoPreset("UTAU Default", 65, 180, 35, 20, 20, 0, 0),
+                new VibratoPreset("UTAU Strong", 65, 210, 55, 25, 25, 0, 0),
+                new VibratoPreset("UTAU Weak", 65, 165, 20, 25, 25, 0, 0)
             });
 
             Save();
@@ -60,7 +60,7 @@ namespace OpenUtau.Core.Util {
             public string DefaultLyric = "a";
             public PortamentoPreset DefaultPortamento = new PortamentoPreset("Standard", 80, -40);
             public List<PortamentoPreset> PortamentoPresets = new List<PortamentoPreset> { };
-            public VibratoPreset DefaultVibrato = new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0);
+            public VibratoPreset DefaultVibrato = new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0, 0);
             public List<VibratoPreset> VibratoPresets = new List<VibratoPreset> { };
             public bool AutoVibratoToggle = false;
             public int AutoVibratoNoteDuration = 481;
@@ -88,8 +88,9 @@ namespace OpenUtau.Core.Util {
             public float VibratoIn = 10;
             public float VibratoOut = 10;
             public float VibratoShift = 0;
+            public float VibratoDrift = 0;
 
-            public VibratoPreset(string name, float length, float period, float depth, float fadein, float fadeout, float shift) {
+            public VibratoPreset(string name, float length, float period, float depth, float fadein, float fadeout, float shift, float drift) {
                 Name = name;
                 VibratoLength = length;
                 VibratoPeriod = period;
@@ -97,6 +98,7 @@ namespace OpenUtau.Core.Util {
                 VibratoIn = fadein;
                 VibratoOut = fadeout;
                 VibratoShift = shift;
+                VibratoDrift = drift;
             }
 
             public override string ToString() => Name;

--- a/OpenUtau/Controls/NotePropertiesControl.axaml
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml
@@ -12,20 +12,25 @@
     <Style Selector="Label,TextBox,Slider,ComboBox,CheckBox">
       <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
+    <Style Selector="Slider.fader">
+      <Setter Property="Focusable" Value="True"/>
+    </Style>
   </UserControl.Styles>
   
   <Grid>
     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
       <StackPanel Margin="10">
+        <TextBlock Text="{Binding Title}" HorizontalAlignment="Center"/>
         <TextBlock Text="!!! WORK IN PROGRESS !!!" HorizontalAlignment="Center" Foreground="Red"/>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.lyric}">
+
+        <Expander Header="{DynamicResource notedefaults.lyric}" HorizontalAlignment="Stretch" Margin="5">
           <Grid ColumnDefinitions="143,*">
             <Label Content="{DynamicResource notedefaults.lyric}" Grid.Column="0"/>
-            <TextBox Text="{Binding Lyric}" IsEnabled="{Binding IsNoteSelected}" Grid.Column="1"/>
+            <TextBox Text="{Binding Lyric}" IsEnabled="{Binding IsNoteSelected}" Grid.Column="1" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
           </Grid>
-        </HeaderedContentControl>
+        </Expander>
 
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.portamento}">
+        <Expander Header="{DynamicResource notedefaults.portamento}" HorizontalAlignment="Stretch" Margin="5">
           <StackPanel IsEnabled="{Binding IsNoteSelected}">
             <Grid ColumnDefinitions="123,20,*">
               <Label Content="{DynamicResource notedefaults.preset}"/>
@@ -34,97 +39,108 @@
             </Grid>
             <Grid ColumnDefinitions="123,20,*,20,*">
               <Button Grid.Column="2" Content="{DynamicResource notedefaults.preset.save}"
-                HorizontalAlignment="Stretch" Click="OnSavePortamentoPreset"
-                ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
+                      HorizontalAlignment="Stretch" Click="OnSavePortamentoPreset"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"
+                      IsEnabled="False"/>
               <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.remove}"
-                HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedPortamentoPreset}"
-                ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
+                      HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedPortamentoPreset}"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
             </Grid>
             <Grid ColumnDefinitions="130,20,50,20,*">
               <Label Content="{DynamicResource notedefaults.portamento.length}"/>
-              <TextBox Grid.Column="2" Text="{Binding PortamentoLength}" />
+              <TextBox Grid.Column="2" Text="{Binding PortamentoLength}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
               <Slider Grid.Column="4" Classes="fader" Value="{Binding PortamentoLength}" Minimum="2" Maximum="320"
-              TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
             </Grid>
             <Grid ColumnDefinitions="130,20,50,20,*">
               <Label Content="{DynamicResource notedefaults.portamento.start}"/>
-              <TextBox Grid.Column="2" Text="{Binding PortamentoStart}" />
+              <TextBox Grid.Column="2" Text="{Binding PortamentoStart}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
               <Slider Grid.Column="4" Classes="fader" Value="{Binding PortamentoStart}" Minimum="-200" Maximum="200"
-              TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
             </Grid>
           </StackPanel>
-        </HeaderedContentControl>
+        </Expander>
 
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.vibrato}">
+        <Expander Header="{DynamicResource notedefaults.vibrato}" HorizontalAlignment="Stretch" Margin="5">
           <StackPanel IsEnabled="{Binding IsNoteSelected}">
-            <ToggleSwitch IsChecked="{Binding VibratoEnable}" OnContent="{DynamicResource prefs.on}" OffContent="{DynamicResource prefs.off}"/>
-            <StackPanel IsEnabled="{Binding VibratoEnable}">
-              <Grid ColumnDefinitions="123,20,*">
-                <Label Content="{DynamicResource notedefaults.preset}"/>
-                <ComboBox Grid.Column="2" ItemsSource="{Binding VibratoPresets}"
-                  SelectedItem="{Binding ApplyVibratoPreset}" HorizontalAlignment="Stretch" />
-              </Grid>
-              <Grid ColumnDefinitions="123,20,*,20,*">
-                <Button Grid.Column="2" Content="{DynamicResource notedefaults.preset.save}"
-                  HorizontalAlignment="Stretch" Click="OnSaveVibratoPreset"
-                  ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
-                <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.remove}"
-                  HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedVibratoPreset}"
-                  ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.length}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoLength}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoLength}" Minimum="0" Maximum="100"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.period}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoPeriod}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoPeriod}" Minimum="5" Maximum="500"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.depth}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoDepth}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoDepth}" Minimum="5" Maximum="200"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.in}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoIn}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoIn}" Minimum="0" Maximum="100"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.out}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoOut}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoOut}" Minimum="0" Maximum="100"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoShift}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoShift}" Minimum="0" Maximum="100"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="123,20,*">
-                <Label Content="{DynamicResource noteproperty.setlongnote}"/>
-                <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>
-              </Grid>
-              <Grid ColumnDefinitions="180,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.autominlength}"/>
-                <TextBox Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Text="{Binding AutoVibratoNoteLength}" />
-                <Slider Grid.Column="4" Classes="fader" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" Minimum="10" Maximum="1920"
-                TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
-              </Grid>
-            </StackPanel>
+            <ToggleSwitch IsChecked="{Binding VibratoEnable, Mode=OneWay}" OnContent="{DynamicResource prefs.on}" OffContent="{DynamicResource prefs.off}"
+                          Click="VibratoEnableClicked"/>
+            <Grid ColumnDefinitions="123,20,*">
+              <Label Content="{DynamicResource notedefaults.preset}"/>
+              <ComboBox Grid.Column="2" ItemsSource="{Binding VibratoPresets}"
+                SelectedItem="{Binding ApplyVibratoPreset}" HorizontalAlignment="Stretch" />
+            </Grid>
+            <Grid ColumnDefinitions="123,20,*,20,*">
+              <Button Grid.Column="2" Content="{DynamicResource notedefaults.preset.save}"
+                      HorizontalAlignment="Stretch" Click="OnSaveVibratoPreset"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"
+                      IsEnabled="False"/>
+              <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.remove}"
+                HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedVibratoPreset}"
+                ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.length}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoLength}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoLength}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.period}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoPeriod}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoPeriod}" Minimum="5" Maximum="500"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.depth}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoDepth}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoDepth}" Minimum="5" Maximum="200"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.in}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoIn}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoIn}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.out}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoOut}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoOut}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoShift}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoShift}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="123,20,*">
+              <Label Content="{DynamicResource noteproperty.setlongnote}"/>
+              <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>
+            </Grid>
+            <Grid ColumnDefinitions="180,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.autominlength}"/>
+              <TextBox Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Text="{Binding AutoVibratoNoteLength}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" Minimum="10" Maximum="1920"
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
           </StackPanel>
-        </HeaderedContentControl>
+        </Expander>
 
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource exps.caption}">
+        <Expander Header="{DynamicResource exps.caption}" HorizontalAlignment="Stretch" Margin="5">
           <StackPanel Name="ExpressionsPanel" />
-        </HeaderedContentControl>
+        </Expander>
+        
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/OpenUtau/Controls/NotePropertiesControl.axaml
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml
@@ -40,8 +40,7 @@
             <Grid ColumnDefinitions="123,20,*,20,*">
               <Button Grid.Column="2" Content="{DynamicResource notedefaults.preset.save}"
                       HorizontalAlignment="Stretch" Click="OnSavePortamentoPreset"
-                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"
-                      IsEnabled="False"/>
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
               <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.remove}"
                       HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedPortamentoPreset}"
                       ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
@@ -75,8 +74,7 @@
             <Grid ColumnDefinitions="123,20,*,20,*">
               <Button Grid.Column="2" Content="{DynamicResource notedefaults.preset.save}"
                       HorizontalAlignment="Stretch" Click="OnSaveVibratoPreset"
-                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"
-                      IsEnabled="False"/>
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
               <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.remove}"
                 HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedVibratoPreset}"
                 ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>

--- a/OpenUtau/Controls/NotePropertiesControl.axaml
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml
@@ -123,6 +123,13 @@
                       TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
                       GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
             </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.drift}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoDrift}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoDrift}" Minimum="-100" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
             <Grid ColumnDefinitions="123,20,*">
               <Label Content="{DynamicResource noteproperty.setlongnote}"/>
               <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>

--- a/OpenUtau/Controls/NotePropertiesControl.axaml.cs
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml.cs
@@ -52,11 +52,13 @@ namespace OpenUtau.App.Controls {
         }
 
         void OnSavePortamentoPreset(object sender, RoutedEventArgs e) {
-            var dialog = new TypeInDialog() {
-                Title = ThemeManager.GetString("notedefaults.preset.namenew"),
-                onFinish = name => ViewModel.SavePortamentoPreset(name),
-            };
-            //dialog.ShowDialog(this);
+            if (VisualRoot is Window window) {
+                var dialog = new TypeInDialog() {
+                    Title = ThemeManager.GetString("notedefaults.preset.namenew"),
+                    onFinish = name => ViewModel.SavePortamentoPreset(name),
+                };
+                dialog.ShowDialog(window);
+            }
         }
 
         void OnRemovePortamentoPreset(object sender, RoutedEventArgs e) {
@@ -64,11 +66,13 @@ namespace OpenUtau.App.Controls {
         }
 
         void OnSaveVibratoPreset(object sender, RoutedEventArgs e) {
-            var dialog = new TypeInDialog() {
-                Title = ThemeManager.GetString("notedefaults.preset.namenew"),
-                onFinish = name => ViewModel.SaveVibratoPreset(name),
-            };
-            //dialog.ShowDialog(this);
+            if (VisualRoot is Window window) {
+                var dialog = new TypeInDialog() {
+                    Title = ThemeManager.GetString("notedefaults.preset.namenew"),
+                    onFinish = name => ViewModel.SaveVibratoPreset(name),
+                };
+                dialog.ShowDialog(window);
+            }
         }
 
         void OnRemoveVibratoPreset(object sender, RoutedEventArgs e) {

--- a/OpenUtau/Controls/NotePropertiesControl.axaml.cs
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reactive.Linq;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
@@ -8,6 +6,7 @@ using OpenUtau.App.Views;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using ReactiveUI;
+using Serilog;
 
 namespace OpenUtau.App.Controls {
     public partial class NotePropertiesControl : UserControl, ICmdSubscriber {
@@ -21,12 +20,35 @@ namespace OpenUtau.App.Controls {
         }
 
         private void LoadPart(UPart? part) {
+            if (NotePropertiesViewModel.PanelControlPressed) {
+                NotePropertiesViewModel.PanelControlPressed = false;
+                DocManager.Inst.EndUndoGroup();
+            }
+            NotePropertiesViewModel.NoteLoading = true;
+
             ViewModel.LoadPart(part);
             ExpressionsPanel.Children.Clear();
             foreach (NotePropertyExpViewModel expVM in ViewModel.Expressions) {
                 var control = new NotePropertyExpression() { DataContext = expVM };
                 ExpressionsPanel.Children.Add(control);
             }
+
+            NotePropertiesViewModel.NoteLoading = false;
+        }
+
+        void OnGotFocus(object sender, GotFocusEventArgs e) {
+            Log.Information("Note property panel got focus");
+            DocManager.Inst.StartUndoGroup();
+            NotePropertiesViewModel.PanelControlPressed = true;
+        }
+        void OnLostFocus(object sender, RoutedEventArgs e) {
+            Log.Information("Note property panel lost focus");
+            NotePropertiesViewModel.PanelControlPressed = false;
+            DocManager.Inst.EndUndoGroup();
+        }
+
+        void VibratoEnableClicked(object sender, RoutedEventArgs e) {
+            ViewModel.SetVibratoEnable();
         }
 
         void OnSavePortamentoPreset(object sender, RoutedEventArgs e) {
@@ -56,11 +78,7 @@ namespace OpenUtau.App.Controls {
         private void OnKeyDown(object? sender, KeyEventArgs e) {
             switch (e.Key) {
                 case Key.Enter:
-                    //OnFinish(sender, e);
-                    e.Handled = true;
-                    break;
-                case Key.Escape:
-                    //OnCancel(sender, e);
+                    TopLevel.GetTopLevel(this)?.FocusManager?.ClearFocus();
                     e.Handled = true;
                     break;
                 default:
@@ -69,8 +87,24 @@ namespace OpenUtau.App.Controls {
         }
 
         public void OnNext(UCommand cmd, bool isUndo) {
-            if (cmd is LoadPartNotification loadPart) {
-                LoadPart(loadPart.part);
+            if (cmd is UNotification notif) {
+                if (cmd is LoadPartNotification) {
+                    LoadPart(notif.part);
+                } else if (cmd is LoadProjectNotification) {
+                    LoadPart(null);
+                } else if (cmd is SingersRefreshedNotification) {
+                    LoadPart(notif.part);
+                }
+            } else if (cmd is TrackCommand) {
+                if (cmd is RemoveTrackCommand removeTrack) {
+                    if (ViewModel.Part != null && removeTrack.removedParts.Contains(ViewModel.Part)) {
+                        LoadPart(null);
+                    }
+                } else if (cmd is TrackChangeSingerCommand trackChangeSinger) {
+                    if (ViewModel.Part != null && trackChangeSinger.track.TrackNo == ViewModel.Part.trackNo) {
+                        // LoadPart(ViewModel.Part); can't load crl
+                    }
+                }
             }
         }
     }

--- a/OpenUtau/Controls/NotePropertyExpression.axaml
+++ b/OpenUtau/Controls/NotePropertyExpression.axaml
@@ -6,10 +6,13 @@
              x:Class="OpenUtau.App.Controls.NotePropertyExpression">
   <Grid ColumnDefinitions="143,7,50,20,*">
     <Label Content="{Binding Name}" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox Text="{Binding Value}" Grid.Column="2" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"/>
+    <TextBox Text="{Binding Value}" Grid.Column="2" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"
+             GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
     <Slider Grid.Column="4" Classes="fader" Value="{Binding Value}" Minimum="{Binding Min}" Maximum="{Binding Max}"
-            TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}" />
+            TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"
+            GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
     <ComboBox Grid.Column="1" Grid.ColumnSpan="4" ItemsSource="{Binding Options}"
-                SelectedIndex="{Binding SelectedOption}" MinWidth="120" IsVisible="{Binding IsOptions}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}" />
+              SelectedIndex="{Binding SelectedOption}" MinWidth="120" IsVisible="{Binding IsOptions}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"
+              IsDropDownOpen="{Binding DropDownOpen, Mode=OneWayToSource}"/>
   </Grid>
 </UserControl>

--- a/OpenUtau/Controls/NotePropertyExpression.axaml.cs
+++ b/OpenUtau/Controls/NotePropertyExpression.axaml.cs
@@ -1,12 +1,26 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
+using OpenUtau.Core;
+using Serilog;
 
 namespace OpenUtau.App.Controls {
     public partial class NotePropertyExpression : UserControl {
         public NotePropertyExpression() {
             InitializeComponent();
+        }
+
+        void OnGotFocus(object sender, GotFocusEventArgs e) {
+            Log.Information("Note property panel got focus");
+            DocManager.Inst.StartUndoGroup();
+            NotePropertiesViewModel.PanelControlPressed = true;
+        }
+        void OnLostFocus(object sender, RoutedEventArgs e) {
+            Log.Information("Note property panel lost focus");
+            NotePropertiesViewModel.PanelControlPressed = false;
+            DocManager.Inst.EndUndoGroup();
         }
 
     }

--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -14,7 +14,7 @@
     </Style>
     <Style Selector="Slider.fader">
       <Setter Property="Foreground" Value="{Binding TrackColor.AccentColor}"/>
-      
+
       <Style Selector="^:pointerover">
         <!--<Style Selector="^ /template/ Thumb">
           <Setter Property="Background" Value="{Binding TrackColor.AccentColorLight}" />
@@ -100,7 +100,7 @@
           </ContextMenu>
         </Button.ContextMenu>
       </Button>
-      <ToggleButton Grid.Row="1" Grid.Column="3" Margin="1" Padding="0" Height="18"
+      <ToggleButton Classes="normal" Grid.Row="1" Grid.Column="3" Margin="1" Padding="0" Height="18"
                     HorizontalAlignment="Stretch"
                     IsChecked="{Binding Mute, Mode=OneWay}" Command="{Binding ToggleMute}">
         <TextBlock Text="M" TextAlignment="Center"/>
@@ -113,7 +113,7 @@
           </ContextMenu>
         </ToggleButton.ContextMenu>
       </ToggleButton>
-      <ToggleButton Grid.Row="2" Grid.Column="3" Margin="1" Padding="0" Height="18"
+      <ToggleButton Classes="normal" Grid.Row="2" Grid.Column="3" Margin="1" Padding="0" Height="18"
                     HorizontalAlignment="Stretch"
                     IsChecked="{Binding Solo, Mode=OneWay}" Command="{Binding ToggleSolo}">
         <TextBlock Text="S" TextAlignment="Center"/>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -163,6 +163,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="notedefaults.vibrato.out">Fade Out</system:String>
   <system:String x:Key="notedefaults.vibrato.period">Period</system:String>
   <system:String x:Key="notedefaults.vibrato.shift">Shift</system:String>
+  <system:String x:Key="notedefaults.vibrato.drift">Drift</system:String>
 
   <system:String x:Key="noteproperty">Note Properties</system:String>
   <system:String x:Key="noteproperty.apply">Apply</system:String>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -164,6 +164,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="notedefaults.vibrato.period">Period</system:String>
   <system:String x:Key="notedefaults.vibrato.shift">Shift</system:String>
 
+  <system:String x:Key="noteproperty">Note Properties</system:String>
   <system:String x:Key="noteproperty.apply">Apply</system:String>
   <system:String x:Key="noteproperty.cancel">Cancel</system:String>
   <system:String x:Key="noteproperty.set">Set</system:String>
@@ -202,7 +203,6 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">Remove Tone Suffix</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">Romaji to Hiragana</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">Note Defaults</system:String>
-  <system:String x:Key="pianoroll.menu.noteproperty">Note Properties</system:String>
   <system:String x:Key="pianoroll.menu.notes">Notes</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtaildash">Add tail "-"</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtailrest">Add tail "R"</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -163,6 +163,7 @@
   <system:String x:Key="notedefaults.vibrato.out">フェードアウト</system:String>
   <system:String x:Key="notedefaults.vibrato.period">周期</system:String>
   <system:String x:Key="notedefaults.vibrato.shift">位相</system:String>
+  <system:String x:Key="notedefaults.vibrato.drift">高さ</system:String>
 
   <system:String x:Key="noteproperty">音符のプロパティ</system:String>
   <system:String x:Key="noteproperty.apply">適用</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -164,6 +164,7 @@
   <system:String x:Key="notedefaults.vibrato.period">周期</system:String>
   <system:String x:Key="notedefaults.vibrato.shift">位相</system:String>
 
+  <system:String x:Key="noteproperty">音符のプロパティ</system:String>
   <system:String x:Key="noteproperty.apply">適用</system:String>
   <system:String x:Key="noteproperty.cancel">キャンセル</system:String>
   <system:String x:Key="noteproperty.set">セット</system:String>
@@ -202,7 +203,6 @@
   <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">音程のSuffixを削除</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">ローマ字→ひらがな</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">デフォルト値を設定</system:String>
-  <system:String x:Key="pianoroll.menu.noteproperty">音符のプロパティ</system:String>
   <system:String x:Key="pianoroll.menu.notes">音符</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtaildash">末尾に"-"を追加</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtailrest">末尾に"R"を追加</system:String>

--- a/OpenUtau/Styles/PianoRollStyles.axaml
+++ b/OpenUtau/Styles/PianoRollStyles.axaml
@@ -1,6 +1,6 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  
+
   <Style Selector="Button,ToggleButton">
     <Setter Property="Focusable" Value="False"/>
   </Style>
@@ -21,28 +21,30 @@
   <Style Selector="ComboBoxItem:selected /template/ ContentPresenter">
     <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrushSemi}"/>
   </Style>
-  
+
   <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
     <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrushSemi}"/>
   </Style>
-  
+
   <Style Selector="Slider.fader">
     <Setter Property="Foreground" Value="{DynamicResource SelectedTrackAccentBrush}"/>
-  </Style>
-  <Style Selector="Slider.fader:pointerover">
-    <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
-      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
+
+    <Style Selector="^:pointerover">
+      <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
+        <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
+      </Style>
+      <Style Selector="^ /template/ Thumb">
+        <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
+      </Style>
     </Style>
-    <Style Selector="^ /template/ Thumb">
-      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
-    </Style>
-  </Style>
-  <Style Selector="Slider.fader:pressed">
-    <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
-      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
-    </Style>
-    <Style Selector="^ /template/ Thumb">
-      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
+
+    <Style Selector="^:pressed">
+      <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
+        <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
+      </Style>
+      <Style Selector="^ /template/ Thumb">
+        <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
+      </Style>
     </Style>
   </Style>
 
@@ -50,12 +52,16 @@
     <Setter Property="BorderBrush" Value="{DynamicResource SelectedTrackAccentBrush}"/>
   </Style>
 
-  <!--
-  <Style Selector="ToggleSwitch:pressed /template/ ">
-    <Setter Property="BorderBrush" Value="{DynamicResource SelectedTrackAccentBrush}"/>
+  <Style Selector="ToggleSwitch">
+    <Style Selector="^:checked /template/ Border#SwitchKnobBounds">
+      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentBrush}" />
+    </Style>
+    <Style Selector="^:checked:pointerover /template/ Border#SwitchKnobBounds">
+      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
+    </Style>
+    <Style Selector="^:checked:pressed /template/ Border#SwitchKnobBounds">
+      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
+    </Style>
   </Style>
-  <Style Selector="ToggleSwitch:pressed:pointerover /template/ ">
-    <Setter Property="BorderBrush" Value="{DynamicResource SelectedTrackAccentLightBrush}"/>
-  </Style>
-  -->
+
 </Styles>

--- a/OpenUtau/Styles/Styles.axaml
+++ b/OpenUtau/Styles/Styles.axaml
@@ -96,7 +96,7 @@
     <Setter Property="Background" Value="{DynamicResource BackgroundColorPointerOver}"/>
   </Style>
 
-  <Style Selector="ToggleButton">
+  <Style Selector="ToggleButton.normal">
     <Setter Property="BorderThickness" Value="0"/>
     <Setter Property="FontSize" Value="12"/>
     <Setter Property="Height" Value="20"/>
@@ -105,32 +105,22 @@
     <Setter Property="HorizontalContentAlignment" Value="Center"/>
     <Setter Property="VerticalContentAlignment" Value="Center"/>
     <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
-  </Style>
-  <Style Selector="ToggleButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
-  </Style>
-  <Style Selector="ToggleButton:pressed  /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
-  </Style>
-  <Style Selector="ToggleButton:checked /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushSemi}" />
-  </Style>
-  <Style Selector="ToggleButton:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
-  </Style>
-  <Style Selector="ToggleButton:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
-  </Style>
-  <Style Selector="ToggleButton.toolbar Path.filled">
-    <Setter Property="Fill" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-  </Style>
-  <Style Selector="ToggleButton.toolbar Ellipse.stroked">
-    <Setter Property="StrokeThickness" Value="1"/>
-    <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-  </Style>
-  <Style Selector="ToggleButton.toolbar Path.stroked">
-    <Setter Property="StrokeThickness" Value="1"/>
-    <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
+    </Style>
+    <Style Selector="^:pressed  /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
+    </Style>
+    <Style Selector="^:checked /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushSemi}" />
+    </Style>
+    <Style Selector="^:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
+    </Style>
+    <Style Selector="^:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
+    </Style>
   </Style>
 
   <Style Selector="ToggleButton.toolbar">
@@ -141,6 +131,35 @@
     <Setter Property="Padding" Value="4,0,4,2"/>
     <Setter Property="HorizontalContentAlignment" Value="Center"/>
     <Setter Property="VerticalContentAlignment" Value="Center"/>
+    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
+
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
+    </Style>
+    <Style Selector="^:pressed  /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
+    </Style>
+    <Style Selector="^:checked /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushSemi}" />
+    </Style>
+    <Style Selector="^:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
+    </Style>
+    <Style Selector="^:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
+    </Style>
+
+    <Style Selector="^ Path.filled">
+      <Setter Property="Fill" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+    <Style Selector="^ Ellipse.stroked">
+      <Setter Property="StrokeThickness" Value="1"/>
+      <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+    <Style Selector="^ Path.stroked">
+      <Setter Property="StrokeThickness" Value="1"/>
+      <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
   </Style>
 
   <Style Selector="ToggleSwitch /template/ Border#SwitchKnobBounds">
@@ -379,5 +398,17 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
+  </Style>
+
+  <Style Selector="Expander" >
+    <Setter Property="CornerRadius" Value="5" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{StaticResource SystemControlForegroundBaseMediumBrush}"/>
+    <Setter Property="Padding" Value="10" />
+    <Setter Property="IsExpanded" Value="True" />
+
+    <Style Selector="^:down /template/ ToggleButton#ExpanderHeader">
+      <Setter Property="BorderBrush" Value="{StaticResource SystemControlForegroundBaseMediumBrush}"/>
+    </Style>
   </Style>
 </Styles>

--- a/OpenUtau/ViewModels/NoteDefaultsViewModel.cs
+++ b/OpenUtau/ViewModels/NoteDefaultsViewModel.cs
@@ -27,6 +27,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public float CurrentVibratoIn { get; set; }
         [Reactive] public float CurrentVibratoOut { get; set; }
         [Reactive] public float CurrentVibratoShift { get; set; }
+        [Reactive] public float CurrentVibratoDrift { get; set; }
         [Reactive] public float AutoVibratoNoteLength { get; set; }
         [Reactive] public bool AutoVibratoToggle { get; set; }
         public List<NotePresets.PortamentoPreset>? PortamentoPresets { get; }
@@ -55,6 +56,7 @@ namespace OpenUtau.App.ViewModels {
             CurrentVibratoIn = NotePresets.Default.DefaultVibrato.VibratoIn;
             CurrentVibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
             CurrentVibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
+            CurrentVibratoDrift = NotePresets.Default.DefaultVibrato.VibratoDrift;
             AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
             AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
             PortamentoPresets = NotePresets.Default.PortamentoPresets;
@@ -109,6 +111,11 @@ namespace OpenUtau.App.ViewModels {
                         NotePresets.Default.DefaultVibrato.VibratoShift = Math.Max(0, Math.Min(100, vibratoShift));
                         NotePresets.Save();
                     });
+            this.WhenAnyValue(vm => vm.CurrentVibratoDrift)
+                    .Subscribe(vibratoShift => {
+                        NotePresets.Default.DefaultVibrato.VibratoDrift = Math.Max(-100, Math.Min(100, vibratoShift));
+                        NotePresets.Save();
+                    });
             this.WhenAnyValue(vm => vm.AutoVibratoToggle)
                     .Subscribe(autoVibratoToggle => {
                         NotePresets.Default.AutoVibratoToggle = autoVibratoToggle;
@@ -140,12 +147,14 @@ namespace OpenUtau.App.ViewModels {
                         CurrentVibratoIn = Math.Max(0, Math.Min(100, vibratoPreset.VibratoIn));
                         CurrentVibratoOut = Math.Max(0, Math.Min(100, vibratoPreset.VibratoOut));
                         CurrentVibratoShift = Math.Max(0, Math.Min(100, vibratoPreset.VibratoShift));
+                        CurrentVibratoDrift = Math.Max(-100, Math.Min(100, vibratoPreset.VibratoDrift));
                         NotePresets.Default.DefaultVibrato.VibratoLength = CurrentVibratoLength;
                         NotePresets.Default.DefaultVibrato.VibratoPeriod = CurrentVibratoPeriod;
                         NotePresets.Default.DefaultVibrato.VibratoDepth = CurrentVibratoDepth;
                         NotePresets.Default.DefaultVibrato.VibratoIn = CurrentVibratoIn;
                         NotePresets.Default.DefaultVibrato.VibratoOut = CurrentVibratoOut;
                         NotePresets.Default.DefaultVibrato.VibratoShift = CurrentVibratoShift;
+                        NotePresets.Default.DefaultVibrato.VibratoDrift = CurrentVibratoDrift;
                         NotePresets.Save();
                     }
                 });
@@ -171,7 +180,7 @@ namespace OpenUtau.App.ViewModels {
             if (string.IsNullOrEmpty(name)) {
                 return;
             }
-            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, CurrentVibratoLength, CurrentVibratoPeriod, CurrentVibratoDepth, CurrentVibratoIn, CurrentVibratoOut, CurrentVibratoShift));
+            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, CurrentVibratoLength, CurrentVibratoPeriod, CurrentVibratoDepth, CurrentVibratoIn, CurrentVibratoOut, CurrentVibratoShift, CurrentVibratoDrift));
             NotePresets.Save();
         }
 
@@ -193,6 +202,7 @@ namespace OpenUtau.App.ViewModels {
             CurrentVibratoIn = NotePresets.Default.DefaultVibrato.VibratoIn;
             CurrentVibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
             CurrentVibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
+            CurrentVibratoDrift = NotePresets.Default.DefaultVibrato.VibratoDrift;
             AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
             AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
         }

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -27,6 +27,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public float VibratoIn { get; set; }
         [Reactive] public float VibratoOut { get; set; }
         [Reactive] public float VibratoShift { get; set; }
+        [Reactive] public float VibratoDrift { get; set; }
         [Reactive] public float AutoVibratoNoteLength { get; set; }
         [Reactive] public bool AutoVibratoToggle { get; set; }
         [Reactive] public bool IsNoteSelected { get; set; } = false;
@@ -99,6 +100,7 @@ namespace OpenUtau.App.ViewModels {
                 VibratoIn = note.vibrato.@in;
                 VibratoOut = note.vibrato.@out;
                 VibratoShift = note.vibrato.shift;
+                VibratoDrift = note.vibrato.drift;
             } else {
                 IsNoteSelected = false;
                 Lyric = NotePresets.Default.DefaultLyric;
@@ -111,6 +113,7 @@ namespace OpenUtau.App.ViewModels {
                 VibratoIn = NotePresets.Default.DefaultVibrato.VibratoIn;
                 VibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
                 VibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
+                VibratoDrift = NotePresets.Default.DefaultVibrato.VibratoDrift;
             }
             AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
             AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
@@ -215,6 +218,10 @@ namespace OpenUtau.App.ViewModels {
                 } else if (cmd is VibratoShiftCommand) {
                     if (noteCommand.Notes.Contains(note)) {
                         VibratoShift = note.vibrato.shift;
+                    }
+                } else if (cmd is VibratoDriftCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        VibratoDrift = note.vibrato.drift;
                     }
                 }
             } else if (cmd is ExpCommand) {
@@ -359,6 +366,18 @@ namespace OpenUtau.App.ViewModels {
                         }
                     }
                 });
+            this.WhenAnyValue(vm => vm.VibratoDrift)
+                .Subscribe(value => {
+                    if (value >= -100 && value <= 100) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.drift != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoDriftCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
 
             this.WhenAnyValue(vm => vm.ApplyPortamentoPreset)
                 .WhereNotNull()
@@ -463,7 +482,7 @@ namespace OpenUtau.App.ViewModels {
             if (string.IsNullOrEmpty(name)) {
                 return;
             }
-            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, VibratoLength, VibratoPeriod, VibratoDepth, VibratoIn, VibratoOut, VibratoShift));
+            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, VibratoLength, VibratoPeriod, VibratoDepth, VibratoIn, VibratoOut, VibratoShift, VibratoDrift));
             NotePresets.Save();
         }
         public void RemoveAppliedVibratoPreset() {

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -12,12 +12,14 @@ using OpenUtau.Core.Util;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using SharpCompress;
+using YamlDotNet.Core.Tokens;
 
 namespace OpenUtau.App.ViewModels {
     public class NotePropertiesViewModel : ViewModelBase, ICmdSubscriber {
+        public string Title { get => ThemeManager.GetString("noteproperty") + " (" + selectedNotes.Count + " notes)"; }
         [Reactive] public string Lyric { get; set; } = "a";
-        [Reactive] public int PortamentoLength { get; set; }
-        [Reactive] public int PortamentoStart { get; set; }
+        [Reactive] public float PortamentoLength { get; set; }
+        [Reactive] public float PortamentoStart { get; set; }
         [Reactive] public bool VibratoEnable { get; set; }
         [Reactive] public float VibratoLength { get; set; }
         [Reactive] public float VibratoPeriod { get; set; }
@@ -42,59 +44,56 @@ namespace OpenUtau.App.ViewModels {
         private NotePresets.PortamentoPreset? appliedPortamentoPreset = NotePresets.Default.DefaultPortamento;
         private NotePresets.VibratoPreset? appliedVibratoPreset = NotePresets.Default.DefaultVibrato;
 
-        private UVoicePart? part;
+        public UVoicePart? Part;
         private HashSet<UNote> selectedNotes = new HashSet<UNote>();
         public List<NotePropertyExpViewModel> Expressions = new List<NotePropertyExpViewModel>();
+        public static bool PanelControlPressed { get; set; } = false;
+        public static bool NoteLoading { get; set; } = false;
+        private static bool AllowNoteEdit { get => PanelControlPressed && !NoteLoading; }
 
         public NotePropertiesViewModel() {
             PortamentoPresets = NotePresets.Default.PortamentoPresets;
             VibratoPresets = NotePresets.Default.VibratoPresets;
 
-            this.WhenAnyValue(vm => vm.ApplyPortamentoPreset)
-                .WhereNotNull()
-                .Subscribe(portamentoPreset => {
-                    if (portamentoPreset != null) {
-                        PortamentoLength = portamentoPreset.PortamentoLength;
-                        PortamentoStart = portamentoPreset.PortamentoStart;
-                    }
-                });
-            this.WhenAnyValue(vm => vm.ApplyVibratoPreset)
-                .WhereNotNull()
-                .Subscribe(vibratoPreset => {
-                    if (vibratoPreset != null) {
-                        VibratoLength = Math.Max(0, Math.Min(100, vibratoPreset.VibratoLength));
-                        VibratoPeriod = Math.Max(5, Math.Min(500, vibratoPreset.VibratoPeriod));
-                        VibratoDepth = Math.Max(5, Math.Min(200, vibratoPreset.VibratoDepth));
-                        VibratoIn = Math.Max(0, Math.Min(100, vibratoPreset.VibratoIn));
-                        VibratoOut = Math.Max(0, Math.Min(100, vibratoPreset.VibratoOut));
-                        VibratoShift = Math.Max(0, Math.Min(100, vibratoPreset.VibratoShift));
-                    }
-                });
+            SetValueChanges();
 
             MessageBus.Current.Listen<NotesSelectionEvent>()
                 .Subscribe(e => {
+                    if (PanelControlPressed) {
+                        PanelControlPressed = false;
+                        DocManager.Inst.EndUndoGroup();
+                    }
+                    NoteLoading = true;
+
                     selectedNotes.Clear();
                     selectedNotes.UnionWith(e.selectedNotes);
                     selectedNotes.UnionWith(e.tempSelectedNotes);
                     OnSelectNotes();
+
+                    NoteLoading = false;
                 });
 
             DocManager.Inst.AddSubscriber(this);
         }
 
+        // note -> panel
         private void OnSelectNotes() {
-            PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
-            PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
-            AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
-            AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
+            this.RaisePropertyChanged(nameof(Title));
 
             if (selectedNotes.Count > 0) {
                 IsNoteSelected = true;
                 var note = selectedNotes.First();
 
                 Lyric = note.lyric;
+                if (note.pitch.data.Count == 2) {
+                    PortamentoLength = note.pitch.data[1].X - note.pitch.data[0].X;
+                    PortamentoStart = note.pitch.data[0].X;
+                } else {
+                    PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+                    PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+                }
                 VibratoEnable = note.vibrato.length == 0 ? false : true;
-                VibratoLength = note.vibrato.length == 0 ? NotePresets.Default.DefaultVibrato.VibratoLength : note.vibrato.length;
+                VibratoLength = note.vibrato.length;
                 VibratoPeriod = note.vibrato.period;
                 VibratoDepth = note.vibrato.depth;
                 VibratoIn = note.vibrato.@in;
@@ -103,6 +102,9 @@ namespace OpenUtau.App.ViewModels {
             } else {
                 IsNoteSelected = false;
                 Lyric = NotePresets.Default.DefaultLyric;
+                PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+                PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+                VibratoEnable = false;
                 VibratoLength = NotePresets.Default.DefaultVibrato.VibratoLength;
                 VibratoPeriod = NotePresets.Default.DefaultVibrato.VibratoPeriod;
                 VibratoDepth = NotePresets.Default.DefaultVibrato.VibratoDepth;
@@ -110,20 +112,24 @@ namespace OpenUtau.App.ViewModels {
                 VibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
                 VibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
             }
+            AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
+            AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
+
             AttachExpressions();
         }
 
         public void LoadPart(UPart? part) {
             Expressions.Clear();
             if (part != null && part is UVoicePart) {
-                this.part = part as UVoicePart;
+                this.Part = part as UVoicePart;
 
                 foreach (KeyValuePair<string, UExpressionDescriptor> pair in DocManager.Inst.Project.expressions) {
                     if (pair.Value.type != UExpressionType.Curve) {
-                        var viewModel = new NotePropertyExpViewModel(pair.Value);
+                        var viewModel = new NotePropertyExpViewModel(pair.Value, this);
                         if (pair.Value.abbr == Ustx.CLR) {
                             var track = DocManager.Inst.Project.tracks[part.trackNo];
                             if (track.VoiceColorExp != null && track.VoiceColorExp.options.Length > 0) {
+                                viewModel.Options.Clear();
                                 track.VoiceColorExp.options.ForEach(opt => viewModel.Options.Add(opt));
                             }
                         }
@@ -132,7 +138,7 @@ namespace OpenUtau.App.ViewModels {
                 }
                 AttachExpressions();
             } else {
-                this.part = null;
+                this.Part = null;
             }
         }
 
@@ -171,12 +177,279 @@ namespace OpenUtau.App.ViewModels {
             }
         }
 
+        #region ICmdSubscriber
+        public void OnNext(UCommand cmd, bool isUndo) {
+            var note = selectedNotes.FirstOrDefault();
+            if (note == null || AllowNoteEdit) { return; }
+
+            if (cmd is NoteCommand noteCommand) {
+                if (cmd is ChangeNoteLyricCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        Lyric = note.lyric;
+                    }
+                } else if (cmd is VibratoLengthCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        if (note.vibrato.length > 0) {
+                            VibratoEnable = true;
+                        } else {
+                            VibratoEnable = false;
+                        }
+                        VibratoLength = note.vibrato.length;
+                    }
+                } else if (cmd is VibratoFadeInCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        VibratoIn = note.vibrato.@in;
+                    }
+                } else if (cmd is VibratoFadeOutCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        VibratoOut = note.vibrato.@out;
+                    }
+                } else if (cmd is VibratoDepthCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        VibratoDepth = note.vibrato.depth;
+                    }
+                } else if (cmd is VibratoPeriodCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        VibratoPeriod = note.vibrato.period;
+                    }
+                } else if (cmd is VibratoShiftCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        VibratoShift = note.vibrato.shift;
+                    }
+                }
+            } else if (cmd is ExpCommand) {
+                if (cmd is PitchExpCommand pitchExpCommand) {
+                    if (pitchExpCommand.Note == null || pitchExpCommand.Note == note) {
+                        if (note.pitch.data.Count == 2) {
+                            PortamentoLength = note.pitch.data[1].X - note.pitch.data[0].X;
+                            PortamentoStart = note.pitch.data[0].X;
+                        } else {
+                            PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+                            PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+                        }
+                    }
+                } else if (cmd is SetPhonemeExpressionCommand || cmd is ResetExpressionsCommand) {
+                    AttachExpressions();
+                }
+            }
+        }
+        #endregion
+
+        // panel -> note
+        private void SetValueChanges() {
+            this.WhenAnyValue(vm => vm.Lyric)
+                .Subscribe(lyric => {
+                    if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                        if (!string.IsNullOrEmpty(lyric)) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.lyric != lyric) {
+                                    DocManager.Inst.ExecuteCmd(new ChangeNoteLyricCommand(Part, note, lyric));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.PortamentoLength)
+                .Subscribe(value => {
+                    if (value >= 2 && value <= 320) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            var pitch = new UPitch() { snapFirst = true };
+                            pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
+                            pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
+                            foreach (UNote note in selectedNotes) {
+                                DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, pitch));
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.PortamentoStart)
+                .Subscribe(value => {
+                    if (value >= -200 && value <= 200) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            var pitch = new UPitch() { snapFirst = true };
+                            pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
+                            pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
+                            foreach (UNote note in selectedNotes) {
+                                DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, pitch));
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoLength)
+                .Subscribe(value => {
+                    if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                        if (value >= 0 && value <= 100) {
+                            UNote first = selectedNotes.First();
+                            foreach (UNote note in selectedNotes) {
+                                if (note != first && AutoVibratoToggle && note.duration < AutoVibratoNoteLength) {
+                                    if (note.vibrato.length != 0) {
+                                        DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, 0));
+                                    }
+                                } else {
+                                    if (note.vibrato.length != value) {
+                                        DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, value));
+                                    }
+                                }
+                            }
+                            if (first.vibrato.length > 0) {
+                                VibratoEnable = true;
+                            } else {
+                                VibratoEnable = false;
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoPeriod)
+                .Subscribe(value => {
+                    if (value >= 5 && value <= 500) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.period != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoPeriodCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoDepth)
+                .Subscribe(value => {
+                    if (value >= 5 && value <= 200) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.depth != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoDepthCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoIn)
+                .Subscribe(value => {
+                    if (value >= 0 && value <= 100) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.@in != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoFadeInCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoOut)
+                .Subscribe(value => {
+                    if (value >= 0 && value <= 100) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.@out != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoFadeOutCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoShift)
+                .Subscribe(value => {
+                    if (value >= 0 && value <= 100) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.shift != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoShiftCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+
+            this.WhenAnyValue(vm => vm.ApplyPortamentoPreset)
+                .WhereNotNull()
+                .Subscribe(portamentoPreset => {
+                    if (portamentoPreset != null && Part != null && selectedNotes.Count > 0) {
+                        DocManager.Inst.StartUndoGroup();
+                        PortamentoLength = portamentoPreset.PortamentoLength;
+                        PanelControlPressed = true;
+                        PortamentoStart = portamentoPreset.PortamentoStart;
+                        PanelControlPressed = false;
+                        DocManager.Inst.EndUndoGroup();
+                    }
+                });
+            this.WhenAnyValue(vm => vm.ApplyVibratoPreset)
+                .WhereNotNull()
+                .Subscribe(vibratoPreset => {
+                    if (vibratoPreset != null && Part != null && selectedNotes.Count > 0) {
+                        DocManager.Inst.StartUndoGroup();
+                        PanelControlPressed = true;
+                        VibratoLength = Math.Max(0, Math.Min(100, vibratoPreset.VibratoLength));
+                        VibratoPeriod = Math.Max(5, Math.Min(500, vibratoPreset.VibratoPeriod));
+                        VibratoDepth = Math.Max(5, Math.Min(200, vibratoPreset.VibratoDepth));
+                        VibratoIn = Math.Max(0, Math.Min(100, vibratoPreset.VibratoIn));
+                        VibratoOut = Math.Max(0, Math.Min(100, vibratoPreset.VibratoOut));
+                        VibratoShift = Math.Max(0, Math.Min(100, vibratoPreset.VibratoShift));
+                        PanelControlPressed = false;
+                        DocManager.Inst.EndUndoGroup();
+                    }
+                });
+        }
+        public void SetVibratoEnable() {
+            if (Part != null && selectedNotes.Count > 0) {
+                DocManager.Inst.StartUndoGroup();
+                bool enable = VibratoEnable;
+                UNote first = selectedNotes.First();
+
+                foreach (UNote note in selectedNotes) {
+                    if (enable) {
+                        if (note.vibrato.length != 0) {
+                            DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, 0));
+                        }
+                    } else {
+                        if (note != first && AutoVibratoToggle && note.duration < AutoVibratoNoteLength) {
+                            if (note.vibrato.length != 0) {
+                                DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, 0));
+                            }
+                        } else {
+                            if (note.vibrato.length != NotePresets.Default.DefaultVibrato.VibratoLength) {
+                                DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, NotePresets.Default.DefaultVibrato.VibratoLength));
+                            }
+                        }
+                    }
+                }
+                DocManager.Inst.EndUndoGroup();
+            }
+        }
+        public void SetNumericalExpressionsChanges(string abbr, float value) {
+            if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                var track = DocManager.Inst.Project.tracks[Part.trackNo];
+
+                foreach (UNote note in selectedNotes) {
+                    foreach (UPhoneme phoneme in Part.phonemes) {
+                        if (phoneme.Parent == note) {
+                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, Part, phoneme, abbr, value));
+                        }
+                    }
+                }
+            }
+        }
+        public void SetOptionalExpressionsChanges(string abbr, int value) {
+            if (!NoteLoading && Part != null && selectedNotes.Count > 0) {
+                var track = DocManager.Inst.Project.tracks[Part.trackNo];
+                DocManager.Inst.StartUndoGroup();
+
+                foreach (UNote note in selectedNotes) {
+                    foreach (UPhoneme phoneme in Part.phonemes) {
+                        if (phoneme.Parent == note) {
+                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, Part, phoneme, abbr, value));
+                        }
+                    }
+                }
+                DocManager.Inst.EndUndoGroup();
+            }
+        }
+
         // presets
         public void SavePortamentoPreset(string name) {
             if (string.IsNullOrEmpty(name)) {
                 return;
             }
-            NotePresets.Default.PortamentoPresets.Add(new NotePresets.PortamentoPreset(name, PortamentoLength, PortamentoStart));
+            NotePresets.Default.PortamentoPresets.Add(new NotePresets.PortamentoPreset(name, (int)PortamentoLength, (int)PortamentoStart));
             NotePresets.Save();
         }
         public void RemoveAppliedPortamentoPreset() {
@@ -200,122 +473,6 @@ namespace OpenUtau.App.ViewModels {
             NotePresets.Default.VibratoPresets.Remove(appliedVibratoPreset);
             NotePresets.Save();
         }
-
-        #region ICmdSubscriber
-        public void OnNext(UCommand cmd, bool isUndo) {
-            var note = selectedNotes.FirstOrDefault();
-            if (note == null) { return; }
-
-            if (cmd is NoteCommand) {
-                if (cmd is ChangeNoteLyricCommand changeNoteLyricCommand) {
-                    if (changeNoteLyricCommand.Notes.Contains(note)) {
-                        Lyric = note.lyric;
-                    }
-                } else if (cmd is VibratoLengthCommand vibratoLengthCommand) {
-                    if (vibratoLengthCommand.Notes.Contains(note)) {
-                        if (note.vibrato.length == 0) {
-                            VibratoEnable = false;
-                            VibratoLength = NotePresets.Default.DefaultVibrato.VibratoLength;
-                        } else {
-                            VibratoEnable = true;
-                            VibratoLength = note.vibrato.length;
-                        }
-                    }
-                } else if (cmd is VibratoFadeInCommand vibratoFadeInCommand) {
-                    if (vibratoFadeInCommand.Notes.Contains(note)) {
-                        VibratoIn = note.vibrato.@in;
-                    }
-                } else if (cmd is VibratoFadeOutCommand vibratoFadeOutCommand) {
-                    if (vibratoFadeOutCommand.Notes.Contains(note)) {
-                        VibratoOut = note.vibrato.@out;
-                    }
-                } else if (cmd is VibratoDepthCommand vibratoDepthCommand) {
-                    if (vibratoDepthCommand.Notes.Contains(note)) {
-                        VibratoDepth = note.vibrato.depth;
-                    }
-                } else if (cmd is VibratoPeriodCommand vibratoPeriodCommand) {
-                    if (vibratoPeriodCommand.Notes.Contains(note)) {
-                        VibratoPeriod = note.vibrato.period;
-                    }
-                } else if (cmd is VibratoShiftCommand vibratoShiftCommand) {
-                    if (vibratoShiftCommand.Notes.Contains(note)) {
-                        VibratoShift = note.vibrato.shift;
-                    }
-                }
-            } else if (cmd is ExpCommand) {
-                if (cmd is PitchExpCommand pitchExpCommand) {
-                    // 
-                } else if (cmd is SetPhonemeExpressionCommand || cmd is ResetExpressionsCommand) {
-                    AttachExpressions();
-                }
-            }
-        }
-        #endregion
-
-        /*public void Finish() {
-            if (notesViewModel.Part != null) {
-                UVoicePart part = notesViewModel.Part;
-                List<UNote> selectedNotes = notesViewModel.Selection.ToList();
-
-                DocManager.Inst.StartUndoGroup();
-
-                if (SetLyric) {
-                    foreach (UNote note in selectedNotes) {
-                        if (note.lyric != Lyric) {
-                            DocManager.Inst.ExecuteCmd(new ChangeNoteLyricCommand(part, note, Lyric));
-                        }
-                    }
-                }
-                if (SetPortamento) {
-                    foreach (UNote note in selectedNotes) {
-                        var pitch = new UPitch();
-                        pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
-                        pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
-                        DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(part, note, pitch));
-                    }
-                }
-                if (SetVibrato) {
-                    foreach (UNote note in selectedNotes) {
-                        if(VibratoEnable && VibratoLength != 0) {
-                            if (!AutoVibratoToggle || (AutoVibratoToggle && note.duration >= AutoVibratoNoteLength)) {
-                                DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(part, note, VibratoLength));
-                                DocManager.Inst.ExecuteCmd(new VibratoFadeInCommand(part, note, VibratoIn));
-                                DocManager.Inst.ExecuteCmd(new VibratoFadeOutCommand(part, note, VibratoOut));
-                                DocManager.Inst.ExecuteCmd(new VibratoDepthCommand(part, note, VibratoDepth));
-                                DocManager.Inst.ExecuteCmd(new VibratoPeriodCommand(part, note, VibratoPeriod));
-                                DocManager.Inst.ExecuteCmd(new VibratoShiftCommand(part, note, VibratoShift));
-                            } else {
-                                DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(part, note, 0));
-                            }
-                        } else if (note.vibrato.length != 0) {
-                            DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(part, note, 0));
-                        }
-                    }
-                }
-                foreach (NotePropertyExpViewModel expVM in Expressions) {
-                    if (expVM.Set) {
-                        float value;
-                        if (expVM.IsNumerical) {
-                            value = expVM.Value;
-                        } else if (expVM.IsOptions) {
-                            value = expVM.SelectedOption;
-                        } else {
-                            continue;
-                        }
-                        var track = notesViewModel.Project.tracks[notesViewModel.Part.trackNo];
-                        foreach (UNote note in selectedNotes) {
-                            foreach (UPhoneme phoneme in notesViewModel.Part.phonemes) {
-                                if (phoneme.Parent == note) {
-                                    DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(notesViewModel.Project, track, notesViewModel.Part, phoneme, expVM.abbr, value));
-                                }
-                            }
-                        }
-                    }
-                }
-
-                DocManager.Inst.EndUndoGroup();
-            }
-        }*/
     }
 
     public class NotePropertyExpViewModel : ViewModelBase {
@@ -331,8 +488,11 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public bool IsNoteSelected { get; set; } = false;
         [Reactive] public float Value { get; set; }
         [Reactive] public int SelectedOption { get; set; }
+        [Reactive] public bool DropDownOpen { get; set; }
 
-        public NotePropertyExpViewModel(UExpressionDescriptor descriptor) {
+        private NotePropertiesViewModel parentViewmodel;
+
+        public NotePropertyExpViewModel(UExpressionDescriptor descriptor, NotePropertiesViewModel parent) {
             Name = descriptor.name;
             defaultValue = descriptor.defaultValue;
             abbr = descriptor.abbr;
@@ -345,6 +505,25 @@ namespace OpenUtau.App.ViewModels {
                 IsOptions = true;
                 descriptor.options.ForEach(opt => Options.Add(opt));
                 SelectedOption = (int)defaultValue;
+            }
+
+            parentViewmodel = parent;
+
+            if (IsNumerical) {
+                this.WhenAnyValue(vm => vm.Value)
+                    .Subscribe(value => {
+                        if (value >= Min && value <= Max) {
+                            parentViewmodel.SetNumericalExpressionsChanges(abbr, value);
+                        }
+                    });
+            }
+            if (IsOptions) {
+                this.WhenAnyValue(vm => vm.SelectedOption)
+                    .Subscribe(value => {
+                        if (value >= 0 && DropDownOpen) {
+                            parentViewmodel.SetOptionalExpressionsChanges(abbr, value);
+                        }
+                    });
             }
         }
         public override string ToString() {

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -32,12 +32,12 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public bool AutoVibratoToggle { get; set; }
         [Reactive] public bool IsNoteSelected { get; set; } = false;
 
-        public List<NotePresets.PortamentoPreset>? PortamentoPresets { get; }
+        [Reactive] public ObservableCollection<NotePresets.PortamentoPreset>? PortamentoPresets { get; private set; }
         public NotePresets.PortamentoPreset? ApplyPortamentoPreset {
             get => appliedPortamentoPreset;
             set => this.RaiseAndSetIfChanged(ref appliedPortamentoPreset, value);
         }
-        public List<NotePresets.VibratoPreset>? VibratoPresets { get; }
+        [Reactive] public ObservableCollection<NotePresets.VibratoPreset>? VibratoPresets { get; private set; }
         public NotePresets.VibratoPreset? ApplyVibratoPreset {
             get => appliedVibratoPreset;
             set => this.RaiseAndSetIfChanged(ref appliedVibratoPreset, value);
@@ -53,8 +53,8 @@ namespace OpenUtau.App.ViewModels {
         private static bool AllowNoteEdit { get => PanelControlPressed && !NoteLoading; }
 
         public NotePropertiesViewModel() {
-            PortamentoPresets = NotePresets.Default.PortamentoPresets;
-            VibratoPresets = NotePresets.Default.VibratoPresets;
+            PortamentoPresets = new ObservableCollection<NotePresets.PortamentoPreset>(NotePresets.Default.PortamentoPresets);
+            VibratoPresets = new ObservableCollection<NotePresets.VibratoPreset>(NotePresets.Default.VibratoPresets);
 
             SetValueChanges();
 
@@ -403,6 +403,7 @@ namespace OpenUtau.App.ViewModels {
                         VibratoIn = Math.Max(0, Math.Min(100, vibratoPreset.VibratoIn));
                         VibratoOut = Math.Max(0, Math.Min(100, vibratoPreset.VibratoOut));
                         VibratoShift = Math.Max(0, Math.Min(100, vibratoPreset.VibratoShift));
+                        VibratoDrift = Math.Max(-100, Math.Min(100, vibratoPreset.VibratoDrift));
                         PanelControlPressed = false;
                         DocManager.Inst.EndUndoGroup();
                     }
@@ -470,6 +471,7 @@ namespace OpenUtau.App.ViewModels {
             }
             NotePresets.Default.PortamentoPresets.Add(new NotePresets.PortamentoPreset(name, (int)PortamentoLength, (int)PortamentoStart));
             NotePresets.Save();
+            PortamentoPresets = new ObservableCollection<NotePresets.PortamentoPreset>(NotePresets.Default.PortamentoPresets);
         }
         public void RemoveAppliedPortamentoPreset() {
             if (appliedPortamentoPreset == null) {
@@ -477,6 +479,7 @@ namespace OpenUtau.App.ViewModels {
             }
             NotePresets.Default.PortamentoPresets.Remove(appliedPortamentoPreset);
             NotePresets.Save();
+            PortamentoPresets = new ObservableCollection<NotePresets.PortamentoPreset>(NotePresets.Default.PortamentoPresets);
         }
         public void SaveVibratoPreset(string name) {
             if (string.IsNullOrEmpty(name)) {
@@ -484,6 +487,7 @@ namespace OpenUtau.App.ViewModels {
             }
             NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, VibratoLength, VibratoPeriod, VibratoDepth, VibratoIn, VibratoOut, VibratoShift, VibratoDrift));
             NotePresets.Save();
+            VibratoPresets = new ObservableCollection<NotePresets.VibratoPreset>(NotePresets.Default.VibratoPresets);
         }
         public void RemoveAppliedVibratoPreset() {
             if (appliedVibratoPreset == null) {
@@ -491,6 +495,7 @@ namespace OpenUtau.App.ViewModels {
             }
             NotePresets.Default.VibratoPresets.Remove(appliedVibratoPreset);
             NotePresets.Save();
+            VibratoPresets = new ObservableCollection<NotePresets.VibratoPreset>(NotePresets.Default.VibratoPresets);
         }
     }
 

--- a/OpenUtau/Views/ExpressionsDialog.axaml
+++ b/OpenUtau/Views/ExpressionsDialog.axaml
@@ -13,6 +13,10 @@
   <Design.DataContext>
     <vm:ExpressionsViewModel/>
   </Design.DataContext>
+  <Window.Styles>
+    <StyleInclude Source="/Styles/PianoRollStyles.axaml"/>
+  </Window.Styles>
+  
   <Grid Margin="{Binding $parent.WindowDecorationMargin}">
     <Border Margin="10,10,10,40" Width="150" HorizontalAlignment="Left">
       <ListBox ItemsSource="{Binding Expressions}" SelectedItem="{Binding Expression}">

--- a/OpenUtau/Views/NoteDefaultsDialog.axaml
+++ b/OpenUtau/Views/NoteDefaultsDialog.axaml
@@ -104,6 +104,12 @@
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoShift}" Minimum="0" Maximum="100"
                       TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
+                <Grid ColumnDefinitions="180,20,50,20,*">
+                  <Label Content="{DynamicResource notedefaults.vibrato.drift}"/>
+                  <TextBox Grid.Column="2" Text="{Binding CurrentVibratoDrift}" />
+                  <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoDrift}" Minimum="-100" Maximum="100"
+                  TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                </Grid>
                   <Grid ColumnDefinitions="173,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.autotoggle}"/>
                       <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -14,502 +14,499 @@
   <Window.Styles>
     <StyleInclude Source="/Styles/PianoRollStyles.axaml"/>
   </Window.Styles>
-  <Grid>
-  <Border>
-    <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="{Binding $parent[1].WindowDecorationMargin}">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="24"/>
-        <RowDefinition Height="24"/>
-        <RowDefinition Height="*" MinHeight="200"/>
-        <RowDefinition Height="10"/>
-        <RowDefinition Height="150" MinHeight="132" MaxHeight="600"/>
-        <RowDefinition Height="4"/>
-      </Grid.RowDefinitions>
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="60"/>
-        <ColumnDefinition Width="*"/>
-        <ColumnDefinition Width="24"/>
-        <ColumnDefinition Width="Auto"/>
-      </Grid.ColumnDefinitions>
-      <Grid Grid.Column="0" Grid.Row="0" Grid.RowSpan="2">
-        <Rectangle HorizontalAlignment="Left" VerticalAlignment="Stretch" Width="12" Fill="{Binding NotesViewModel.TrackAccentColor}"/>
-        <Border Margin="12,0,0,0" Width="48" Height="48" ClipToBounds="True">
-          <Image HorizontalAlignment="Center" VerticalAlignment="Center"
-                 Width="50" Height="50" Stretch="None" Source="{Binding NotesViewModel.Avatar}"/>
-        </Border>
-      </Grid>
-      <ScrollBar Name="HScrollBar" Classes="music" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                 Margin="0,4,0,4" Orientation="Horizontal" AllowAutoHide="False"
-                 DataContext="{Binding NotesViewModel}"
-                 Maximum="{Binding HScrollBarMax, Mode=OneWay}"
-                 Value="{Binding TickOffset}"
-                 ViewportSize="{Binding ViewportTicks}"
-                 LargeChange="{Binding ViewportTicks}"
-                 SmallChange="{Binding SmallChangeX}" PointerWheelChanged="HScrollPointerWheelChanged"/>
-      <ScrollBar Name="VScrollBar" Classes="music" Grid.Row="2" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                 Margin="4,0,4,0" Orientation="Vertical" AllowAutoHide="False"
-                 DataContext="{Binding NotesViewModel}"
-                 Maximum="{Binding VScrollBarMax, Mode=OneWay}"
-                 Value="{Binding TrackOffset}"
-                 ViewportSize="{Binding ViewportTracks}"
-                 LargeChange="{Binding ViewportTracks}"
-                 SmallChange="{Binding SmallChangeY}" PointerWheelChanged="VScrollPointerWheelChanged"/>
-      <c:TrackBackground Grid.Column="0" Grid.Row="2" IsPianoRoll="True" IsKeyboard="True"
-                         Foreground="{DynamicResource BlackKeyBrush}"
-                         Background="{DynamicResource WhiteKeyBrush}"
-                         DataContext="{Binding NotesViewModel}"
-                         TrackHeight="{Binding TrackHeight}"
-                         TrackOffset="{Binding TrackOffset}"
-                         PointerWheelChanged="KeyboardPointerWheelChanged"
-                         PointerPressed="KeyboardPointerPressed"
-                         PointerMoved="KeyboardPointerMoved"
-                         PointerReleased="KeyboardPointerReleased"/>
-      <Grid Grid.Column="0" Grid.Row="4">
-        <c:ExpSelector Name="expSelector1" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
-                       Index="0" Margin="0,0,0,0" ToolTip.Tip="Alt + 1"/>
-        <c:ExpSelector Name="expSelector2" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
-                       Index="1" Margin="0,22,0,0" ToolTip.Tip="Alt + 2"/>
-        <c:ExpSelector Name="expSelector3" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
-                       Index="2" Margin="0,44,0,0" ToolTip.Tip="Alt + 3"/>
-        <c:ExpSelector Name="expSelector4" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
-                       Index="3" Margin="0,66,0,0" ToolTip.Tip="Alt + 4"/>
-        <c:ExpSelector Name="expSelector5" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
-                       Index="4" Margin="0,88,0,0" ToolTip.Tip="Alt + 5"/>
-        <Button VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="20" Height="20" Margin="0" Background="Transparent" Click="OnExpButtonClick">
-          <Path Classes="clear" Width="24" Height="24"
-                Data="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"
-                Fill="{StaticResource NeutralAccentBrush}">
-            <Path.RenderTransform>
-              <TransformGroup>
-                <ScaleTransform ScaleX=".75" ScaleY=".75"/>
-                <TranslateTransform X="0" Y="1"/>
-              </TransformGroup>
-            </Path.RenderTransform>
-          </Path>
-        </Button>
-      </Grid>
-      <Canvas Name="TimelineCanvas" Grid.Row="1" Grid.Column="1"
-              Background="Transparent" ClipToBounds="True"
-              PointerWheelChanged="TimelinePointerWheelChanged"
-              PointerPressed="TimelinePointerPressed"
-              PointerMoved="TimelinePointerMoved"
-              PointerReleased="TimelinePointerReleased">
-        <Path Name="PlayPos"
-              Canvas.Left="{Binding NotesViewModel.PlayPosX}"
-              Canvas.Top="0" ZIndex="100" IsHitTestVisible="False"
-              Fill="{DynamicResource NeutralAccentBrushSemi}"
-              Data="M -6.5 0 L 6.5 0 L 6.5 3 L 0 9 L -6.5 3 Z"/>
-      </Canvas>
-      <c:TrackBackground Grid.Row="2" Grid.Column="1" IsHitTestVisible="False"
-                         Foreground="{DynamicResource TrackBackgroundAltBrush}"
-                         DataContext="{Binding NotesViewModel}"
-                         Bounds="{Binding Bounds, Mode=OneWayToSource}"
-                         TrackHeight="{Binding TrackHeight}"
-                         TrackOffset="{Binding TrackOffset}" IsPianoRoll="True"/>
-      <c:TickBackground Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" IsHitTestVisible="False"
-                        Foreground="{DynamicResource TickLineBrush}"
-                        Background="{DynamicResource TickLineBrushLow}"
-                        Resolution="{Binding PlaybackViewModel.Resolution}"
-                        TickWidth="{Binding NotesViewModel.TickWidth}"
-                        TickOrigin="{Binding NotesViewModel.TickOrigin}"
-                        TickOffset="{Binding NotesViewModel.TickOffset}"
-                        SnapDiv="{Binding NotesViewModel.SnapDiv, Mode=OneWay}"
-                        SnapTicks="{Binding NotesViewModel.SnapTicks}"
-                        ShowBarNumber="True"/>
-      <Image Grid.Row="2" Grid.RowSpan="3" Grid.Column="1" HorizontalAlignment="Right" Margin="0,0,100,0"
-             Source="{Binding NotesViewModel.Portrait}" OpacityMask="{Binding NotesViewModel.PortraitMask}" Stretch="None"/>
-      <Border Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
-              Margin="0,0,0,60" Height="60" IsHitTestVisible="False">
-        <c:WaveformImage DataContext="{Binding NotesViewModel, Mode=OneWay}"
-                         TickWidth="{Binding TickWidth, Mode=OneWay}"
-                         TickOffset="{Binding TickOffset, Mode=OneWay}"
-                         ShowWaveform="{Binding ShowWaveform, Mode=OneWay}"/>
+
+  <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="{Binding $parent[1].WindowDecorationMargin}">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="24"/>
+      <RowDefinition Height="24"/>
+      <RowDefinition Height="*" MinHeight="200"/>
+      <RowDefinition Height="10"/>
+      <RowDefinition Height="150" MinHeight="132" MaxHeight="600"/>
+      <RowDefinition Height="4"/>
+    </Grid.RowDefinitions>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="60"/>
+      <ColumnDefinition Width="*"/>
+      <ColumnDefinition Width="24"/>
+      <ColumnDefinition Width="Auto"/>
+    </Grid.ColumnDefinitions>
+    <Grid Grid.Column="0" Grid.Row="0" Grid.RowSpan="2">
+      <Rectangle HorizontalAlignment="Left" VerticalAlignment="Stretch" Width="12" Fill="{Binding NotesViewModel.TrackAccentColor}"/>
+      <Border Margin="12,0,0,0" Width="48" Height="48" ClipToBounds="True">
+        <Image HorizontalAlignment="Center" VerticalAlignment="Center"
+               Width="50" Height="50" Stretch="None" Source="{Binding NotesViewModel.Avatar}"/>
       </Border>
-      <c:NotesCanvas Grid.Row="2" Grid.Column="1"
-                     TickWidth="{Binding NotesViewModel.TickWidth}"
-                     TrackHeight="{Binding NotesViewModel.TrackHeight}"
-                     TickOffset="{Binding NotesViewModel.TickOffset}"
-                     TrackOffset="{Binding NotesViewModel.TrackOffset}"
-                     ShowVibrato="{Binding NotesViewModel.ShowVibrato}"
-                     ShowPitch="{Binding NotesViewModel.ShowPitch}"
-                     ShowFinalPitch="{Binding NotesViewModel.ShowFinalPitch}"
-                     Part="{Binding NotesViewModel.Part}"
-                     PointerPressed="NotesCanvasPointerPressed"
-                     PointerMoved="NotesCanvasPointerMoved"
-                     PointerReleased="NotesCanvasPointerReleased"
-                     DoubleTapped="NotesCanvasDoubleTapped"
-                     PointerWheelChanged="NotesCanvasPointerWheelChanged">
-        <c:NotesCanvas.ContextMenu>
-          <ContextMenu ItemsSource="{Binding NotesContextMenuItems}"
-                       Opening="NotesContextMenuOpening"
-                       Closing="NotesContextMenuClosing">
-            <ContextMenu.Styles>
-              <Style Selector="MenuItem">
-                <Setter Property="Header" Value="{Binding Header}"/>
-                <Setter Property="Command" Value="{Binding Command, FallbackValue={x:Null}}"/>
-                <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
-                <Setter Property="ItemsSource" Value="{Binding Items}"/>
-              </Style>
-            </ContextMenu.Styles>
-          </ContextMenu>
-        </c:NotesCanvas.ContextMenu>
-      </c:NotesCanvas>
-      <Canvas Grid.Row="2" Grid.Column="1" IsHitTestVisible="False" ClipToBounds="True">
-        <Rectangle Name="PlayPosHighlight"
-                   Width="{Binding NotesViewModel.PlayPosHighlightWidth, Mode=OneWay}"
-                   Height="{Binding $parent.Bounds.Height, Mode=OneWay}"
-                   Canvas.Left="{Binding NotesViewModel.PlayPosHighlightX, Mode=OneWay}"
-                   Canvas.Top="0" ZIndex="-10"
-                   Fill="{DynamicResource NeutralAccentBrushSemi2}"/>
-        <Rectangle Name="SelectionBox" StrokeThickness="2"
-                   Stroke="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                   Fill="{DynamicResource TickLineBrushLow}" ZIndex="1000"
-                   IsHitTestVisible="False" IsVisible="False"/>
-      </Canvas>
-      <StackPanel Grid.Row="2" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Top"
-                  Margin="12,12,0,0" Orientation="Horizontal">
-        <Border CornerRadius="2" BoxShadow="0 0 5 1 #1F000000"
-                Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
-          <Border CornerRadius="2" ClipToBounds="True">
-            <StackPanel Orientation="Horizontal">
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" CornerRadius="2,0,0,2"
-                            IsChecked="{Binding NotesViewModel.CursorTool, Mode=OneWay}"
-                            Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="1"
-                            ToolTip.Tip="{DynamicResource pianoroll.tool.selectionv2}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M10.07,14.27C10.57,14.03 11.16,14.25 11.4,14.75L13.7,19.74L15.5,18.89L13.19,13.91C12.95,13.41 13.17,12.81 13.67,12.58L13.95,12.5L16.25,12.05L8,5.12V15.9L9.82,14.43L10.07,14.27M13.64,21.97C13.14,22.21 12.54,22 12.31,21.5L10.13,16.76L7.62,18.78C7.45,18.92 7.24,19 7,19A1,1 0 0,1 6,18V3A1,1 0 0,1 7,2C7.24,2 7.47,2.09 7.64,2.23L7.65,2.22L19.14,11.86C19.57,12.22 19.62,12.85 19.27,13.27C19.12,13.45 18.91,13.57 18.7,13.61L15.54,14.23L17.74,18.96C18,19.46 17.76,20.05 17.26,20.28L13.64,21.97Z" >
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".55" ScaleY=".55" />
-                        <TranslateTransform X="-2" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                            IsChecked="{Binding NotesViewModel.PenTool, Mode=OneWay}"
-                            Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="2"
-                            ToolTip.Tip="{DynamicResource pianoroll.tool.penv2}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M14.06,9L15,9.94L5.92,19H5V18.08L14.06,9M17.66,3C17.41,3 17.15,3.1 16.96,3.29L15.13,5.12L18.88,8.87L20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18.17,3.09 17.92,3 17.66,3M14.06,6.19L3,17.25V21H6.75L17.81,9.94L14.06,6.19Z" >
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".6" ScaleY=".6" />
-                        <TranslateTransform X="-2" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                            IsChecked="{Binding NotesViewModel.PenPlusTool, Mode=OneWay}"
-                            Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="2+"
-                            ToolTip.Tip="{DynamicResource pianoroll.tool.penplus}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M14.1,9L15,9.9L5.9,19H5V18.1L14.1,9M17.7,3C17.5,3 17.2,3.1 17,3.3L15.2,5.1L18.9,8.9L20.7,7C21.1,6.6 21.1,6 20.7,5.6L18.4,3.3C18.2,3.1 17.9,3 17.7,3M14.1,6.2L3,17.2V21H6.8L17.8,9.9L14.1,6.2M7,2V5H10V7H7V10H5V7H2V5H5V2H7Z" >
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".6" ScaleY=".6" />
-                        <TranslateTransform X="-1" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                            IsChecked="{Binding NotesViewModel.EraserTool, Mode=OneWay}"
-                            Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="3"
-                            ToolTip.Tip="{DynamicResource pianoroll.tool.eraser}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M16.24,3.56L21.19,8.5C21.97,9.29 21.97,10.55 21.19,11.34L12,20.53C10.44,22.09 7.91,22.09 6.34,20.53L2.81,17C2.03,16.21 2.03,14.95 2.81,14.16L13.41,3.56C14.2,2.78 15.46,2.78 16.24,3.56M4.22,15.58L7.76,19.11C8.54,19.9 9.8,19.9 10.59,19.11L14.12,15.58L9.17,10.63L4.22,15.58Z" >
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".6" ScaleY=".6" />
-                        <TranslateTransform X="-2" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                            IsChecked="{Binding NotesViewModel.DrawPitchTool, Mode=OneWay}"
-                            Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="4"
-                            ToolTip.Tip="{DynamicResource pianoroll.tool.drawpitch}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M9.75 20.85C11.53 20.15 11.14 18.22 10.24 17C9.35 15.75 8.12 14.89 6.88 14.06C6 13.5 5.19 12.8 4.54 12C4.26 11.67 3.69 11.06 4.27 10.94C4.86 10.82 5.88 11.4 6.4 11.62C7.31 12 8.21 12.44 9.05 12.96L10.06 11.26C8.5 10.23 6.5 9.32 4.64 9.05C3.58 8.89 2.46 9.11 2.1 10.26C1.78 11.25 2.29 12.25 2.87 13.03C4.24 14.86 6.37 15.74 7.96 17.32C8.3 17.65 8.71 18.04 8.91 18.5C9.12 18.94 9.07 18.97 8.6 18.97C7.36 18.97 5.81 18 4.8 17.36L3.79 19.06C5.32 20 7.88 21.47 9.75 20.85M20.84 5.25C21.06 5.03 21.06 4.67 20.84 4.46L19.54 3.16C19.33 2.95 18.97 2.95 18.76 3.16L17.74 4.18L19.82 6.26M11 10.92V13H13.08L19.23 6.85L17.15 4.77L11 10.92Z" >
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".7" ScaleY=".7" />
-                        <TranslateTransform X="-1" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                            IsChecked="{Binding NotesViewModel.KnifeTool, Mode=OneWay}"
-                            Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="5"
-                            ToolTip.Tip="{DynamicResource pianoroll.tool.knife}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M7.22,11.91C6.89,12.24 6.71,12.65 6.66,13.08L12.17,15.44L20.66,6.96C21.44,6.17 21.44,4.91 20.66,4.13L19.24,2.71C18.46,1.93 17.2,1.93 16.41,2.71L7.22,11.91M5,16V21.75L10.81,16.53L5.81,14.53L5,16M17.12,4.83C17.5,4.44 18.15,4.44 18.54,4.83C18.93,5.23 18.93,5.86 18.54,6.25C18.15,6.64 17.5,6.64 17.12,6.25C16.73,5.86 16.73,5.23 17.12,4.83Z" >
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".6" ScaleY=".6" />
-                        <TranslateTransform X="-1" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-            </StackPanel>
-          </Border>
+    </Grid>
+    <ScrollBar Name="HScrollBar" Classes="music" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+               Margin="0,4,0,4" Orientation="Horizontal" AllowAutoHide="False"
+               DataContext="{Binding NotesViewModel}"
+               Maximum="{Binding HScrollBarMax, Mode=OneWay}"
+               Value="{Binding TickOffset}"
+               ViewportSize="{Binding ViewportTicks}"
+               LargeChange="{Binding ViewportTicks}"
+               SmallChange="{Binding SmallChangeX}" PointerWheelChanged="HScrollPointerWheelChanged"/>
+    <ScrollBar Name="VScrollBar" Classes="music" Grid.Row="2" Grid.Column="2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+               Margin="4,0,4,0" Orientation="Vertical" AllowAutoHide="False"
+               DataContext="{Binding NotesViewModel}"
+               Maximum="{Binding VScrollBarMax, Mode=OneWay}"
+               Value="{Binding TrackOffset}"
+               ViewportSize="{Binding ViewportTracks}"
+               LargeChange="{Binding ViewportTracks}"
+               SmallChange="{Binding SmallChangeY}" PointerWheelChanged="VScrollPointerWheelChanged"/>
+    <c:TrackBackground Grid.Column="0" Grid.Row="2" IsPianoRoll="True" IsKeyboard="True"
+                       Foreground="{DynamicResource BlackKeyBrush}"
+                       Background="{DynamicResource WhiteKeyBrush}"
+                       DataContext="{Binding NotesViewModel}"
+                       TrackHeight="{Binding TrackHeight}"
+                       TrackOffset="{Binding TrackOffset}"
+                       PointerWheelChanged="KeyboardPointerWheelChanged"
+                       PointerPressed="KeyboardPointerPressed"
+                       PointerMoved="KeyboardPointerMoved"
+                       PointerReleased="KeyboardPointerReleased"/>
+    <Grid Grid.Column="0" Grid.Row="4">
+      <c:ExpSelector Name="expSelector1" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
+                     Index="0" Margin="0,0,0,0" ToolTip.Tip="Alt + 1"/>
+      <c:ExpSelector Name="expSelector2" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
+                     Index="1" Margin="0,22,0,0" ToolTip.Tip="Alt + 2"/>
+      <c:ExpSelector Name="expSelector3" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
+                     Index="2" Margin="0,44,0,0" ToolTip.Tip="Alt + 3"/>
+      <c:ExpSelector Name="expSelector4" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
+                     Index="3" Margin="0,66,0,0" ToolTip.Tip="Alt + 4"/>
+      <c:ExpSelector Name="expSelector5" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Top"
+                     Index="4" Margin="0,88,0,0" ToolTip.Tip="Alt + 5"/>
+      <Button VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="20" Height="20" Margin="0" Background="Transparent" Click="OnExpButtonClick">
+        <Path Classes="clear" Width="24" Height="24"
+              Data="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"
+              Fill="{StaticResource NeutralAccentBrush}">
+          <Path.RenderTransform>
+            <TransformGroup>
+              <ScaleTransform ScaleX=".75" ScaleY=".75"/>
+              <TranslateTransform X="0" Y="1"/>
+            </TransformGroup>
+          </Path.RenderTransform>
+        </Path>
+      </Button>
+    </Grid>
+    <Canvas Name="TimelineCanvas" Grid.Row="1" Grid.Column="1"
+            Background="Transparent" ClipToBounds="True"
+            PointerWheelChanged="TimelinePointerWheelChanged"
+            PointerPressed="TimelinePointerPressed"
+            PointerMoved="TimelinePointerMoved"
+            PointerReleased="TimelinePointerReleased">
+      <Path Name="PlayPos"
+            Canvas.Left="{Binding NotesViewModel.PlayPosX}"
+            Canvas.Top="0" ZIndex="100" IsHitTestVisible="False"
+            Fill="{DynamicResource NeutralAccentBrushSemi}"
+            Data="M -6.5 0 L 6.5 0 L 6.5 3 L 0 9 L -6.5 3 Z"/>
+    </Canvas>
+    <c:TrackBackground Grid.Row="2" Grid.Column="1" IsHitTestVisible="False"
+                       Foreground="{DynamicResource TrackBackgroundAltBrush}"
+                       DataContext="{Binding NotesViewModel}"
+                       Bounds="{Binding Bounds, Mode=OneWayToSource}"
+                       TrackHeight="{Binding TrackHeight}"
+                       TrackOffset="{Binding TrackOffset}" IsPianoRoll="True"/>
+    <c:TickBackground Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" IsHitTestVisible="False"
+                      Foreground="{DynamicResource TickLineBrush}"
+                      Background="{DynamicResource TickLineBrushLow}"
+                      Resolution="{Binding PlaybackViewModel.Resolution}"
+                      TickWidth="{Binding NotesViewModel.TickWidth}"
+                      TickOrigin="{Binding NotesViewModel.TickOrigin}"
+                      TickOffset="{Binding NotesViewModel.TickOffset}"
+                      SnapDiv="{Binding NotesViewModel.SnapDiv, Mode=OneWay}"
+                      SnapTicks="{Binding NotesViewModel.SnapTicks}"
+                      ShowBarNumber="True"/>
+    <Image Grid.Row="2" Grid.RowSpan="3" Grid.Column="1" HorizontalAlignment="Right" Margin="0,0,100,0"
+           Source="{Binding NotesViewModel.Portrait}" OpacityMask="{Binding NotesViewModel.PortraitMask}" Stretch="None"/>
+    <Border Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
+            Margin="0,0,0,60" Height="60" IsHitTestVisible="False">
+      <c:WaveformImage DataContext="{Binding NotesViewModel, Mode=OneWay}"
+                       TickWidth="{Binding TickWidth, Mode=OneWay}"
+                       TickOffset="{Binding TickOffset, Mode=OneWay}"
+                       ShowWaveform="{Binding ShowWaveform, Mode=OneWay}"/>
+    </Border>
+    <c:NotesCanvas Grid.Row="2" Grid.Column="1"
+                   TickWidth="{Binding NotesViewModel.TickWidth}"
+                   TrackHeight="{Binding NotesViewModel.TrackHeight}"
+                   TickOffset="{Binding NotesViewModel.TickOffset}"
+                   TrackOffset="{Binding NotesViewModel.TrackOffset}"
+                   ShowVibrato="{Binding NotesViewModel.ShowVibrato}"
+                   ShowPitch="{Binding NotesViewModel.ShowPitch}"
+                   ShowFinalPitch="{Binding NotesViewModel.ShowFinalPitch}"
+                   Part="{Binding NotesViewModel.Part}"
+                   PointerPressed="NotesCanvasPointerPressed"
+                   PointerMoved="NotesCanvasPointerMoved"
+                   PointerReleased="NotesCanvasPointerReleased"
+                   DoubleTapped="NotesCanvasDoubleTapped"
+                   PointerWheelChanged="NotesCanvasPointerWheelChanged">
+      <c:NotesCanvas.ContextMenu>
+        <ContextMenu ItemsSource="{Binding NotesContextMenuItems}"
+                     Opening="NotesContextMenuOpening"
+                     Closing="NotesContextMenuClosing">
+          <ContextMenu.Styles>
+            <Style Selector="MenuItem">
+              <Setter Property="Header" Value="{Binding Header}"/>
+              <Setter Property="Command" Value="{Binding Command, FallbackValue={x:Null}}"/>
+              <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
+              <Setter Property="ItemsSource" Value="{Binding Items}"/>
+            </Style>
+          </ContextMenu.Styles>
+        </ContextMenu>
+      </c:NotesCanvas.ContextMenu>
+    </c:NotesCanvas>
+    <Canvas Grid.Row="2" Grid.Column="1" IsHitTestVisible="False" ClipToBounds="True">
+      <Rectangle Name="PlayPosHighlight"
+                 Width="{Binding NotesViewModel.PlayPosHighlightWidth, Mode=OneWay}"
+                 Height="{Binding $parent.Bounds.Height, Mode=OneWay}"
+                 Canvas.Left="{Binding NotesViewModel.PlayPosHighlightX, Mode=OneWay}"
+                 Canvas.Top="0" ZIndex="-10"
+                 Fill="{DynamicResource NeutralAccentBrushSemi2}"/>
+      <Rectangle Name="SelectionBox" StrokeThickness="2"
+                 Stroke="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                 Fill="{DynamicResource TickLineBrushLow}" ZIndex="1000"
+                 IsHitTestVisible="False" IsVisible="False"/>
+    </Canvas>
+    <StackPanel Grid.Row="2" Grid.Column="1" HorizontalAlignment="Left" VerticalAlignment="Top"
+                Margin="12,12,0,0" Orientation="Horizontal">
+      <Border CornerRadius="2" BoxShadow="0 0 5 1 #1F000000"
+              Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+        <Border CornerRadius="2" ClipToBounds="True">
+          <StackPanel Orientation="Horizontal">
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" CornerRadius="2,0,0,2"
+                          IsChecked="{Binding NotesViewModel.CursorTool, Mode=OneWay}"
+                          Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="1"
+                          ToolTip.Tip="{DynamicResource pianoroll.tool.selectionv2}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M10.07,14.27C10.57,14.03 11.16,14.25 11.4,14.75L13.7,19.74L15.5,18.89L13.19,13.91C12.95,13.41 13.17,12.81 13.67,12.58L13.95,12.5L16.25,12.05L8,5.12V15.9L9.82,14.43L10.07,14.27M13.64,21.97C13.14,22.21 12.54,22 12.31,21.5L10.13,16.76L7.62,18.78C7.45,18.92 7.24,19 7,19A1,1 0 0,1 6,18V3A1,1 0 0,1 7,2C7.24,2 7.47,2.09 7.64,2.23L7.65,2.22L19.14,11.86C19.57,12.22 19.62,12.85 19.27,13.27C19.12,13.45 18.91,13.57 18.7,13.61L15.54,14.23L17.74,18.96C18,19.46 17.76,20.05 17.26,20.28L13.64,21.97Z" >
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".55" ScaleY=".55" />
+                      <TranslateTransform X="-2" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
+                          IsChecked="{Binding NotesViewModel.PenTool, Mode=OneWay}"
+                          Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="2"
+                          ToolTip.Tip="{DynamicResource pianoroll.tool.penv2}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M14.06,9L15,9.94L5.92,19H5V18.08L14.06,9M17.66,3C17.41,3 17.15,3.1 16.96,3.29L15.13,5.12L18.88,8.87L20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18.17,3.09 17.92,3 17.66,3M14.06,6.19L3,17.25V21H6.75L17.81,9.94L14.06,6.19Z" >
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".6" ScaleY=".6" />
+                      <TranslateTransform X="-2" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
+                          IsChecked="{Binding NotesViewModel.PenPlusTool, Mode=OneWay}"
+                          Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="2+"
+                          ToolTip.Tip="{DynamicResource pianoroll.tool.penplus}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M14.1,9L15,9.9L5.9,19H5V18.1L14.1,9M17.7,3C17.5,3 17.2,3.1 17,3.3L15.2,5.1L18.9,8.9L20.7,7C21.1,6.6 21.1,6 20.7,5.6L18.4,3.3C18.2,3.1 17.9,3 17.7,3M14.1,6.2L3,17.2V21H6.8L17.8,9.9L14.1,6.2M7,2V5H10V7H7V10H5V7H2V5H5V2H7Z" >
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".6" ScaleY=".6" />
+                      <TranslateTransform X="-1" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
+                          IsChecked="{Binding NotesViewModel.EraserTool, Mode=OneWay}"
+                          Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="3"
+                          ToolTip.Tip="{DynamicResource pianoroll.tool.eraser}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M16.24,3.56L21.19,8.5C21.97,9.29 21.97,10.55 21.19,11.34L12,20.53C10.44,22.09 7.91,22.09 6.34,20.53L2.81,17C2.03,16.21 2.03,14.95 2.81,14.16L13.41,3.56C14.2,2.78 15.46,2.78 16.24,3.56M4.22,15.58L7.76,19.11C8.54,19.9 9.8,19.9 10.59,19.11L14.12,15.58L9.17,10.63L4.22,15.58Z" >
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".6" ScaleY=".6" />
+                      <TranslateTransform X="-2" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
+                          IsChecked="{Binding NotesViewModel.DrawPitchTool, Mode=OneWay}"
+                          Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="4"
+                          ToolTip.Tip="{DynamicResource pianoroll.tool.drawpitch}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M9.75 20.85C11.53 20.15 11.14 18.22 10.24 17C9.35 15.75 8.12 14.89 6.88 14.06C6 13.5 5.19 12.8 4.54 12C4.26 11.67 3.69 11.06 4.27 10.94C4.86 10.82 5.88 11.4 6.4 11.62C7.31 12 8.21 12.44 9.05 12.96L10.06 11.26C8.5 10.23 6.5 9.32 4.64 9.05C3.58 8.89 2.46 9.11 2.1 10.26C1.78 11.25 2.29 12.25 2.87 13.03C4.24 14.86 6.37 15.74 7.96 17.32C8.3 17.65 8.71 18.04 8.91 18.5C9.12 18.94 9.07 18.97 8.6 18.97C7.36 18.97 5.81 18 4.8 17.36L3.79 19.06C5.32 20 7.88 21.47 9.75 20.85M20.84 5.25C21.06 5.03 21.06 4.67 20.84 4.46L19.54 3.16C19.33 2.95 18.97 2.95 18.76 3.16L17.74 4.18L19.82 6.26M11 10.92V13H13.08L19.23 6.85L17.15 4.77L11 10.92Z" >
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".7" ScaleY=".7" />
+                      <TranslateTransform X="-1" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
+                          IsChecked="{Binding NotesViewModel.KnifeTool, Mode=OneWay}"
+                          Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="5"
+                          ToolTip.Tip="{DynamicResource pianoroll.tool.knife}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M7.22,11.91C6.89,12.24 6.71,12.65 6.66,13.08L12.17,15.44L20.66,6.96C21.44,6.17 21.44,4.91 20.66,4.13L19.24,2.71C18.46,1.93 17.2,1.93 16.41,2.71L7.22,11.91M5,16V21.75L10.81,16.53L5.81,14.53L5,16M17.12,4.83C17.5,4.44 18.15,4.44 18.54,4.83C18.93,5.23 18.93,5.86 18.54,6.25C18.15,6.64 17.5,6.64 17.12,6.25C16.73,5.86 16.73,5.23 17.12,4.83Z" >
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".6" ScaleY=".6" />
+                      <TranslateTransform X="-1" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+          </StackPanel>
         </Border>
-        <Border Width="12" Height="20"/>
-        <Border CornerRadius="2" BoxShadow="0 0 5 1 #1F000000"
-                Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
-          <Border CornerRadius="2" ClipToBounds="True">
-            <StackPanel Orientation="Horizontal">
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" CornerRadius="2,0,0,2" IsChecked="{Binding NotesViewModel.ShowTips}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.tips}">
-                <Grid Width="18" Height="18">
-                  <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Text="?" FontWeight="Bold"
-                             Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.PlayTone}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.tone}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M21,3V15.5A3.5,3.5 0 0,1 17.5,19A3.5,3.5 0 0,1 14,15.5A3.5,3.5 0 0,1 17.5,12C18.04,12 18.55,12.12 19,12.34V6.47L9,8.6V17.5A3.5,3.5 0 0,1 5.5,21A3.5,3.5 0 0,1 2,17.5A3.5,3.5 0 0,1 5.5,14C6.04,14 6.55,14.12 7,14.34V6L21,3Z" >
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".6" ScaleY=".6" />
-                        <TranslateTransform X="-2" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowVibrato}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.vibrato}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="stroked" Data="M-6.5 1 L-6 1.5 L-4.5 0 L-2 2.5 L0.5 0 L3 2.5 L6.5 -1 L6 -1.5 L4.5 0 L2 -2.5 L-0.5 0 L-3 -2.5 Z">
-                    <Path.RenderTransform>
-                      <TranslateTransform X="9" Y="9"/>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowPitch}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.pitch}">
-                <Grid Width="18" Height="18">
-                  <Ellipse Classes="stroked" Height="4" Width="4" Margin="2,0,0,5" HorizontalAlignment="Left" VerticalAlignment="Bottom"/>
-                  <Ellipse Classes="stroked" Height="4" Width="4" Margin="0,5,2,0" HorizontalAlignment="Right" VerticalAlignment="Top"/>
-                  <Path Classes="stroked" Data="M 6.5 11.5 L 8 11.5 L 8.5 11 L 9.5 7 L 10 6.5 L 11.5 6.5"/>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowFinalPitch}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.finalpitch}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="stroked" Data="M 5.5 11.5 L 8 11.5 L 8.5 11 L 9.5 7 L 10 6.5 L 12.5 6.5"/>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowWaveform}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.waveform}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M22 12L20 13L19 14L18 13L17 16L16 13L15 21L14 13L13 15L12 13L11 17L10 13L9 22L8 13L7 19L6 13L5 14L4 13L2 12L4 11L5 10L6 11L7 5L8 11L9 2L10 11L11 7L12 11L13 9L14 11L15 3L16 11L17 8L18 11L19 10L20 11L22 12Z">
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".67" ScaleY=".67" />
-                        <TranslateTransform X="-2" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowPhoneme}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.phoneme}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="stroked" Data="M 3 13 L 6 5.5 L 12 5.5 L 15 13"/>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowNoteParams}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.noteparams}">
-                <Grid Width="18" Height="18">
-                  <Path Classes="filled" Data="M3,17V19H9V17H3M3,5V7H13V5H3M13,21V19H21V17H13V15H11V21H13M7,9V11H3V13H7V15H9V9H7M21,13V11H11V13H21M15,9H17V7H21V5H17V3H15V9Z">
-                    <Path.RenderTransform>
-                      <TransformGroup>
-                        <ScaleTransform ScaleX=".65" ScaleY=".65" />
-                        <TranslateTransform X="-2" Y="-2"/>
-                      </TransformGroup>
-                    </Path.RenderTransform>
-                  </Path>
-                </Grid>
-              </ToggleButton>
-              <ToggleButton Name="SnapToggle" Classes="toolbar" Margin="0" Padding="1" Height="20" IsChecked="{Binding NotesViewModel.IsSnapOn}"
-                            ToolTip.Tip="{DynamicResource pianoroll.toggle.snap}">
-                <Border Width="18" Height="18">
-                  <Path Classes="stroked" Data="M 4.5 13.5 L 7.5 13.5 L 7.5 9.5 A 1,1 0 1 1 10.5,9.5 L 10.5 13.5 L 13.5 13.5 L 13.5 8.5 A 1,1 0 1 0 4.5,8.5 Z"/>
-                </Border>
-              </ToggleButton>
-              <Button Margin="0" Padding="0,1" Height="20" Width="40" Background="Transparent" Click="OnSnapDivMenuButton">
-                <TextBlock Grid.Column="0" Text="{Binding NotesViewModel.SnapDivText}"
-                           TextAlignment="Right" FontSize="10" FontFamily="monospace"
+      </Border>
+      <Border Width="12" Height="20"/>
+      <Border CornerRadius="2" BoxShadow="0 0 5 1 #1F000000"
+              Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+        <Border CornerRadius="2" ClipToBounds="True">
+          <StackPanel Orientation="Horizontal">
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" CornerRadius="2,0,0,2" IsChecked="{Binding NotesViewModel.ShowTips}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.tips}">
+              <Grid Width="18" Height="18">
+                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Text="?" FontWeight="Bold"
                            Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
-                <Button.ContextMenu>
-                  <ContextMenu Name="SnapDivMenu" PlacementMode="Bottom" ItemsSource="{Binding NotesViewModel.SnapDivs}" KeyDown="OnSnapDivKeyDown">
-                    <ContextMenu.DataTemplates>
-                      <DataTemplate DataType="vm:MenuItemViewModel">
-                        <MenuItem Header="{Binding Header}" Command="{Binding Command, FallbackValue={x:Null}}" CommandParameter="{Binding CommandParameter}"/>
-                      </DataTemplate>
-                    </ContextMenu.DataTemplates>
-                  </ContextMenu>
-                </Button.ContextMenu>
-              </Button>
-            </StackPanel>
-          </Border>
-        </Border>
-        <Border Width="12" Height="20"/>
-        <Border CornerRadius="2" BoxShadow="0 0 5 1 #1F000000">
-          <Border CornerRadius="2" ClipToBounds="True">
-            <Menu CornerRadius="2" Height="20" Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                  Closed="OnMenuClosed" PointerExited="OnMenuPointerLeave">
-              <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.part}" CornerRadius="2,0,0,2">
-                <MenuItem Header="{DynamicResource pianoroll.menu.part.legacypluginexp}" ItemsSource="{Binding LegacyPlugins}">
-                  <MenuItem.DataTemplates>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.PlayTone}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.tone}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M21,3V15.5A3.5,3.5 0 0,1 17.5,19A3.5,3.5 0 0,1 14,15.5A3.5,3.5 0 0,1 17.5,12C18.04,12 18.55,12.12 19,12.34V6.47L9,8.6V17.5A3.5,3.5 0 0,1 5.5,21A3.5,3.5 0 0,1 2,17.5A3.5,3.5 0 0,1 5.5,14C6.04,14 6.55,14.12 7,14.34V6L21,3Z" >
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".6" ScaleY=".6" />
+                      <TranslateTransform X="-2" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowVibrato}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.vibrato}">
+              <Grid Width="18" Height="18">
+                <Path Classes="stroked" Data="M-6.5 1 L-6 1.5 L-4.5 0 L-2 2.5 L0.5 0 L3 2.5 L6.5 -1 L6 -1.5 L4.5 0 L2 -2.5 L-0.5 0 L-3 -2.5 Z">
+                  <Path.RenderTransform>
+                    <TranslateTransform X="9" Y="9"/>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowPitch}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.pitch}">
+              <Grid Width="18" Height="18">
+                <Ellipse Classes="stroked" Height="4" Width="4" Margin="2,0,0,5" HorizontalAlignment="Left" VerticalAlignment="Bottom"/>
+                <Ellipse Classes="stroked" Height="4" Width="4" Margin="0,5,2,0" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+                <Path Classes="stroked" Data="M 6.5 11.5 L 8 11.5 L 8.5 11 L 9.5 7 L 10 6.5 L 11.5 6.5"/>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowFinalPitch}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.finalpitch}">
+              <Grid Width="18" Height="18">
+                <Path Classes="stroked" Data="M 5.5 11.5 L 8 11.5 L 8.5 11 L 9.5 7 L 10 6.5 L 12.5 6.5"/>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowWaveform}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.waveform}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M22 12L20 13L19 14L18 13L17 16L16 13L15 21L14 13L13 15L12 13L11 17L10 13L9 22L8 13L7 19L6 13L5 14L4 13L2 12L4 11L5 10L6 11L7 5L8 11L9 2L10 11L11 7L12 11L13 9L14 11L15 3L16 11L17 8L18 11L19 10L20 11L22 12Z">
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".67" ScaleY=".67" />
+                      <TranslateTransform X="-2" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowPhoneme}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.phoneme}">
+              <Grid Width="18" Height="18">
+                <Path Classes="stroked" Data="M 3 13 L 6 5.5 L 12 5.5 L 15 13"/>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowNoteParams}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.noteparams}">
+              <Grid Width="18" Height="18">
+                <Path Classes="filled" Data="M3,17V19H9V17H3M3,5V7H13V5H3M13,21V19H21V17H13V15H11V21H13M7,9V11H3V13H7V15H9V9H7M21,13V11H11V13H21M15,9H17V7H21V5H17V3H15V9Z">
+                  <Path.RenderTransform>
+                    <TransformGroup>
+                      <ScaleTransform ScaleX=".65" ScaleY=".65" />
+                      <TranslateTransform X="-2" Y="-2"/>
+                    </TransformGroup>
+                  </Path.RenderTransform>
+                </Path>
+              </Grid>
+            </ToggleButton>
+            <ToggleButton Name="SnapToggle" Classes="toolbar" Margin="0" Padding="1" Height="20" IsChecked="{Binding NotesViewModel.IsSnapOn}"
+                          ToolTip.Tip="{DynamicResource pianoroll.toggle.snap}">
+              <Border Width="18" Height="18">
+                <Path Classes="stroked" Data="M 4.5 13.5 L 7.5 13.5 L 7.5 9.5 A 1,1 0 1 1 10.5,9.5 L 10.5 13.5 L 13.5 13.5 L 13.5 8.5 A 1,1 0 1 0 4.5,8.5 Z"/>
+              </Border>
+            </ToggleButton>
+            <Button Margin="0" Padding="0,1" Height="20" Width="40" Background="Transparent" Click="OnSnapDivMenuButton">
+              <TextBlock Grid.Column="0" Text="{Binding NotesViewModel.SnapDivText}"
+                         TextAlignment="Right" FontSize="10" FontFamily="monospace"
+                         Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+              <Button.ContextMenu>
+                <ContextMenu Name="SnapDivMenu" PlacementMode="Bottom" ItemsSource="{Binding NotesViewModel.SnapDivs}" KeyDown="OnSnapDivKeyDown">
+                  <ContextMenu.DataTemplates>
                     <DataTemplate DataType="vm:MenuItemViewModel">
                       <MenuItem Header="{Binding Header}" Command="{Binding Command, FallbackValue={x:Null}}" CommandParameter="{Binding CommandParameter}"/>
                     </DataTemplate>
-                  </MenuItem.DataTemplates>
-                </MenuItem>
-              </MenuItem>
-              <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.notes}" ItemsSource="{Binding NoteBatchEdits}">
-                <MenuItem.DataTemplates>
-                  <DataTemplate DataType="vm:MenuItemViewModel">
-                    <MenuItem Header="{Binding Header}" Command="{Binding Command, FallbackValue={x:Null}}" CommandParameter="{Binding CommandParameter}"/>
-                  </DataTemplate>
-                </MenuItem.DataTemplates>
-              </MenuItem>
-              <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.lyrics}" ItemsSource="{Binding LyricBatchEdits}">
-                <MenuItem.DataTemplates>
-                  <DataTemplate DataType="vm:MenuItemViewModel">
-                    <MenuItem Header="{Binding Header}" Command="{Binding Command, FallbackValue={x:Null}}" CommandParameter="{Binding CommandParameter}"/>
-                  </DataTemplate>
-                </MenuItem.DataTemplates>
-              </MenuItem>
-              <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.lyrics.edit}" Click="OnMenuEditLyrics"/>
-              <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.notedefaults}" Click="OnMenuNoteDefaults"/>
-            </Menu>
-          </Border>
+                  </ContextMenu.DataTemplates>
+                </ContextMenu>
+              </Button.ContextMenu>
+            </Button>
+          </StackPanel>
         </Border>
-      </StackPanel>
-      <Rectangle Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
-                 Margin="0,0,0,60" Height="6" Opacity="0.15" IsVisible="{Binding NotesViewModel.ShowPhoneme}">
-        <Rectangle.Fill>
-          <LinearGradientBrush StartPoint="0,0" EndPoint="0,6">
-            <GradientStop Color="Transparent" Offset="0"/>
-            <GradientStop Color="Black" Offset="1"/>
-          </LinearGradientBrush>
-        </Rectangle.Fill>
-      </Rectangle>
-      <c:PhonemeCanvas Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Margin="0" Height="60"
-                       Background="{DynamicResource BackgroundBrushSemi}"
-                       TickWidth="{Binding NotesViewModel.TickWidth}"
-                       TickOffset="{Binding NotesViewModel.TickOffset}"
-                       Part="{Binding NotesViewModel.Part}" IsVisible="{Binding NotesViewModel.ShowPhoneme}"
-                       DoubleTapped="PhonemeCanvasDoubleTapped"
-                       PointerPressed="PhonemeCanvasPointerPressed"
-                       PointerMoved="PhonemeCanvasPointerMoved"
-                       PointerReleased="PhonemeCanvasPointerReleased"/>
-      <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                    Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Focusable="False" Cursor="SizeNorthSouth"/>
-      <c:TrackBackground Grid.Row="4" Grid.Column="1" IsHitTestVisible="False"
-                         Foreground="{DynamicResource TrackBackgroundAltBrush}"
-                         TrackHeight="{Binding NotesViewModel.ExpTrackHeight}"/>
-      <c:TickBackground Grid.Row="4"  Grid.Column="1" IsHitTestVisible="False"
-                        Foreground="{DynamicResource TickLineBrush}"
-                        Background="{DynamicResource TickLineBrushLow}"
-                        Resolution="{Binding PlaybackViewModel.Resolution}"
+      </Border>
+      <Border Width="12" Height="20"/>
+      <Border CornerRadius="2" BoxShadow="0 0 5 1 #1F000000">
+        <Border CornerRadius="2" ClipToBounds="True">
+          <Menu CornerRadius="2" Height="20" Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                Closed="OnMenuClosed" PointerExited="OnMenuPointerLeave">
+            <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.part}" CornerRadius="2,0,0,2">
+              <MenuItem Header="{DynamicResource pianoroll.menu.part.legacypluginexp}" ItemsSource="{Binding LegacyPlugins}">
+                <MenuItem.DataTemplates>
+                  <DataTemplate DataType="vm:MenuItemViewModel">
+                    <MenuItem Header="{Binding Header}" Command="{Binding Command, FallbackValue={x:Null}}" CommandParameter="{Binding CommandParameter}"/>
+                  </DataTemplate>
+                </MenuItem.DataTemplates>
+              </MenuItem>
+            </MenuItem>
+            <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.notes}" ItemsSource="{Binding NoteBatchEdits}">
+              <MenuItem.DataTemplates>
+                <DataTemplate DataType="vm:MenuItemViewModel">
+                  <MenuItem Header="{Binding Header}" Command="{Binding Command, FallbackValue={x:Null}}" CommandParameter="{Binding CommandParameter}"/>
+                </DataTemplate>
+              </MenuItem.DataTemplates>
+            </MenuItem>
+            <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.lyrics}" ItemsSource="{Binding LyricBatchEdits}">
+              <MenuItem.DataTemplates>
+                <DataTemplate DataType="vm:MenuItemViewModel">
+                  <MenuItem Header="{Binding Header}" Command="{Binding Command, FallbackValue={x:Null}}" CommandParameter="{Binding CommandParameter}"/>
+                </DataTemplate>
+              </MenuItem.DataTemplates>
+            </MenuItem>
+            <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.lyrics.edit}" Click="OnMenuEditLyrics"/>
+            <MenuItem Height="20" Header="{DynamicResource pianoroll.menu.notedefaults}" Click="OnMenuNoteDefaults"/>
+          </Menu>
+        </Border>
+      </Border>
+    </StackPanel>
+    <Rectangle Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Bottom"
+               Margin="0,0,0,60" Height="6" Opacity="0.15" IsVisible="{Binding NotesViewModel.ShowPhoneme}">
+      <Rectangle.Fill>
+        <LinearGradientBrush StartPoint="0,0" EndPoint="0,6">
+          <GradientStop Color="Transparent" Offset="0"/>
+          <GradientStop Color="Black" Offset="1"/>
+        </LinearGradientBrush>
+      </Rectangle.Fill>
+    </Rectangle>
+    <c:PhonemeCanvas Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" Margin="0" Height="60"
+                     Background="{DynamicResource BackgroundBrushSemi}"
+                     TickWidth="{Binding NotesViewModel.TickWidth}"
+                     TickOffset="{Binding NotesViewModel.TickOffset}"
+                     Part="{Binding NotesViewModel.Part}" IsVisible="{Binding NotesViewModel.ShowPhoneme}"
+                     DoubleTapped="PhonemeCanvasDoubleTapped"
+                     PointerPressed="PhonemeCanvasPointerPressed"
+                     PointerMoved="PhonemeCanvasPointerMoved"
+                     PointerReleased="PhonemeCanvasPointerReleased"/>
+    <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Focusable="False" Cursor="SizeNorthSouth"/>
+    <c:TrackBackground Grid.Row="4" Grid.Column="1" IsHitTestVisible="False"
+                       Foreground="{DynamicResource TrackBackgroundAltBrush}"
+                       TrackHeight="{Binding NotesViewModel.ExpTrackHeight}"/>
+    <c:TickBackground Grid.Row="4"  Grid.Column="1" IsHitTestVisible="False"
+                      Foreground="{DynamicResource TickLineBrush}"
+                      Background="{DynamicResource TickLineBrushLow}"
+                      Resolution="{Binding PlaybackViewModel.Resolution}"
+                      TickWidth="{Binding NotesViewModel.TickWidth}"
+                      TickOrigin="{Binding NotesViewModel.TickOrigin}"
+                      TickOffset="{Binding NotesViewModel.TickOffset}"
+                      SnapDiv="{Binding NotesViewModel.SnapDiv, Mode=OneWay}"/>
+    <c:ExpressionCanvas Grid.Row="4" Grid.Column="1" Opacity="{Binding NotesViewModel.ExpShadowOpacity}"
                         TickWidth="{Binding NotesViewModel.TickWidth}"
-                        TickOrigin="{Binding NotesViewModel.TickOrigin}"
                         TickOffset="{Binding NotesViewModel.TickOffset}"
-                        SnapDiv="{Binding NotesViewModel.SnapDiv, Mode=OneWay}"/>
-      <c:ExpressionCanvas Grid.Row="4" Grid.Column="1" Opacity="{Binding NotesViewModel.ExpShadowOpacity}"
-                          TickWidth="{Binding NotesViewModel.TickWidth}"
-                          TickOffset="{Binding NotesViewModel.TickOffset}"
-                          Part="{Binding NotesViewModel.Part}"
-                          Key="{Binding NotesViewModel.SecondaryKey}"/>
-      <c:ExpressionCanvas Grid.Row="4" Grid.Column="1"
-                          Bounds="{Binding NotesViewModel.ExpBounds, Mode=OneWayToSource}"
-                          TickWidth="{Binding NotesViewModel.TickWidth}"
-                          TickOffset="{Binding NotesViewModel.TickOffset}"
-                          Part="{Binding NotesViewModel.Part}"
-                          Key="{Binding NotesViewModel.PrimaryKey}"
-                          PointerPressed="ExpCanvasPointerPressed"
-                          PointerMoved="ExpCanvasPointerMoved"
-                          PointerReleased="ExpCanvasPointerReleased">
-      </c:ExpressionCanvas>
-      <TextBlock Classes="tips" Grid.Row="4" Grid.Column="1"
-                 IsHitTestVisible="False" VerticalAlignment="Bottom" Margin="10,5"
-                 IsVisible="{Binding NotesViewModel.PrimaryKeyNotSupported}"
-                 Text="{DynamicResource tip.exps.notsupported}"/>
-      <Border Grid.Column="3" Grid.RowSpan="5"
-              IsEnabled="{Binding NotesViewModel.ShowNoteParams}"
-              IsVisible="{Binding NotesViewModel.ShowNoteParams}"
-              Background="{DynamicResource SystemRegionBrush}" Padding="0">
-        <c:NotePropertiesControl/>
-      </Border>
-      
-      <Border Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-              BoxShadow="inset 0 0 5 1 #3F000000" ClipToBounds="True" IsHitTestVisible="False">
-        <Grid>
-          <Border Classes="tips" HorizontalAlignment="Center" VerticalAlignment="Center"
-                IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
-            <TextBlock Classes="tips" Grid.Column="0" Margin="10,5"
-                       Text="{DynamicResource tip.notes.basics}"/>
-          </Border>
-          <Border Classes="tips" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0" Padding="4,4,4,2"
-                   IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
-            <TextBlock Classes="tips" Text="{DynamicResource tip.notes.zoomx}"/>
-          </Border>
-          <Border Classes="tips" HorizontalAlignment="Right" VerticalAlignment="Top" Padding="4,4,4,2"
-                   IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
-            <TextBlock Classes="tips" Text="{DynamicResource tip.notes.zoomy}"/>
-          </Border>
-          <Border HorizontalAlignment="Center" VerticalAlignment="Center"
-                IsVisible="{Binding NotesViewModel.PlayPosWaitingRendering}">
-            <TextBlock Text="{DynamicResource progress.waitingrendering}"/>
-          </Border>
-        </Grid>
-      </Border>
-      <Grid Grid.Row="2" Grid.Column="1" RowDefinitions="1*,1*">
-        <Border Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Top"
-                BoxShadow="0 0 5 1 #3F000000">
-          <c:LyricBox Name="LyricBox" Width="360"/>
+                        Part="{Binding NotesViewModel.Part}"
+                        Key="{Binding NotesViewModel.SecondaryKey}"/>
+    <c:ExpressionCanvas Grid.Row="4" Grid.Column="1"
+                        Bounds="{Binding NotesViewModel.ExpBounds, Mode=OneWayToSource}"
+                        TickWidth="{Binding NotesViewModel.TickWidth}"
+                        TickOffset="{Binding NotesViewModel.TickOffset}"
+                        Part="{Binding NotesViewModel.Part}"
+                        Key="{Binding NotesViewModel.PrimaryKey}"
+                        PointerPressed="ExpCanvasPointerPressed"
+                        PointerMoved="ExpCanvasPointerMoved"
+                        PointerReleased="ExpCanvasPointerReleased">
+    </c:ExpressionCanvas>
+    <TextBlock Classes="tips" Grid.Row="4" Grid.Column="1"
+               IsHitTestVisible="False" VerticalAlignment="Bottom" Margin="10,5"
+               IsVisible="{Binding NotesViewModel.PrimaryKeyNotSupported}"
+               Text="{DynamicResource tip.exps.notsupported}"/>
+    <Border Grid.Column="3" Grid.RowSpan="5"
+            IsEnabled="{Binding NotesViewModel.ShowNoteParams}"
+            IsVisible="{Binding NotesViewModel.ShowNoteParams}"
+            Background="{DynamicResource SystemRegionBrush}" Padding="0">
+      <c:NotePropertiesControl/>
+    </Border>
+
+    <Border Grid.Row="1" Grid.RowSpan="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+            BoxShadow="inset 0 0 5 1 #3F000000" ClipToBounds="True" IsHitTestVisible="False">
+      <Grid>
+        <Border Classes="tips" HorizontalAlignment="Center" VerticalAlignment="Center"
+              IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
+          <TextBlock Classes="tips" Grid.Column="0" Margin="10,5"
+                     Text="{DynamicResource tip.notes.basics}"/>
+        </Border>
+        <Border Classes="tips" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0" Padding="4,4,4,2"
+                 IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
+          <TextBlock Classes="tips" Text="{DynamicResource tip.notes.zoomx}"/>
+        </Border>
+        <Border Classes="tips" HorizontalAlignment="Right" VerticalAlignment="Top" Padding="4,4,4,2"
+                 IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
+          <TextBlock Classes="tips" Text="{DynamicResource tip.notes.zoomy}"/>
+        </Border>
+        <Border HorizontalAlignment="Center" VerticalAlignment="Center"
+              IsVisible="{Binding NotesViewModel.PlayPosWaitingRendering}">
+          <TextBlock Text="{DynamicResource progress.waitingrendering}"/>
         </Border>
       </Grid>
-      <Border Grid.Row="4" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-              BoxShadow="inset 0 0 5 1 #3F000000" ClipToBounds="True" IsHitTestVisible="False">
-        <Border Classes="tips" HorizontalAlignment="Center" VerticalAlignment="Center"
-                IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
-          <TextBlock Classes="tips" Grid.Column="0" Margin="10,5"
-                     Text="{DynamicResource tip.exps}"/>
-        </Border>
-      </Border>
-      <Border Grid.Row="1" Grid.Column="2" Background="Transparent"
-              HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="0" Height="24"
-              PointerWheelChanged="ViewScalerPointerWheelChanged">
-        <c:ViewScaler Name="VScaler" DataContext="{Binding NotesViewModel}" Value="{Binding TrackHeight}" Min="{Binding TrackHeightMin}" Max="{Binding TrackHeightMax}"/>
-      </Border>
-      <Canvas Name="ValueTipCanvas" Grid.Column="1" Grid.Row="1" Grid.RowSpan="4" IsHitTestVisible="False">
-        <Border Name="ValueTip" BorderThickness="1"
-                BorderBrush="{DynamicResource NeutralAccentBrush}"
-                Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
-          <TextBlock Name="ValueTipText" Margin="2"/>
-        </Border>
-      </Canvas>
-      <ProgressBar Grid.Row="5" Grid.ColumnSpan="3" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Value="{Binding Progress}"/>
-    </Grid>
     </Border>
+    <Grid Grid.Row="2" Grid.Column="1" RowDefinitions="1*,1*">
+      <Border Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Top"
+              BoxShadow="0 0 5 1 #3F000000">
+        <c:LyricBox Name="LyricBox" Width="360"/>
+      </Border>
+    </Grid>
+    <Border Grid.Row="4" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+            BoxShadow="inset 0 0 5 1 #3F000000" ClipToBounds="True" IsHitTestVisible="False">
+      <Border Classes="tips" HorizontalAlignment="Center" VerticalAlignment="Center"
+              IsVisible="{Binding NotesViewModel.ShowTips}" BoxShadow="0 0 5 1 #3F000000">
+        <TextBlock Classes="tips" Grid.Column="0" Margin="10,5"
+                   Text="{DynamicResource tip.exps}"/>
+      </Border>
+    </Border>
+    <Border Grid.Row="1" Grid.Column="2" Background="Transparent"
+            HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="0" Height="24"
+            PointerWheelChanged="ViewScalerPointerWheelChanged">
+      <c:ViewScaler Name="VScaler" DataContext="{Binding NotesViewModel}" Value="{Binding TrackHeight}" Min="{Binding TrackHeightMin}" Max="{Binding TrackHeightMax}"/>
+    </Border>
+    <Canvas Name="ValueTipCanvas" Grid.Column="1" Grid.Row="1" Grid.RowSpan="4" IsHitTestVisible="False">
+      <Border Name="ValueTip" BorderThickness="1"
+              BorderBrush="{DynamicResource NeutralAccentBrush}"
+              Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+        <TextBlock Name="ValueTipText" Margin="2"/>
+      </Border>
+    </Canvas>
+    <ProgressBar Grid.Row="5" Grid.ColumnSpan="3" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Value="{Binding Progress}"/>
   </Grid>
 </Window>

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -186,7 +186,7 @@
                 HorizontalAlignment="Right">
       <Border BorderThickness="1" CornerRadius="4" ClipToBounds="True"
               BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}">
-        <ToggleButton Background="Transparent" IsChecked="{Binding ZoomInMel}">
+        <ToggleButton Classes="normal" Background="Transparent" IsChecked="{Binding ZoomInMel}">
           <Path Fill="{DynamicResource SystemControlForegroundBaseHighBrush}"
                 Data="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z">
             <Path.RenderTransform>


### PR DESCRIPTION
New Features:
- Textboxes and sliders now work
- Vibrato drift (move height)
This is a parameter that has existed internally in ustx up to now, but has not been used.
Currently the only way to change this parameter is to manipulate the note property.
![image](https://github.com/stakira/OpenUtau/assets/130257355/a5d3d19f-7397-4285-887e-0f8a708f43e8)

Not yet implemented:

- Right click on the slider does not work
(PointerPressed does not work well on sliders, so Focus is used instead, and it cannot determine if it is a right click or not.)