### PR TITLE
[EN Delta] Refactoring code + fix ValidateAlias bugs + restore proper VCC connections + fix single consonants

### DIFF
--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -120,7 +120,7 @@ namespace OpenUtau.Plugin.Builtin {
             string[] diphthongs = new[] { "aI", "eI", "OI", "aU", "oU", "VI", "VU", "@U" };
             string[] affricates = new[] { "dZ", "tS" };
             foreach (string s in original) {
-                if (diphthongs.Contains(s) && !HasOto($"b{s}", note.tone)) {
+                if (diphthongs.Contains(s) && !HasOto($"{s} b", note.tone)) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
                 } else if (affricates.Contains(s) && (!HasOto($"i {s}", note.tone) && !HasOto($"i: {s}", note.tone))) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });

--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -34,7 +34,7 @@ namespace OpenUtau.Plugin.Builtin {
                 .ToDictionary(parts => parts[0], parts => parts[1]);
 
         // For banks aliased with VOCALOID-style phonemes
-        private readonly Dictionary<string, string> vocaSampa = "A=Q;E=e;i=i:;u=u:;O=O:;3=@r".Split(';')
+        private readonly Dictionary<string, string> vocaSampa = "A=Q;E=e;i=i:;u=u:;O=O:;3=@r;oU=@U".Split(';')
                 .Select(entry => entry.Split('='))
                 .Where(parts => parts.Length == 2)
                 .Where(parts => parts[0] != parts[1])

--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -122,7 +122,7 @@ namespace OpenUtau.Plugin.Builtin {
             foreach (string s in original) {
                 if (diphthongs.Contains(s) && !HasOto($"{s} b", note.tone)) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
-                } else if (affricates.Contains(s) && (!HasOto($"i {s}", note.tone) && !HasOto($"i: {s}", note.tone))) {
+                } else if (affricates.Contains(s) && !HasOto($"i {s}", note.tone) && !HasOto($"i: {s}", note.tone)) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
                 } else {
                     modified.Add(s);

--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -125,7 +125,7 @@ namespace OpenUtau.Plugin.Builtin {
             foreach (string s in original) {
                 if (diphthongs.Contains(s) && !HasOto($"b{s}", note.tone)) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
-                } else if (affricates.Contains(s) && !HasOto($"i {s}", note.tone)) {
+                } else if (affricates.Contains(s) && (!HasOto($"i {s}", note.tone) || !HasOto($"i: {s}", note.tone))) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
                 } else {
                     modified.Add(s);

--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -286,10 +286,10 @@ namespace OpenUtau.Plugin.Builtin {
                         } else if (HasOto(vcc, syllable.tone) || HasOto(ValidateAlias(vcc), syllable.tone)) {
                             phonemes.Add(vcc);
                             break;
-                        } else if ((!HasOto(vcc, syllable.tone) || !HasOto(ValidateAlias(vcc), syllable.tone)) && (HasOto(vcc2, syllable.tone) || HasOto(ValidateAlias(vcc2), syllable.tone))) {
+                        } else if (HasOto(vcc2, syllable.tone) || HasOto(ValidateAlias(vcc2), syllable.tone)) {
                             phonemes.Add(vcc2);
                             break;
-                        } else if ((!HasOto(vcc2, syllable.tone) || !HasOto(ValidateAlias(vcc2), syllable.tone)) && (HasOto(vc, syllable.tone) || HasOto(ValidateAlias(vc), syllable.tone))) {
+                        } else if (HasOto(vc, syllable.tone) || HasOto(ValidateAlias(vc), syllable.tone)) {
                             phonemes.Add(vc);
                             break;
                         } else {

--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
-using NAudio.Dmo;
 using OpenUtau.Api;
 using OpenUtau.Core.G2p;
-using OpenUtau.Core.Util;
 using Serilog;
 
 namespace OpenUtau.Plugin.Builtin {

--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -125,7 +125,7 @@ namespace OpenUtau.Plugin.Builtin {
             foreach (string s in original) {
                 if (diphthongs.Contains(s) && !HasOto($"b{s}", note.tone)) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
-                } else if (affricates.Contains(s) && (!HasOto($"i {s}", note.tone) || !HasOto($"i: {s}", note.tone))) {
+                } else if (affricates.Contains(s) && (!HasOto($"i {s}", note.tone) && !HasOto($"i: {s}", note.tone))) {
                     modified.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
                 } else {
                     modified.Add(s);
@@ -285,9 +285,11 @@ namespace OpenUtau.Plugin.Builtin {
                             }
                         } else if (HasOto(vcc, syllable.tone) || HasOto(ValidateAlias(vcc), syllable.tone)) {
                             phonemes.Add(vcc);
+                            firstC = 1;
                             break;
                         } else if (HasOto(vcc2, syllable.tone) || HasOto(ValidateAlias(vcc2), syllable.tone)) {
                             phonemes.Add(vcc2);
+                            firstC = 1;
                             break;
                         } else if (HasOto(vc, syllable.tone) || HasOto(ValidateAlias(vc), syllable.tone)) {
                             phonemes.Add(vc);
@@ -304,8 +306,8 @@ namespace OpenUtau.Plugin.Builtin {
                 var rccv = $"- {string.Join("", cc)}{v}";
                 var cc1 = $"{string.Join("", cc.Skip(i))}";
                 var ccv = string.Join("", cc.Skip(i)) + v;
-                var ucv = $"_{cc.Last()}{v}";
-                if (!HasOto(rccv, syllable.vowelTone)) {
+                var ucv = $"_{cc.Last()}{v}"; ;
+                if (!HasOto(rccv, syllable.vowelTone) || !HasOto(ValidateAlias(rccv), syllable.vowelTone)) {
                     if (!HasOto(cc1, syllable.tone)) {
                         cc1 = ValidateAlias(cc1);
                     }
@@ -369,7 +371,7 @@ namespace OpenUtau.Plugin.Builtin {
                         } else if (HasOto(cc1, syllable.tone) && HasOto(cc2, syllable.tone) && !cc1.Contains($"{string.Join("", cc.Skip(i))}")) {
                             // like [V C1] [C1 C2] [C2 C3] [C3 ..]
                             phonemes.Add(cc1);
-                        } else if (TryAddPhoneme(phonemes, syllable.tone, cc1, ValidateAlias(cc1))) {
+                        } else if (TryAddPhoneme(phonemes, syllable.tone, cc1)) {
                             // like [V C1] [C1 C2] [C2 ..]
                             if (cc1.Contains($"{string.Join("", cc.Skip(i))}")) {
                                 i++;
@@ -387,7 +389,7 @@ namespace OpenUtau.Plugin.Builtin {
                         }
                     } else {
                         // like [V C1] [C1 C2]  [C2 ..] or like [V C1] [C1 -] [C3 ..]
-                        TryAddPhoneme(phonemes, syllable.tone, cc1, ValidateAlias(cc1), cc[i], ValidateAlias(cc[i]));
+                        TryAddPhoneme(phonemes, syllable.tone, cc1, cc[i], ValidateAlias(cc[i]));
                     }
                 }
             }
@@ -583,9 +585,7 @@ namespace OpenUtau.Plugin.Builtin {
             }
             foreach (var consonant1 in new[] { "r ", "r\\ " }) {
                 foreach (var consonant2 in consonants) {
-                    foreach (var dash in new[] { "-" }) {
-                        alias = alias.Replace(consonant1 + consonant2 + dash, "3 " + consonant2 + dash);
-                    }
+                    alias = alias.Replace(consonant1 + consonant2, "3 " + consonant2);
                 }
             }
             return alias;

--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -267,10 +267,8 @@ namespace OpenUtau.Plugin.Builtin {
                 var rccv = $"- {string.Join("", cc)}{v}";
                 var cc1 = $"{string.Join("", cc.Skip(i))}";
                 var ccv = string.Join("", cc.Skip(i)) + v;
-                var vcc = $"{prevV} {string.Join("", cc.Take(2))}";
-                var vcc2 = $"{prevV}{string.Join(" ", cc.Take(2))}";
                 var ucv = $"_{cc.Last()}{v}";
-                if (!HasOto(rccv, syllable.vowelTone) && !vcc.Contains(cc1) && !vcc2.Contains(cc1) && !ValidateAlias(vcc).Contains(cc1) && !ValidateAlias(vcc2).Contains(cc1)) {
+                if (!HasOto(rccv, syllable.vowelTone)) {
                     if (!HasOto(cc1, syllable.tone)) {
                         cc1 = ValidateAlias(cc1);
                     }
@@ -306,7 +304,7 @@ namespace OpenUtau.Plugin.Builtin {
                         }
                     }
                     var cc2 = $"{string.Join("", cc.Skip(i))}";
-                    if (i + 1 < lastC && !vcc.Contains(cc2) && !vcc2.Contains(cc2) && !ValidateAlias(vcc).Contains(cc2) && !ValidateAlias(vcc2).Contains(cc2)) {
+                    if (i + 1 < lastC) {
                         if (!HasOto(cc2, syllable.tone)) {
                             cc2 = ValidateAlias(cc2);
                         }
@@ -357,20 +355,15 @@ namespace OpenUtau.Plugin.Builtin {
                             if (affricates.Contains(cc[i + 1])) {
                                 i++;
                             } else {
-                                //    // continue as usual
+                                //  continue as usual
                             }
                         } else {
                             // like [V C1] [C1] [C2 ..]
-                            if (!vcc.Contains(cc[i + 1]) && !vcc2.Contains(cc[i + 1])) {
-                                TryAddPhoneme(phonemes, syllable.tone, cc[i + 1], ValidateAlias(cc[i + 1]), $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"));
-                            }
+                            TryAddPhoneme(phonemes, syllable.tone, cc[i], ValidateAlias(cc[i]));
                         }
                     } else {
                         // like [V C1] [C1 C2]  [C2 ..] or like [V C1] [C1 -] [C3 ..]
-                        TryAddPhoneme(phonemes, syllable.tone, cc1);
-                        if (affricates.Contains(cc[i]) && !HasOto(cc1, syllable.tone)) {
-                            TryAddPhoneme(phonemes, syllable.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} -", ValidateAlias($"{cc[i]} -"));
-                        }
+                        TryAddPhoneme(phonemes, syllable.tone, cc1, ValidateAlias(cc1), cc[i], ValidateAlias(cc[i]));
                     }
                 }
             }
@@ -390,11 +383,18 @@ namespace OpenUtau.Plugin.Builtin {
             } else if (ending.IsEndingVCWithOneConsonant) {
                 var vc = $"{v} {cc[0]}";
                 var vcr = $"{v} {cc[0]}-";
+                var vcr2 = $"{v}{cc[0]} -";
                 if (HasOto(vcr, ending.tone)) {
                     phonemes.Add(vcr);
                 } else if (!HasOto(vcr, ending.tone) && HasOto(ValidateAlias(vcr), ending.tone)) {
                     vcr = ValidateAlias(vcr);
                     phonemes.Add(vcr);
+                } else if (HasOto(vcr, ending.tone)) {
+                    phonemes.Add(vcr);
+                } else if (!HasOto(ValidateAlias(vcr), ending.tone) && HasOto(vcr2, ending.tone)) {
+                    phonemes.Add(vcr2);
+                } else if (!HasOto(vcr2, ending.tone) && HasOto(ValidateAlias(vcr2), ending.tone)) {
+                    phonemes.Add(ValidateAlias(vcr2));
                 } else {
                     if (HasOto(vc, ending.tone)) {
                         phonemes.Add(vc);

--- a/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ENDeltaPhonemizer.cs
@@ -205,12 +205,13 @@ namespace OpenUtau.Plugin.Builtin {
                 var ucv = $"_{cc.Last()}{v}";
                 if (HasOto(rccv, syllable.vowelTone) || HasOto(ValidateAlias(rccv), syllable.vowelTone)) {
                     basePhoneme = rccv;
-                } else if ((!HasOto(rccv, syllable.vowelTone) || !HasOto(ValidateAlias(rccv), syllable.vowelTone)) && (HasOto(crv, syllable.vowelTone) || HasOto(ValidateAlias(crv), syllable.vowelTone))) {
-                    basePhoneme = crv;
                 } else {
-                    basePhoneme = $"{cc.Last()}{v}";
                     if (HasOto(ucv, syllable.vowelTone) || HasOto(ValidateAlias(ucv), syllable.vowelTone)) {
                         basePhoneme = ucv;
+                    } else if (HasOto(crv, syllable.vowelTone) || HasOto(ValidateAlias(crv), syllable.vowelTone)) {
+                        basePhoneme = crv;
+                    } else {
+                        basePhoneme = $"{cc.Last()}{v}";
                     }
                     // try RCC
                     for (var i = cc.Length; i > 1; i--) {
@@ -229,13 +230,15 @@ namespace OpenUtau.Plugin.Builtin {
                             basePhoneme = ccv;
                             lastC = i;
                             break;
-                        } else if (!HasOto(ccv, syllable.vowelTone) || !HasOto(ValidateAlias(ccv), syllable.vowelTone) && (HasOto(crv, syllable.vowelTone) || HasOto(ValidateAlias(crv), syllable.vowelTone))) {
-                            basePhoneme = crv;
-                            break;
                         } else {
-                            basePhoneme = $"{cc.Last()}{v}";
                             if (HasOto(ucv, syllable.vowelTone) || HasOto(ValidateAlias(ucv), syllable.vowelTone)) {
                                 basePhoneme = ucv;
+                                break;
+                            } else if (HasOto(crv, syllable.vowelTone) || HasOto(ValidateAlias(crv), syllable.vowelTone)) {
+                                basePhoneme = crv;
+                                break;
+                            } else {
+                                basePhoneme = $"{cc.Last()}{v}";
                                 break;
                             }
                         }


### PR DESCRIPTION
- Important code refactor. Wasn't originally planning to, but it was for the better. This includes a major `ValidateAlias()` overhaul.
- Add support for `[C V]` notes (with a space).
- Added support for more accurate X-SAMPA symbols, if the voicebank has them (e.g. `r\` for the English R).
- Fixes several `ValidateAlias()` bugs and unnecessary things I added. It's now vastly more simplified (see above).
- Restore proper VCC connections, they should now function properly, even together with CC transitions.
- Restore/fix functionality of single consonants in certain positions. Yes this means the "consonants from hell" are back, just make them very quiet and/or fix the envelopes, I don't know how to fix it otherwise, I'm very sorry. Otherwise certain clusters might not work, if they're not present in the voicebank, so I have to rely on them sadly.
- Remove `[C] -]` functionality in lieu of CC transitions; it did not work very well, and I'm not sure it's necessary.
- Add alternate VCR ending, e.g. `[VC -]`.

**TODO:**
- Maybe rename phonemizer to "English X-SAMPA Phonemizer" + custom dictionary/template (e.g. `en-xsampa.yaml`)? Only if consensus is in favor.
- Write phonemizer tests?