### PR TITLE
Save displayed expressions in Ustx

### DIFF
--- a/OpenUtau.Core/Ustx/UProject.cs
+++ b/OpenUtau.Core/Ustx/UProject.cs
@@ -45,6 +45,9 @@ namespace OpenUtau.Core.Ustx {
         [Obsolete("Since ustx v0.6")] public int beatUnit = 4;
 
         public Dictionary<string, UExpressionDescriptor> expressions = new Dictionary<string, UExpressionDescriptor>();
+        public string[] expSelectors = new string[] { Format.Ustx.DYN, Format.Ustx.PITD, Format.Ustx.CLR, Format.Ustx.ENG, Format.Ustx.VEL };
+        public int expPrimary = 0;
+        public int expSecondary = 1;
         public List<UTimeSignature> timeSignatures;
         public List<UTempo> tempos;
         public List<UTrack> tracks;

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -142,6 +142,9 @@ namespace OpenUtau.Core.Util {
             public bool ShowWaveform = true;
             public bool ShowPhoneme = true;
             public bool ShowNoteParams = false;
+            public string[] ExpSelectors = new string[] { Format.Ustx.DYN, Format.Ustx.PITD, Format.Ustx.CLR, Format.Ustx.ENG, Format.Ustx.VEL };
+            public int ExpPrimary = 4;
+            public int ExpSecondary = 3;
             public Dictionary<string, string> DefaultResamplers = new Dictionary<string, string>();
             public Dictionary<string, string> DefaultWavtools = new Dictionary<string, string>();
             public string LyricHelper = string.Empty;

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -142,9 +142,6 @@ namespace OpenUtau.Core.Util {
             public bool ShowWaveform = true;
             public bool ShowPhoneme = true;
             public bool ShowNoteParams = false;
-            public string[] ExpSelectors = new string[] { Format.Ustx.DYN, Format.Ustx.PITD, Format.Ustx.CLR, Format.Ustx.ENG, Format.Ustx.VEL };
-            public int ExpPrimary = 4;
-            public int ExpSecondary = 3;
             public Dictionary<string, string> DefaultResamplers = new Dictionary<string, string>();
             public Dictionary<string, string> DefaultWavtools = new Dictionary<string, string>();
             public string LyricHelper = string.Empty;

--- a/OpenUtau/Controls/ExpSelector.axaml.cs
+++ b/OpenUtau/Controls/ExpSelector.axaml.cs
@@ -32,11 +32,19 @@ namespace OpenUtau.App.Controls {
         }
 
         private void TextBlockPointerPressed(object sender, PointerPressedEventArgs e) {
-            ((ExpSelectorViewModel)DataContext!).OnSelected();
+            ((ExpSelectorViewModel)DataContext!).OnSelected(true);
         }
 
         public void SelectExp() {
-            ((ExpSelectorViewModel)DataContext!).OnSelected();
+            ((ExpSelectorViewModel)DataContext!).OnSelected(false);
+        }
+
+        public string GetExpAbbr() {
+            return ((ExpSelectorViewModel)DataContext!).GetExpAbbr();
+        }
+
+        public bool SetExp(string abbr) {
+            return ((ExpSelectorViewModel)DataContext!).SetExp(abbr);
         }
     }
 }

--- a/OpenUtau/Controls/ExpSelector.axaml.cs
+++ b/OpenUtau/Controls/ExpSelector.axaml.cs
@@ -18,6 +18,7 @@ namespace OpenUtau.App.Controls {
 
         private int index;
 
+
         public ExpSelector() {
             InitializeComponent();
             DataContext = new ExpSelectorViewModel();
@@ -37,14 +38,6 @@ namespace OpenUtau.App.Controls {
 
         public void SelectExp() {
             ((ExpSelectorViewModel)DataContext!).OnSelected(false);
-        }
-
-        public string GetExpAbbr() {
-            return ((ExpSelectorViewModel)DataContext!).GetExpAbbr();
-        }
-
-        public bool SetExp(string abbr) {
-            return ((ExpSelectorViewModel)DataContext!).SetExp(abbr);
         }
     }
 }

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -915,7 +915,6 @@ namespace OpenUtau.App.Views {
                 // Workaround for new window losing focus.
                 openPianoRollWindow = true;
                 int tick = viewModel.TracksViewModel.PointToTick(args.GetPosition(canvas));
-                pianoRollWindow.SaveExpressions();
                 DocManager.Inst.ExecuteCmd(new LoadPartNotification(partControl.part, DocManager.Inst.Project, tick));
                 pianoRollWindow.AttachExpressions();
             }

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -915,9 +915,9 @@ namespace OpenUtau.App.Views {
                 // Workaround for new window losing focus.
                 openPianoRollWindow = true;
                 int tick = viewModel.TracksViewModel.PointToTick(args.GetPosition(canvas));
-                string[] pianorollCache = pianoRollWindow.CacheExpressions();
+                pianoRollWindow.SaveExpressions();
                 DocManager.Inst.ExecuteCmd(new LoadPartNotification(partControl.part, DocManager.Inst.Project, tick));
-                pianoRollWindow.LoadCacheExpressions(pianorollCache);
+                pianoRollWindow.AttachExpressions();
             }
         }
 

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -11,7 +11,6 @@ using OpenUtau.App.Controls;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
-using OpenUtau.Core.Util;
 using ReactiveUI;
 using Serilog;
 
@@ -61,7 +60,6 @@ namespace OpenUtau.App.Views {
 
         void WindowClosing(object? sender, WindowClosingEventArgs e) {
             Hide();
-            SaveExpressions();
             e.Cancel = true;
         }
 
@@ -1278,23 +1276,13 @@ namespace OpenUtau.App.Views {
             return false;
         }
 
-        public void SaveExpressions() {
-            var exps = new ExpSelector[] { expSelector1, expSelector2, expSelector3, expSelector4, expSelector5 };
-            for (int i = 0; i < exps.Length; i++) {
-                Preferences.Default.ExpSelectors[i] = exps[i].GetExpAbbr();
-            }
-            Preferences.Save();
-        }
         public void AttachExpressions() {
             if (expSelector1 == null) {
                 return;
             }
             var exps = new ExpSelector[] { expSelector1, expSelector2, expSelector3, expSelector4, expSelector5 };
-            for (int i = 0; i < exps.Length; i++) {
-                exps[i].SetExp(Preferences.Default.ExpSelectors[i]);
-            }
-            exps[Preferences.Default.ExpSecondary].SelectExp();
-            exps[Preferences.Default.ExpPrimary].SelectExp();
+            exps[DocManager.Inst.Project.expSecondary].SelectExp();
+            exps[DocManager.Inst.Project.expPrimary].SelectExp();
         }
     }
 }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -11,6 +11,7 @@ using OpenUtau.App.Controls;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using ReactiveUI;
 using Serilog;
 
@@ -60,6 +61,7 @@ namespace OpenUtau.App.Views {
 
         void WindowClosing(object? sender, WindowClosingEventArgs e) {
             Hide();
+            SaveExpressions();
             e.Cancel = true;
         }
 
@@ -1276,41 +1278,23 @@ namespace OpenUtau.App.Views {
             return false;
         }
 
-        public string[] CacheExpressions() {
-            NotesViewModel vm = (DataContext as PianoRollViewModel)!.NotesViewModel;
-            return new string[] { vm.SecondaryKey, vm.PrimaryKey };
+        public void SaveExpressions() {
+            var exps = new ExpSelector[] { expSelector1, expSelector2, expSelector3, expSelector4, expSelector5 };
+            for (int i = 0; i < exps.Length; i++) {
+                Preferences.Default.ExpSelectors[i] = exps[i].GetExpAbbr();
+            }
+            Preferences.Save();
         }
-        public void LoadCacheExpressions(string[] cache) {
+        public void AttachExpressions() {
             if (expSelector1 == null) {
                 return;
             }
-            foreach (string key in cache) {
-                UExpressionDescriptor? exp = (expSelector1.DataContext as ExpSelectorViewModel)?.Descriptor;
-                if (exp != null && exp.abbr == key) {
-                    expSelector1.SelectExp();
-                    continue;
-                }
-                exp = (expSelector2.DataContext as ExpSelectorViewModel)?.Descriptor;
-                if (exp != null && exp.abbr == key) {
-                    expSelector2.SelectExp();
-                    continue;
-                }
-                exp = (expSelector3.DataContext as ExpSelectorViewModel)?.Descriptor;
-                if (exp != null && exp.abbr == key) {
-                    expSelector3.SelectExp();
-                    continue;
-                }
-                exp = (expSelector4.DataContext as ExpSelectorViewModel)?.Descriptor;
-                if (exp != null && exp.abbr == key) {
-                    expSelector4.SelectExp();
-                    continue;
-                }
-                exp = (expSelector5.DataContext as ExpSelectorViewModel)?.Descriptor;
-                if (exp != null && exp.abbr == key) {
-                    expSelector5.SelectExp();
-                    continue;
-                }
+            var exps = new ExpSelector[] { expSelector1, expSelector2, expSelector3, expSelector4, expSelector5 };
+            for (int i = 0; i < exps.Length; i++) {
+                exps[i].SetExp(Preferences.Default.ExpSelectors[i]);
             }
+            exps[Preferences.Default.ExpSecondary].SelectExp();
+            exps[Preferences.Default.ExpPrimary].SelectExp();
         }
     }
 }


### PR DESCRIPTION
- ~~Expressions selections are saved in preferences and are restored even when we open another project or restart it.~~
- ~~Each of the five expressions is saved just before reopening or closing the piano roll.~~
- ~~Which of the expressions to operate is saved when selected.~~
- ~~It might be nice to save individual settings for each renderer in the future, but I haven't gotten that far yet.~~

- Expressions selections are saved in ustx.
- For each ExpSelectors, which expressions is selected is always tied to the field in UProject, and the phenomenon of it being reset each time the pianoroll is opened has been resolved. They are saved as a string, and if it does not exist, it is selected in the same order as before (the 0th in Descriptors if it is the top ExpSelector).