### PR TITLE
[JA CVVC & Presamp] Semi-fix for voice color fallbacks

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
@@ -103,6 +103,39 @@ namespace OpenUtau.Plugin.Builtin {
         private bool checkOtoUntilHit(string[] input, Note note, out UOto oto) {
             oto = default;
             var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+            var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
+
+            var otos = new List<UOto>();
+            foreach (string test in input) {
+                if (singer.TryGetMappedOto(test + attr.alternate, note.tone + attr.toneShift, attr.voiceColor, out var otoAlt)) {
+                    otos.Add(otoAlt);
+                } else if (singer.TryGetMappedOto(test, note.tone + attr.toneShift, attr.voiceColor, out var otoCandidacy)) {
+                    otos.Add(otoCandidacy);
+                }
+            }
+
+            string color = attr.voiceColor ?? "";
+            if (otos.Count > 0) {
+                if (otos.Any(oto => (oto.Color ?? string.Empty) == color)) {
+                    oto = otos.Find(oto => (oto.Color ?? string.Empty) == color);
+                    return true;
+                } else if (otos.Any(oto => (color ?? string.Empty) == color)) {
+                    oto = otos.Find(oto => (color ?? string.Empty) == color);
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        // checking VCs
+        // when VC does not exist, it will not be inserted
+        // TODO: fix duplicate voice color fallback bug (for now, this is better than nothing)
+        private bool checkOtoUntilHitVc(string[] input, Note note, out UOto oto) {
+            oto = default;
+            var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+            var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
 
             var otos = new List<UOto>();
             foreach (string test in input) {
@@ -124,6 +157,7 @@ namespace OpenUtau.Plugin.Builtin {
             }
             return false;
         }
+
 
         // can probably be cleaned up more but i have work in the morning. have fun.
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
@@ -217,7 +251,7 @@ namespace OpenUtau.Plugin.Builtin {
                         vcPhonemes[1] = $"{vowel} {con}";
                 }
                 //if (singer.TryGetMappedOto(vcPhoneme, note.tone + attr0.toneShift, attr0.voiceColor, out var oto1)) {
-                if (checkOtoUntilHit(vcPhonemes, note, out var oto1)) {
+                if (checkOtoUntilHitVc(vcPhonemes, note, out var oto1)) {
                     vcPhoneme = oto1.Alias;
                 } else {
                     return new Result {

--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Classic;
 using OpenUtau.Api;
-using OpenUtau.Classic;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Plugin.Builtin {
@@ -20,7 +18,7 @@ namespace OpenUtau.Plugin.Builtin {
         // Partial supporting: [NUM][APPEND][PITCH] -> Using to exclude useless characters in lyrics
 
         // in case voicebank is missing certain symbols
-        static readonly string[] substitution = new string[] {  
+        static readonly string[] substitution = new string[] {
             "ty,ch,ts=t", "j,dy=d", "gy=g", "ky=k", "py=p", "ny=n", "ry=r", "my=m", "hy,f=h", "by,v=b", "dz=z", "l=r", "ly=l"
         };
 
@@ -200,7 +198,7 @@ namespace OpenUtau.Plugin.Builtin {
                             }
                             // next is CV (VC needed)
                             tests = new List<string> { $"{vowel}{vcpad}・" };
-                            if (checkOtoUntilHit(tests, note, out oto1)) {
+                            if (checkOtoUntilHitVc(tests, note, out oto1)) {
                                 vcPhoneme = oto1.Alias;
                             } else {
                                 return MakeSimpleResult(currentLyric);
@@ -226,6 +224,10 @@ namespace OpenUtau.Plugin.Builtin {
                             }
                         }
 
+                        var otos = new List<UOto>();
+                        var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+                        string color = attr.voiceColor ?? "";
+
                         // Insert VC before next neighbor
                         vcPhoneme = $"{vowel}{vcpad}{consonant}";
                         var vcPhonemes = new List<string> { vcPhoneme };
@@ -233,7 +235,8 @@ namespace OpenUtau.Plugin.Builtin {
                         if (substituteLookup.TryGetValue(consonant ?? string.Empty, out var con)) {
                             vcPhonemes.Add($"{vowel}{vcpad}{con}");
                         }
-                        if (checkOtoUntilHit(vcPhonemes, note, out var oto)) {
+                        if (checkOtoUntilHitVc(vcPhonemes, note, out var oto)) {
+                            otos.Any(oto => (oto.Color ?? string.Empty) == color);
                             vcPhoneme = oto.Alias;
                         } else {
                             return MakeSimpleResult(currentLyric);
@@ -290,6 +293,9 @@ namespace OpenUtau.Plugin.Builtin {
                 if (otos.Any(oto => (oto.Color ?? string.Empty) == color)) {
                     oto = otos.Find(oto => (oto.Color ?? string.Empty) == color);
                     return true;
+                } else if (otos.Any(oto => (color ?? string.Empty) == color)) {
+                    oto = otos.Find(oto => (color ?? string.Empty) == color);
+                    return true;
                 } else {
                     return false;
                 }
@@ -297,5 +303,32 @@ namespace OpenUtau.Plugin.Builtin {
             return false;
         }
 
+        // checking VCs
+        // when VC does not exist, it will not be inserted
+        // TODO: fix duplicate voice color fallback bug (for now, this is better than nothing)
+        private bool checkOtoUntilHitVc(List<string> input, Note note, out UOto oto) {
+            oto = default;
+            var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+
+            var otos = new List<UOto>();
+            foreach (string test in input) {
+                if (singer.TryGetMappedOto(test + attr.alternate, note.tone + attr.toneShift, attr.voiceColor, out var otoAlt)) {
+                    otos.Add(otoAlt);
+                } else if (singer.TryGetMappedOto(test, note.tone + attr.toneShift, attr.voiceColor, out var otoCandidacy)) {
+                    otos.Add(otoCandidacy);
+                }
+            }
+
+            string color = attr.voiceColor ?? "";
+            if (otos.Count > 0) {
+                if (otos.Any(oto => (oto.Color ?? string.Empty) == color)) {
+                    oto = otos.Find(oto => (oto.Color ?? string.Empty) == color);
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Quote from #757:

> There was a bug in both of these phonemizers where, if an append voice color contains the same suffix as on the main voice color, the voice color would fall back to having no suffix on that particular pitch. Now it will fall back on the main voice color instead, as intended.

Note that the current PR only semi-fixes this problem; the bug will still persist on VC notes, which will be null (absent) when an append voice color contains the same suffix as the main voice color. However, base notes (starting CV, base CV, VCV) will work as intended with this fix. (The reason for this is to keep supporting CV-only voice colors; otherwise, they would insert VCs of the main color, which isn't always desirable, especially with "effect voices" (growl, unvoiced/whisper).)

A workaround for now is to manually insert a consonant note, which will look like a VC note, e.g. ``[m]`` which will turn into ``[V m]`` (where ``V`` is a vowel). Note that for this to work with the Presamp phonemizer, it's highly recommended to include a presamp.ini with your voicebank with a blank ``[PRIORITY]`` line for this to work on stop consonants. JA CVVC will not have this issue, since it does not have a Priority function to begin with.

**TODO:** As stated above, I need to fix this for VC notes as well. Help and tips for this are highly appreciated.
