### PR TITLE
Make it easier to extend the tail of a project

### DIFF
--- a/OpenUtau/ViewModels/TracksViewModel.cs
+++ b/OpenUtau/ViewModels/TracksViewModel.cs
@@ -51,7 +51,7 @@ namespace OpenUtau.App.ViewModels {
     public class TracksViewModel : ViewModelBase, ICmdSubscriber {
         public UProject Project => DocManager.Inst.Project;
         [Reactive] public Rect Bounds { get; set; }
-        public int TickCount => Math.Max(Project.timeAxis.BarBeatToTickPos(32, 0), Project.EndTick);
+        public int TickCount => Math.Max(Project.timeAxis.BarBeatToTickPos(32, 0), Project.EndTick + 23040);
         public int TrackCount => Math.Max(20, Project.tracks.Count + 1);
         [Reactive] public double TickWidth { get; set; }
         public double TrackHeightMin => ViewConstants.TrackHeightMin;


### PR DESCRIPTION
Before this change, if I want to extend the tail of a project, I have to drag and scroll many times:

https://github.com/stakira/OpenUtau/assets/54425948/29ec704a-4d41-4665-ab79-0a5e2bba3bba

After this change, I can extend the tail of a project in one drag:

https://github.com/stakira/OpenUtau/assets/54425948/e9e0e7d4-d9c8-42f7-a899-234ba05ba5de

