### PR TITLE
Fix unable to save oto when the voicebank contains wavs that haven't been oto'd

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -409,7 +409,7 @@ namespace OpenUtau.Classic {
         public static void WriteOtoSet(OtoSet otoSet, Stream stream, Encoding encoding) {
             using (var writer = new StreamWriter(stream, encoding)) {
                 foreach (var oto in otoSet.Otos) {
-                    if (!oto.IsValid) {
+                    if (!oto.IsValid && (oto.FileTrace != null)) {
                         writer.Write(oto.FileTrace.line);
                         writer.Write('\n');
                         continue;


### PR DESCRIPTION
For wavs that haven't been oto'd, openutau will create a dummy `Oto` object whose `IsValid` is false and FileTrace is null, which will cause error when saving oto.