### PR TITLE
[PinyinLyricsHelper] Convert pinyin to lower variant in PinyinLyricsHelper

### DIFF
--- a/OpenUtau.Core/Util/LyricsHelper.cs
+++ b/OpenUtau.Core/Util/LyricsHelper.cs
@@ -54,7 +54,7 @@ namespace OpenUtau.Core.Util {
     public class PinyinLyricsHelper : ILyricsHelper {
         public string Source => "汉->han";
         public string Convert(string lyric) {
-            return TinyPinyin.PinyinHelper.GetPinyin(lyric);
+            return TinyPinyin.PinyinHelper.GetPinyin(lyric).ToLowerInvariant();
         }
     }
 


### PR DESCRIPTION
Currently, when using the PinyinLyricsHelper, the suggested pinyin are all in uppercase. As a result, the LyricsHelper does not function properly. With this, it will be fixed so that the lowercase variant will be inserted.