### PR TITLE
Check and Remapping voice color

### DIFF
--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -146,6 +146,16 @@ namespace OpenUtau.Core {
         public override string ToString() => "Singers refreshed.";
     }
 
+    public class VoiceColorRemappingNotification : UNotification {
+        public int TrackNo;
+        public bool Validate;
+        public VoiceColorRemappingNotification(int trackNo, bool validate) {
+            TrackNo = trackNo;
+            Validate = validate;
+        }
+        public override string ToString() => "Voice color remapping.";
+    }
+
     public class OtoChangedNotification : UNotification {
         public readonly bool external;
         public OtoChangedNotification(bool external = false) {

--- a/OpenUtau.Core/Ustx/UTrack.cs
+++ b/OpenUtau.Core/Ustx/UTrack.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core.Render;
@@ -95,6 +96,7 @@ namespace OpenUtau.Core.Ustx {
         public double Volume { set; get; }
         public double Pan { set; get; }
         [YamlIgnore] public UExpressionDescriptor VoiceColorExp { set; get; }
+        public string[] VoiceColorNames { get; set; } = new string[] { "" };
 
         public UTrack() {
         }
@@ -145,6 +147,33 @@ namespace OpenUtau.Core.Ustx {
                     VoiceColorExp.max = VoiceColorExp.options.Length - 1;
                 }
             }
+        }
+
+        public bool ValidateVoiceColor(out string[] oldColors, out string[] newColors) {
+            bool discrepancy = false;
+            oldColors = new string[0];
+            newColors = new string[0];
+
+            if (Singer != null && Singer.Found && VoiceColorExp != null) {
+                oldColors = VoiceColorNames.ToArray();
+                newColors = VoiceColorExp.options.ToArray();
+
+                if (VoiceColorNames.Length > 1) {
+                    if (VoiceColorNames.Length != VoiceColorExp.options.Length) {
+                        // DocManager.Inst.ExecuteCmd(new VoiceColorDiscrepancyNotification(TrackNo));
+                        discrepancy = true;
+                    } else {
+                        for (int i = 0; i < VoiceColorNames.Length; i++) {
+                            if (VoiceColorNames[i] != VoiceColorExp.options[i]) {
+                                discrepancy = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                VoiceColorNames = VoiceColorExp.options.ToArray();
+            }
+            return discrepancy;
         }
 
         public void BeforeSave() {

--- a/OpenUtau.Core/Ustx/UTrack.cs
+++ b/OpenUtau.Core/Ustx/UTrack.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core.Render;
@@ -151,16 +150,14 @@ namespace OpenUtau.Core.Ustx {
 
         public bool ValidateVoiceColor(out string[] oldColors, out string[] newColors) {
             bool discrepancy = false;
-            oldColors = new string[0];
+            oldColors = VoiceColorNames.ToArray();
             newColors = new string[0];
 
             if (Singer != null && Singer.Found && VoiceColorExp != null) {
-                oldColors = VoiceColorNames.ToArray();
                 newColors = VoiceColorExp.options.ToArray();
 
                 if (VoiceColorNames.Length > 1) {
                     if (VoiceColorNames.Length != VoiceColorExp.options.Length) {
-                        // DocManager.Inst.ExecuteCmd(new VoiceColorDiscrepancyNotification(TrackNo));
                         discrepancy = true;
                     } else {
                         for (int i = 0; i < VoiceColorNames.Length; i++) {

--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -173,13 +173,14 @@
       </Grid>
       <Grid.ContextMenu>
         <ContextMenu>
-          <MenuItem Classes="context" Header="{StaticResource tracks.remove}" Command="{Binding Remove}"/>
-          <MenuItem Classes="context" Header="{StaticResource tracks.moveup}" Command="{Binding MoveUp}"/>
-          <MenuItem Classes="context" Header="{StaticResource tracks.movedown}" Command="{Binding MoveDown}"/>
-          <MenuItem Classes="context" Header="{StaticResource tracks.rename}" Command="{Binding Rename}"/>
-          <MenuItem Classes="context" Header="{StaticResource tracks.trackcolor}" Command="{Binding SelectTrackColor}"/>
-          <MenuItem Classes="context" Header="{StaticResource tracks.duplicate}" Command="{Binding Duplicate}"/>
-          <MenuItem Classes="context" Header="{StaticResource tracks.duplicatesettings}" Command="{Binding DuplicateSettings}"/>
+          <MenuItem Classes="context" Header="{DynamicResource tracks.remove}" Command="{Binding Remove}"/>
+          <MenuItem Classes="context" Header="{DynamicResource tracks.moveup}" Command="{Binding MoveUp}"/>
+          <MenuItem Classes="context" Header="{DynamicResource tracks.movedown}" Command="{Binding MoveDown}"/>
+          <MenuItem Classes="context" Header="{DynamicResource tracks.rename}" Command="{Binding Rename}"/>
+          <MenuItem Classes="context" Header="{DynamicResource tracks.trackcolor}" Command="{Binding SelectTrackColor}"/>
+          <MenuItem Classes="context" Header="{DynamicResource tracks.duplicate}" Command="{Binding Duplicate}"/>
+          <MenuItem Classes="context" Header="{DynamicResource tracks.duplicatesettings}" Command="{Binding DuplicateSettings}"/>
+          <MenuItem Classes="context" Header="{DynamicResource dialogs.voicecolorremapping}" Command="{Binding VoiceColorRemapping}"/>
         </ContextMenu>
       </Grid.ContextMenu>
     </Grid>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -45,6 +45,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Location</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>
+  <system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>
+  <system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>
 
   <system:String x:Key="errors.caption">Error</system:String>
 

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -45,6 +45,8 @@
   <system:String x:Key="dialogs.tracksettings.location">場所</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">デフォルト設定として保存</system:String>
+  <system:String x:Key="dialogs.voicecolorremapping">Voice colorの再マッピング</system:String>
+  <system:String x:Key="dialogs.voicecolorremapping.caption">このトラック内のすべての音符に適用されます：</system:String>
 
   <system:String x:Key="errors.caption">エラー</system:String>
 

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -3,11 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Threading.Tasks;
-using Avalonia;
-using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using DynamicData.Binding;
-using OpenUtau.App.Views;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using ReactiveUI;
@@ -97,6 +94,7 @@ namespace OpenUtau.App.ViewModels {
             var args = Environment.GetCommandLineArgs();
             if (args.Length == 2 && File.Exists(args[1])) {
                 Core.Format.Formats.LoadProject(new string[] { args[1] });
+                DocManager.Inst.ExecuteCmd(new VoiceColorRemappingNotification(-1, true));
                 return;
             }
             NewProject();
@@ -123,9 +121,7 @@ namespace OpenUtau.App.ViewModels {
                 return;
             }
             Core.Format.Formats.LoadProject(files);
-            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && desktop.MainWindow is MainWindow mainWindow) {
-                mainWindow.ValidateTrackVoiceColor();
-            }
+            DocManager.Inst.ExecuteCmd(new VoiceColorRemappingNotification(-1, true));
             this.RaisePropertyChanged(nameof(Title));
         }
 

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -3,8 +3,11 @@ using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using DynamicData.Binding;
+using OpenUtau.App.Views;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using ReactiveUI;
@@ -120,6 +123,9 @@ namespace OpenUtau.App.ViewModels {
                 return;
             }
             Core.Format.Formats.LoadProject(files);
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && desktop.MainWindow is MainWindow mainWindow) {
+                mainWindow.ValidateTrackVoiceColor();
+            }
             this.RaisePropertyChanged(nameof(Title));
         }
 

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -77,6 +77,7 @@ namespace OpenUtau.App.ViewModels {
                         };
                         DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, track, settings));
                     }
+                    DocManager.Inst.ExecuteCmd(new VoiceColorRemappingNotification(track.TrackNo, true));
                     DocManager.Inst.EndUndoGroup();
                     if (!string.IsNullOrEmpty(singer?.Id) && singer.Found) {
                         Preferences.Default.RecentSingers.Remove(singer.Id);
@@ -438,6 +439,12 @@ namespace OpenUtau.App.ViewModels {
                 TrackColor = track.TrackColor
             }));
             DocManager.Inst.EndUndoGroup();
+        }
+
+        public void VoiceColorRemapping() {
+            if (track.Singer != null && track.Singer.Found && track.VoiceColorExp != null) {
+                DocManager.Inst.ExecuteCmd(new VoiceColorRemappingNotification(track.TrackNo, false));
+            }
         }
     }
 }

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Threading;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Media;

--- a/OpenUtau/ViewModels/VoiceColorMappingViewModel.cs
+++ b/OpenUtau/ViewModels/VoiceColorMappingViewModel.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DynamicData;
+
+namespace OpenUtau.App.ViewModels {
+    public class VoiceColorMappingViewModel : ViewModelBase {
+
+        public string TrackName { get; set; }
+        public ObservableCollection<ColorMapping> ColorMappings { get; set; } = new ObservableCollection<ColorMapping>();
+
+        public VoiceColorMappingViewModel(string[] oldColors, string[] newColors, string trackName) {
+            var NewColors = new ObservableCollection<string>(newColors);
+            TrackName = trackName;
+
+            for (int i = 0; i < oldColors.Length; i++) {
+                if (newColors.Contains(oldColors[i])) {
+                    ColorMappings.Add(new ColorMapping(oldColors[i], i, newColors.IndexOf(oldColors[i]), NewColors));
+                } else if (i < newColors.Length) {
+                    ColorMappings.Add(new ColorMapping(oldColors[i], i, i, NewColors));
+                } else {
+                    ColorMappings.Add(new ColorMapping(oldColors[i], i, 0, NewColors));
+                }
+            }
+        }
+    }
+
+    public class ColorMapping {
+        public string Name { get; set; }
+        public int OldIndex { get; set; }
+        public int SelectedIndex { get; set; }
+        public ObservableCollection<string> NewColors { get; set; }
+
+        public ColorMapping(string name,int oldIndex, int selectedIndex, ObservableCollection<string> newColors) {
+            Name = name;
+            OldIndex = oldIndex;
+            SelectedIndex = selectedIndex;
+            NewColors = newColors;
+        }
+    }
+}

--- a/OpenUtau/ViewModels/VoiceColorMappingViewModel.cs
+++ b/OpenUtau/ViewModels/VoiceColorMappingViewModel.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DynamicData;
 
 namespace OpenUtau.App.ViewModels {
@@ -14,10 +11,13 @@ namespace OpenUtau.App.ViewModels {
 
         public VoiceColorMappingViewModel(string[] oldColors, string[] newColors, string trackName) {
             var NewColors = new ObservableCollection<string>(newColors);
+            NewColors[0] = "(Default)";
             TrackName = trackName;
 
             for (int i = 0; i < oldColors.Length; i++) {
-                if (newColors.Contains(oldColors[i])) {
+                if (i == 0) {
+                    ColorMappings.Add(new ColorMapping("(Default)", 0, 0, NewColors));
+                } else if (newColors.Contains(oldColors[i])) {
                     ColorMappings.Add(new ColorMapping(oldColors[i], i, newColors.IndexOf(oldColors[i]), NewColors));
                 } else if (i < newColors.Length) {
                     ColorMappings.Add(new ColorMapping(oldColors[i], i, i, NewColors));

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -192,6 +192,75 @@ namespace OpenUtau.App.Views {
             }
         }
 
+        public async void ValidateTrackVoiceColor() {
+            foreach (var track in DocManager.Inst.Project.tracks) {
+                if (track.ValidateVoiceColor(out var oldColors, out var newColors)) {
+                    await VoiceColorRemappingAsync(track, oldColors, newColors);
+                }
+            }
+        }
+        async Task VoiceColorRemappingAsync(UTrack track, string[] oldColors, string[] newColors) {
+            var parts = DocManager.Inst.Project.parts.Where(part => part.trackNo == track.TrackNo);
+            if (parts.Any(part => part is UVoicePart)) {
+                var dialog = new VoiceColorMappingDialog();
+                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName);
+                dialog.DataContext = vm;
+                await dialog.ShowDialog(this);
+
+                if (dialog.Apply) {
+                    DocManager.Inst.StartUndoGroup();
+                    foreach (var part in parts) {
+                        if (part is UVoicePart voicePart) {
+                            foreach (var phoneme in voicePart.phonemes) {
+                                var tuple = phoneme.GetExpression(DocManager.Inst.Project, track, Ustx.CLR);
+                                if (tuple.Item2) { // phoneme has color
+                                    if (vm.ColorMappings.Any(m => m.OldIndex == tuple.Item1)) {
+                                        var mapping = vm.ColorMappings.First(m => m.OldIndex == tuple.Item1);
+                                        if (mapping.OldIndex != mapping.SelectedIndex) {
+                                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, mapping.SelectedIndex));
+                                        }
+                                    } else {
+                                        DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, 0));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    DocManager.Inst.EndUndoGroup();
+                }
+            }
+        }
+        void VoiceColorRemapping(UTrack track, string[] oldColors, string[] newColors) {
+            var parts = DocManager.Inst.Project.parts.Where(part => part.trackNo == track.TrackNo);
+            if (parts.Any(part => part is UVoicePart)) {
+                var dialog = new VoiceColorMappingDialog();
+                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName);
+                dialog.DataContext = vm;
+                dialog.onFinish = () => {
+                    DocManager.Inst.StartUndoGroup();
+                    foreach (var part in parts) {
+                        if (part is UVoicePart voicePart) {
+                            foreach (var phoneme in voicePart.phonemes) {
+                                var tuple = phoneme.GetExpression(DocManager.Inst.Project, track, Ustx.CLR);
+                                if (tuple.Item2) { // phoneme has color
+                                    if (vm.ColorMappings.Any(m => m.OldIndex == tuple.Item1)) {
+                                        var mapping = vm.ColorMappings.First(m => m.OldIndex == tuple.Item1);
+                                        if (mapping.OldIndex != mapping.SelectedIndex) {
+                                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, mapping.SelectedIndex));
+                                        }
+                                    } else {
+                                        DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, 0));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    DocManager.Inst.EndUndoGroup();
+                };
+                dialog.ShowDialog(this);
+            }
+        }
+
         void OnMainMenuOpened(object sender, RoutedEventArgs args) {
             viewModel.RefreshOpenRecent();
             viewModel.RefreshTemplates();
@@ -283,6 +352,7 @@ namespace OpenUtau.App.Views {
                 Log.Error(e, $"Failed to import files");
                 _ = await MessageBox.ShowError(this, e);
             }
+            ValidateTrackVoiceColor();
         }
 
         async void OnMenuImportAudio(object sender, RoutedEventArgs args) {
@@ -1025,6 +1095,14 @@ namespace OpenUtau.App.Views {
         public void OnNext(UCommand cmd, bool isUndo) {
             if (cmd is ErrorMessageNotification notif) {
                 MessageBox.ShowError(this, notif.message, notif.e);
+            } else if (cmd is VoiceColorRemappingNotification voicecolorNotif) { // call from track header
+                UTrack track = DocManager.Inst.Project.tracks[voicecolorNotif.TrackNo];
+                if (!voicecolorNotif.Validate) {
+                    VoiceColorRemapping(track, track.VoiceColorNames, track.VoiceColorExp.options);
+                } else if (track.ValidateVoiceColor(out var oldColors, out var newColors)) {
+                    VoiceColorRemapping(track, oldColors, newColors);
+                }
+                
             }
         }
     }

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -192,75 +192,6 @@ namespace OpenUtau.App.Views {
             }
         }
 
-        public async void ValidateTrackVoiceColor() {
-            foreach (var track in DocManager.Inst.Project.tracks) {
-                if (track.ValidateVoiceColor(out var oldColors, out var newColors)) {
-                    await VoiceColorRemappingAsync(track, oldColors, newColors);
-                }
-            }
-        }
-        async Task VoiceColorRemappingAsync(UTrack track, string[] oldColors, string[] newColors) {
-            var parts = DocManager.Inst.Project.parts.Where(part => part.trackNo == track.TrackNo);
-            if (parts.Any(part => part is UVoicePart)) {
-                var dialog = new VoiceColorMappingDialog();
-                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName);
-                dialog.DataContext = vm;
-                await dialog.ShowDialog(this);
-
-                if (dialog.Apply) {
-                    DocManager.Inst.StartUndoGroup();
-                    foreach (var part in parts) {
-                        if (part is UVoicePart voicePart) {
-                            foreach (var phoneme in voicePart.phonemes) {
-                                var tuple = phoneme.GetExpression(DocManager.Inst.Project, track, Ustx.CLR);
-                                if (tuple.Item2) { // phoneme has color
-                                    if (vm.ColorMappings.Any(m => m.OldIndex == tuple.Item1)) {
-                                        var mapping = vm.ColorMappings.First(m => m.OldIndex == tuple.Item1);
-                                        if (mapping.OldIndex != mapping.SelectedIndex) {
-                                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, mapping.SelectedIndex));
-                                        }
-                                    } else {
-                                        DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, 0));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    DocManager.Inst.EndUndoGroup();
-                }
-            }
-        }
-        void VoiceColorRemapping(UTrack track, string[] oldColors, string[] newColors) {
-            var parts = DocManager.Inst.Project.parts.Where(part => part.trackNo == track.TrackNo);
-            if (parts.Any(part => part is UVoicePart)) {
-                var dialog = new VoiceColorMappingDialog();
-                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName);
-                dialog.DataContext = vm;
-                dialog.onFinish = () => {
-                    DocManager.Inst.StartUndoGroup();
-                    foreach (var part in parts) {
-                        if (part is UVoicePart voicePart) {
-                            foreach (var phoneme in voicePart.phonemes) {
-                                var tuple = phoneme.GetExpression(DocManager.Inst.Project, track, Ustx.CLR);
-                                if (tuple.Item2) { // phoneme has color
-                                    if (vm.ColorMappings.Any(m => m.OldIndex == tuple.Item1)) {
-                                        var mapping = vm.ColorMappings.First(m => m.OldIndex == tuple.Item1);
-                                        if (mapping.OldIndex != mapping.SelectedIndex) {
-                                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, mapping.SelectedIndex));
-                                        }
-                                    } else {
-                                        DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, 0));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    DocManager.Inst.EndUndoGroup();
-                };
-                dialog.ShowDialog(this);
-            }
-        }
-
         void OnMainMenuOpened(object sender, RoutedEventArgs args) {
             viewModel.RefreshOpenRecent();
             viewModel.RefreshTemplates();
@@ -352,7 +283,7 @@ namespace OpenUtau.App.Views {
                 Log.Error(e, $"Failed to import files");
                 _ = await MessageBox.ShowError(this, e);
             }
-            ValidateTrackVoiceColor();
+            ValidateTracksVoiceColor();
         }
 
         async void OnMenuImportAudio(object sender, RoutedEventArgs args) {
@@ -1062,6 +993,71 @@ namespace OpenUtau.App.Views {
             DocManager.Inst.EndUndoGroup();
         }
 
+        async void ValidateTracksVoiceColor() {
+            DocManager.Inst.StartUndoGroup();
+            foreach (var track in DocManager.Inst.Project.tracks) {
+                if (track.ValidateVoiceColor(out var oldColors, out var newColors)) {
+                    await VoiceColorRemappingAsync(track, oldColors, newColors);
+                }
+            }
+            DocManager.Inst.EndUndoGroup();
+        }
+        async Task VoiceColorRemappingAsync(UTrack track, string[] oldColors, string[] newColors) {
+            var parts = DocManager.Inst.Project.parts.Where(part => part.trackNo == track.TrackNo);
+            if (parts.Any(part => part is UVoicePart vpart && vpart.notes.Count > 0)) {
+                var dialog = new VoiceColorMappingDialog();
+                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName);
+                dialog.DataContext = vm;
+                await dialog.ShowDialog(this);
+
+                if (dialog.Apply) {
+                    foreach (var part in parts) {
+                        if (part is UVoicePart voicePart) {
+                            foreach (var phoneme in voicePart.phonemes) {
+                                var tuple = phoneme.GetExpression(DocManager.Inst.Project, track, Ustx.CLR);
+                                if (vm.ColorMappings.Any(m => m.OldIndex == tuple.Item1)) {
+                                    var mapping = vm.ColorMappings.First(m => m.OldIndex == tuple.Item1);
+                                    if (mapping.OldIndex != mapping.SelectedIndex) {
+                                        DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, mapping.SelectedIndex));
+                                    }
+                                } else {
+                                    DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, 0));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        void VoiceColorRemapping(UTrack track, string[] oldColors, string[] newColors) {
+            var parts = DocManager.Inst.Project.parts.Where(part => part.trackNo == track.TrackNo);
+            if (parts.Any(part => part is UVoicePart vpart && vpart.notes.Count > 0)) {
+                var dialog = new VoiceColorMappingDialog();
+                VoiceColorMappingViewModel vm = new VoiceColorMappingViewModel(oldColors, newColors, track.TrackName);
+                dialog.DataContext = vm;
+                dialog.onFinish = () => {
+                    DocManager.Inst.StartUndoGroup();
+                    foreach (var part in parts) {
+                        if (part is UVoicePart voicePart) {
+                            foreach (var phoneme in voicePart.phonemes) {
+                                var tuple = phoneme.GetExpression(DocManager.Inst.Project, track, Ustx.CLR);
+                                if (vm.ColorMappings.Any(m => m.OldIndex == tuple.Item1)) {
+                                    var mapping = vm.ColorMappings.First(m => m.OldIndex == tuple.Item1);
+                                    if (mapping.OldIndex != mapping.SelectedIndex) {
+                                        DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, mapping.SelectedIndex));
+                                    }
+                                } else {
+                                    DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, voicePart, phoneme, Ustx.CLR, 0));
+                                }
+                            }
+                        }
+                    }
+                    DocManager.Inst.EndUndoGroup();
+                };
+                dialog.ShowDialog(this);
+            }
+        }
+
         public async void WindowClosing(object? sender, WindowClosingEventArgs e) {
             if (forceClose || DocManager.Inst.ChangesSaved) {
                 return;
@@ -1095,14 +1091,17 @@ namespace OpenUtau.App.Views {
         public void OnNext(UCommand cmd, bool isUndo) {
             if (cmd is ErrorMessageNotification notif) {
                 MessageBox.ShowError(this, notif.message, notif.e);
-            } else if (cmd is VoiceColorRemappingNotification voicecolorNotif) { // call from track header
-                UTrack track = DocManager.Inst.Project.tracks[voicecolorNotif.TrackNo];
-                if (!voicecolorNotif.Validate) {
-                    VoiceColorRemapping(track, track.VoiceColorNames, track.VoiceColorExp.options);
-                } else if (track.ValidateVoiceColor(out var oldColors, out var newColors)) {
-                    VoiceColorRemapping(track, oldColors, newColors);
+            } else if (cmd is VoiceColorRemappingNotification voicecolorNotif) {
+                if(voicecolorNotif.TrackNo < 0 || DocManager.Inst.Project.tracks.Count <= voicecolorNotif.TrackNo) {
+                    ValidateTracksVoiceColor();
+                } else {
+                    UTrack track = DocManager.Inst.Project.tracks[voicecolorNotif.TrackNo];
+                    if (!voicecolorNotif.Validate) {
+                        VoiceColorRemapping(track, track.VoiceColorNames, track.VoiceColorExp.options);
+                    } else if (track.ValidateVoiceColor(out var oldColors, out var newColors)) {
+                        VoiceColorRemapping(track, oldColors, newColors);
+                    }
                 }
-                
             }
         }
     }

--- a/OpenUtau/Views/VoiceColorMappingDialog.axaml
+++ b/OpenUtau/Views/VoiceColorMappingDialog.axaml
@@ -8,7 +8,7 @@
         Title="{DynamicResource dialogs.voicecolorremapping}"
         WindowStartupLocation="CenterOwner"
         ExtendClientAreaToDecorationsHint="False">
-  <Grid RowDefinitions="40,1*,20" Margin="10">
+  <Grid RowDefinitions="40,1*,30" Margin="10">
     <StackPanel Grid.Row="0" >
       <TextBlock Text="{DynamicResource dialogs.voicecolorremapping.caption}" />
       <TextBlock Text="{Binding TrackName}" />
@@ -22,13 +22,16 @@
               <TextBlock Text="{Binding Name}"
                          Grid.Column="0" HorizontalAlignment="Right" Margin="0,5,10,5"/>
               <ComboBox ItemsSource="{Binding NewColors}" SelectedIndex="{Binding SelectedIndex}"
-                        Grid.Column="1" HorizontalAlignment="Left" Margin="10,5,0,5"/>
+                        Grid.Column="1" HorizontalAlignment="Left" Margin="10,5,0,5" MinWidth="100" />
             </Grid>
           </DataTemplate>
         </ItemsControl.ItemTemplate>
       </ItemsControl>
-    </ScrollViewer> 
-    
-    <Button Content="{DynamicResource dialogs.messagebox.ok}" Click="OkButtonClick" Grid.Row="2" Width="100" HorizontalAlignment="Center" />
+    </ScrollViewer>
+
+    <StackPanel Orientation="Horizontal" Grid.Row="2" HorizontalAlignment="Center" Spacing="10">
+      <Button Content="{DynamicResource dialogs.messagebox.ok}" Click="Ok_OnClick" Width="100" />
+      <Button Content="{DynamicResource dialogs.messagebox.cancel}" Click="Cancel_OnClick" Width="100"/>
+    </StackPanel>
   </Grid>
 </Window>

--- a/OpenUtau/Views/VoiceColorMappingDialog.axaml
+++ b/OpenUtau/Views/VoiceColorMappingDialog.axaml
@@ -1,0 +1,34 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" MinWidth="200" MinHeight="200" Width="350" Height="350"
+        x:Class="OpenUtau.App.Views.VoiceColorMappingDialog"
+        Icon="/Assets/open-utau.ico"
+        Title="{DynamicResource dialogs.voicecolorremapping}"
+        WindowStartupLocation="CenterOwner"
+        ExtendClientAreaToDecorationsHint="False">
+  <Grid RowDefinitions="40,1*,20" Margin="10">
+    <StackPanel Grid.Row="0" >
+      <TextBlock Text="{DynamicResource dialogs.voicecolorremapping.caption}" />
+      <TextBlock Text="{Binding TrackName}" />
+    </StackPanel>
+
+    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" >
+      <ItemsControl ItemsSource="{Binding ColorMappings}" VerticalAlignment="Stretch" >
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <Grid ColumnDefinitions="1*,1*">
+              <TextBlock Text="{Binding Name}"
+                         Grid.Column="0" HorizontalAlignment="Right" Margin="0,5,10,5"/>
+              <ComboBox ItemsSource="{Binding NewColors}" SelectedIndex="{Binding SelectedIndex}"
+                        Grid.Column="1" HorizontalAlignment="Left" Margin="10,5,0,5"/>
+            </Grid>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </ScrollViewer> 
+    
+    <Button Content="{DynamicResource dialogs.messagebox.ok}" Click="OkButtonClick" Grid.Row="2" Width="100" HorizontalAlignment="Center" />
+  </Grid>
+</Window>

--- a/OpenUtau/Views/VoiceColorMappingDialog.axaml.cs
+++ b/OpenUtau/Views/VoiceColorMappingDialog.axaml.cs
@@ -12,9 +12,9 @@ namespace OpenUtau.App.Views {
             InitializeComponent();
         }
 
-        private void OkButtonClick(object? sender, RoutedEventArgs e) {
-            Finish();
-        }
+        private void Ok_OnClick(object sender, RoutedEventArgs e) => Finish();
+
+        private void Cancel_OnClick(object sender, RoutedEventArgs e) => Close();
 
         private void Finish() {
             Apply = true;

--- a/OpenUtau/Views/VoiceColorMappingDialog.axaml.cs
+++ b/OpenUtau/Views/VoiceColorMappingDialog.axaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace OpenUtau.App.Views {
+    public partial class VoiceColorMappingDialog : Window {
+        public Action? onFinish;
+        public bool Apply { get; private set; } = false;
+
+        public VoiceColorMappingDialog() {
+            InitializeComponent();
+        }
+
+        private void OkButtonClick(object? sender, RoutedEventArgs e) {
+            Finish();
+        }
+
+        private void Finish() {
+            Apply = true;
+            if (onFinish != null) {
+                onFinish.Invoke();
+            }
+            Close();
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e) {
+            if (e.Key == Key.Escape) {
+                e.Handled = true;
+                Close();
+            } else if (e.Key == Key.Enter) {
+                e.Handled = true;
+                Finish();
+            } else {
+                base.OnKeyDown(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
New Features:
- Voice color remapping dialog
![image](https://github.com/stakira/OpenUtau/assets/130257355/ac8854d3-b69a-4eda-af32-8056147e9bd8)
![image](https://github.com/stakira/OpenUtau/assets/130257355/8fbd55ec-4b62-4fbb-861a-0f88ebe657cc)
- Voice color remapping menu in track header context menu
- When the project is opened, show the remapping dialog if the voice color lineup has been changed
- When changing voice banks, show the remapping dialog if the voice color lineup is different

Internal change:
Stores the name of the voice colors in the UTrack class