### PR TITLE
Update avalonia to 11.0.4

### DIFF
--- a/OpenUtau/Controls/OtoPlot.cs
+++ b/OpenUtau/Controls/OtoPlot.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Media.TextFormatting;
@@ -414,8 +415,8 @@ namespace OpenUtau.App.Controls {
             preText.Draw(context, new Point(preutterX, height));
         }
 
-        protected override void OnUnloaded() {
-            base.OnUnloaded();
+        protected override void OnUnloaded(RoutedEventArgs e) {
+            base.OnUnloaded(e);
             wavBitmap?.Dispose();
             melBitmap?.Dispose();
         }

--- a/OpenUtau/OpenUtau.csproj
+++ b/OpenUtau/OpenUtau.csproj
@@ -33,15 +33,15 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-rc1.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.4" />
     <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
     <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="2.2.3" />
     <PackageReference Include="ReactiveUI.Fody" Version="18.3.1" />
-    <PackageReference Include="Avalonia" Version="11.0.0-rc1.1" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-rc1.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-rc1.1" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-rc1.1" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-rc1.1" />
+    <PackageReference Include="Avalonia" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.4" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.4" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />


### PR DESCRIPTION
Fixes #822

Only tested on Linux, but I imagine it should be fine on other platforms. The minor OtoPlot change was due to an Avalonia.Controls API change between 11.0.0-rc1 and 11.0.0-rc2