### PR TITLE
Fix unable to install vb from Mac on Windows

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankInstaller.cs
+++ b/OpenUtau.Core/Classic/VoicebankInstaller.cs
@@ -43,7 +43,7 @@ namespace OpenUtau.Classic {
                 AdjustBasePath(archive, path, touches);
                 int total = archive.Entries.Count();
                 int count = 0;
-                bool hasCharacterYaml = archive.Entries.Any(e => e.Key.EndsWith(kCharacterYaml));
+                bool hasCharacterYaml = archive.Entries.Any(e => Path.GetFileName(e.Key) == kCharacterYaml);
                 foreach (var entry in archive.Entries) {
                     progress.Invoke(100.0 * ++count / total, entry.Key);
                     if (entry.Key.Contains("..")) {
@@ -54,7 +54,7 @@ namespace OpenUtau.Classic {
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath));
                     if (!entry.IsDirectory && entry.Key != kInstallTxt) {
                         entry.WriteToFile(Path.Combine(basePath, entry.Key), extractionOptions);
-                        if (!hasCharacterYaml && filePath.EndsWith(kCharacterTxt)) {
+                        if (!hasCharacterYaml && Path.GetFileName(filePath) == kCharacterTxt) {
                             var config = new VoicebankConfig() {
                                 TextFileEncoding = textEncoding.WebName,
                                 SingerType = singerType,
@@ -63,7 +63,7 @@ namespace OpenUtau.Classic {
                                 config.Save(stream);
                             }
                         }
-                        if (hasCharacterYaml && filePath.EndsWith(kCharacterYaml)) {
+                        if (hasCharacterYaml && Path.GetFileName(filePath) == kCharacterYaml) {
                             VoicebankConfig? config = null;
                             using (var stream = File.Open(filePath, FileMode.Open)) {
                                 config = VoicebankConfig.Load(stream);

--- a/OpenUtau/ViewModels/SingerSetupViewModel.cs
+++ b/OpenUtau/ViewModels/SingerSetupViewModel.cs
@@ -91,7 +91,7 @@ namespace OpenUtau.App.ViewModels {
 
         private VoicebankConfig? LoadCharacterYaml(string archiveFilePath) {
             using (var archive = ArchiveFactory.Open(archiveFilePath)) {
-                var entry = archive.Entries.FirstOrDefault(e => e.Key.EndsWith("character.yaml"));
+                var entry = archive.Entries.FirstOrDefault(e => Path.GetFileName(e.Key)=="character.yaml");
                 if (entry == null) {
                     return null;
                 }


### PR DESCRIPTION
If a voicebank is created on Mac and has a "_MACOSX" folder with a "._character.yaml" in it, openutau will fail to intall it on windows
![image](https://github.com/stakira/OpenUtau/assets/54425948/fe33a912-b5b2-43fd-9fd9-0face0872b21)
