### PR TITLE
Refactor phonemizer test utility method

### DIFF
--- a/OpenUtau.Test/Plugins/DeDiphoneTest.cs
+++ b/OpenUtau.Test/Plugins/DeDiphoneTest.cs
@@ -14,24 +14,18 @@ namespace OpenUtau.Plugins {
         [Theory]
         [InlineData("de_diphone",
             new string[] { "guten", "Tag" },
-            new string[] { "", "" },
             new string[] { "C4", "C4" },
-            new string[] { "", "" },
             new string[] { "- g_C4", "g uw_C4", "uw t_C4", "t ax_C4", "ax n_C4", "n t", "t aa_C4", "aa k_C4", "k -_C4" })]
         [InlineData("de_diphone",
             new string[] { "guten", "+", "Tag" },
-            new string[] { "", "", "" },
             new string[] { "F3", "F4", "C4" },
-            new string[] { "", "", "" },
             new string[] { "- g_F3", "g uw_F3", "uw t_F4", "t ax_F4", "ax n_F4", "n t", "t aa_C4", "aa k_C4", "k -_C4" })]
         [InlineData("de_diphone",
             new string[] { "Mond", "+", "+", "+", "Licht", "+" },
-            new string[] { "", "", "", "", "", "" },
             new string[] { "F4", "C4", "F4", "F4", "C4", "F4" },
-            new string[] { "", "", "", "", "", "" },
             new string[] { "- m_F4", "m ooh_F4", "ooh n_F4", "n t", "t l", "l ih_C4", "ih cc_F4", "cc t", "t -_F4" })]
-        public void PhonemizeTest(string singerName, string[] lyrics, string[] alts, string[] tones, string[] colors, string[] aliases) {
-            RunPhonemizeTest(singerName, lyrics, alts, tones, colors, aliases);
+        public void PhonemizeTest(string singerName, string[] lyrics, string[] tones, string[] aliases) {
+            RunPhonemizeTest(singerName, lyrics, RepeatString(lyrics.Length, ""), tones, RepeatString(lyrics.Length, ""), aliases);
         }
     }
 }

--- a/OpenUtau.Test/Plugins/DeVccvTest.cs
+++ b/OpenUtau.Test/Plugins/DeVccvTest.cs
@@ -14,24 +14,18 @@ namespace OpenUtau.Plugins {
         [Theory]
         [InlineData("de_vccv",
             new string[] { "guten", "Tag" },
-            new string[] { "", "" },
             new string[] { "A2", "A2" },
-            new string[] { "", "" },
             new string[] { "- guA2", "u tA2", "t@A2", "@n", "ntA2", "taA2", "akA2" })]
         [InlineData("de_vccv",
             new string[] { "guten", "+", "Tag" },
-            new string[] { "", "", "" },
             new string[] { "D3", "G3", "D3" },
-            new string[] { "", "", "" },
             new string[] { "- guD3", "u tD3", "t@G3", "@nG3", "ntG3", "taD3", "akD3" })]
         [InlineData("de_vccv",
             new string[] { "Mond", "+", "+", "+", "Licht", "+" },
-            new string[] { "", "", "", "", "", "" },
             new string[] { "G3", "D3", "G3", "G3", "D3", "G3" },
-            new string[] { "", "", "", "", "", "" },
             new string[] { "- moG3", "onG3", "nt -G3", "t lG3", "lID3", "ICG3", "Ct -G3" })]
-        public void PhonemizeTest(string singerName, string[] lyrics, string[] alts, string[] tones, string[] colors, string[] aliases) {
-            RunPhonemizeTest(singerName, lyrics, alts, tones, colors, aliases);
+        public void PhonemizeTest(string singerName, string[] lyrics, string[] tones, string[] aliases) {
+            RunPhonemizeTest(singerName, lyrics, RepeatString(lyrics.Length, ""), tones, RepeatString(lyrics.Length, ""), aliases);
         }
     }
 }

--- a/OpenUtau.Test/Plugins/EnArpaTest.cs
+++ b/OpenUtau.Test/Plugins/EnArpaTest.cs
@@ -1,4 +1,4 @@
-using OpenUtau.Api;
+﻿using OpenUtau.Api;
 using OpenUtau.Plugin.Builtin;
 using Xunit;
 using Xunit.Abstractions;
@@ -14,24 +14,21 @@ namespace OpenUtau.Plugins {
         [Theory]
         [InlineData("en_arpa",
             new string[] { "good", "morning" },
-            new string[] { "", "" },
             new string[] { "C4", "C4" },
             new string[] { "", "" },
             new string[] { "- g_3", "g uh_3", "uh d_3", "d m_3", "m ao_3", "ao r_3", "r n_3", "n ih_3", "ih ng_3", "ng -_3" })]
         [InlineData("en_arpa",
             new string[] { "good", "morning", "-" },
-            new string[] { "", "", "" },
             new string[] { "A3", "F4", "C4" },
             new string[] { "", "", "" },
             new string[] { "- g_3", "g uh_3", "uh d_3", "d m_3", "m ao", "ao r", "r n", "n ih", "ih ng", "ng -_3" })]
         [InlineData("en_arpa",
             new string[] { "moon", "+", "+", "+", "star", "+" },
-            new string[] { "", "", "", "", "", "" },
             new string[] { "F4", "C4", "F4", "F4", "C4", "F4" },
             new string[] { "Whisper", "", "", "", "", "" },
             new string[] { "- m_W", "m uw", "uw n", "n s", "s t_3", "t aa_3", "aa r", "r -" })]
-        public void PhonemizeTest(string singerName, string[] lyrics, string[] alts, string[] tones, string[] colors, string[] aliases) {
-            RunPhonemizeTest(singerName, lyrics, alts, tones, colors, aliases);
+        public void PhonemizeTest(string singerName, string[] lyrics, string[] tones, string[] colors, string[] aliases) {
+            RunPhonemizeTest(singerName, lyrics, RepeatString(lyrics.Length, ""), tones, colors, aliases);
         }
     }
 }

--- a/OpenUtau.Test/Plugins/EnToJaTest.cs
+++ b/OpenUtau.Test/Plugins/EnToJaTest.cs
@@ -232,16 +232,7 @@ namespace OpenUtau.Plugins {
         }
 
         private void SameAltsTonesColorsTest(string singerName, string[] aliases, string[] lyrics) { 
-            RunPhonemizeTest(singerName, lyrics, 
-                RepeatString(lyrics.Length, ""), 
-                RepeatString(lyrics.Length, "C4"), 
-                RepeatString(lyrics.Length, ""), aliases);
-        }
-
-        private string[] RepeatString(int count, string s) {
-            string[] array = new string[count];
-            Array.Fill(array, s);
-            return array;
+            SameAltsTonesColorsTest(singerName, lyrics, aliases, "", "C4", "");
         }
     }
 }

--- a/OpenUtau.Test/Plugins/EnVCCVTest.cs
+++ b/OpenUtau.Test/Plugins/EnVCCVTest.cs
@@ -1,4 +1,4 @@
-using OpenUtau.Api;
+﻿using OpenUtau.Api;
 using OpenUtau.Plugin.Builtin;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,12 +13,9 @@ namespace OpenUtau.Plugins {
         [Theory]
         [InlineData("en_vccv",
             new string[] { "test", "words" },
-            new string[] { "", "", },
-            new string[] { "C4", "C4" },
-            new string[] { "", "", },
             new string[] { "-te", "es-", "st", "w3", "3d-", "dz-" })]
-        public void BasicPhonemizingTest(string singerName, string[] lyrics, string[] alts, string[] tones, string[] colors, string[] aliases) {
-            RunPhonemizeTest(singerName, lyrics, alts, tones, colors, aliases);
+        public void BasicPhonemizingTest(string singerName, string[] lyrics, string[] aliases) {
+            SameAltsTonesColorsTest(singerName, lyrics, aliases, "", "C4", "");
         }
     }
 }

--- a/OpenUtau.Test/Plugins/EnXSampaTest.cs
+++ b/OpenUtau.Test/Plugins/EnXSampaTest.cs
@@ -1,4 +1,4 @@
-using OpenUtau.Api;
+﻿using OpenUtau.Api;
 using OpenUtau.Plugin.Builtin;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,12 +13,9 @@ namespace OpenUtau.Plugins {
         [Theory]
         [InlineData("en_delta0",
             new string[] { "my", "test" },
-            new string[] { "", "" },
-            new string[] { "C4", "C4" },
-            new string[] { "", "", },
             new string[] { "- maI", "aI t", "tE", "E st-" })]
-        public void BasicPhonemizingTest(string singerName, string[] lyrics, string[] alts, string[] tones, string[] colors, string[] aliases) {
-            RunPhonemizeTest(singerName, lyrics, alts, tones, colors, aliases);
+        public void BasicPhonemizingTest(string singerName, string[] lyrics, string[] aliases) {
+            SameAltsTonesColorsTest(singerName, lyrics, aliases, "", "C4", "");
         }
     }
 }

--- a/OpenUtau.Test/Plugins/JaCvvcTest.cs
+++ b/OpenUtau.Test/Plugins/JaCvvcTest.cs
@@ -14,30 +14,26 @@ namespace OpenUtau.Plugins {
         [Theory]
         [InlineData("ja_cvvc",
             new string[] { "あ", "+", "あ", "-" },
-            new string[] { "", "", "", "" },
             new string[] { "C4", "C4", "C4", "C4" },
             new string[] { "", "", "弱", "" },
             new string[] { "- あ_C4", "a あ_弱C4", "-" })]
         [InlineData("ja_cvvc",
             new string[] { "お", "にょ", "ひょ", "みょ", "びょ", "ぴょ", "りょ" },
-            new string[] { "", "", "", "", "", "", "" },
             new string[] { "A3", "C4", "D4", "E4", "F4", "G3", "F3" },
             new string[] { "", "弱", "", "", "強", "", "" },
             new string[] { "- お_A3", "o ny_A3", "にょ_弱C4", "o hy_弱C4", "ひょ_C4", "o my_C4", "みょ_F4", "o by_F4", "びょ_強F4", "o py_強F4", "ぴょ_A3", "o ry_A3", "りょ_A3" })]
         [InlineData("ja_cvvc",
             new string[] { "ラ", "リ", "ル", "ら" },
-            new string[] { "", "", "", "" },
             new string[] { "C4", "C4", "C4", "C4" },
             new string[] { "", "", "", "" },
             new string[] { "ラ_C4", "a ly_C4", "リ_C4", "i l_C4", "ル_C4", "u r_C4", "ら_C4" })]
         [InlineData("ja_cvvc",
             new string[] { "\u304c", "\u304b\u3099", "\u30f4", "\u30a6\u3099" }, // が, が, ヴ, ヴ
-            new string[] { "", "", "", "" },
             new string[] { "A3", "C4", "D4", "E4" },
             new string[] { "", "", "", "" },
             new string[] { "が_A3", "a g_A3", "が_C4", "a v_C4", "ヴ_C4", "u v_C4", "ヴ_F4" })]
-        public void PhonemizeTest(string singerName, string[] lyrics, string[] alts, string[] tones, string[] colors, string[] aliases) {
-            RunPhonemizeTest(singerName, lyrics, alts, tones, colors, aliases);
+        public void PhonemizeTest(string singerName, string[] lyrics, string[] tones, string[] colors, string[] aliases) {
+            RunPhonemizeTest(singerName, lyrics, RepeatString(lyrics.Length, ""), tones, colors, aliases);
         }
     }
 }

--- a/OpenUtau.Test/Plugins/JaPresampTest.cs
+++ b/OpenUtau.Test/Plugins/JaPresampTest.cs
@@ -14,36 +14,34 @@ namespace OpenUtau.Plugins {
         [Theory]
         [InlineData("ja_presamp",
             new string[] { "あ", "+", "あ", "-" },
-            new string[] { "", "", "", "" },
             new string[] { "C4", "C4", "C4", "C4" },
             new string[] { "", "", "波", "" },
             new string[] { "- あ_D4", "a あ波_D4", "a -_D4" })]
         [InlineData("ja_presamp",
             new string[] { "お", "にょ", "ひょ", "みょ", "びょ", "ぴょ", "りょ", "R" },
-            new string[] { "", "", "", "", "", "", "", "" },
             new string[] { "A3", "C4", "D4", "E4", "F4", "G4", "A4", "A4" },
             new string[] { "", "", "波", "星", "星", "貝", "貝", "貝" },
             new string[] { "- お_A3", "o にょ_D4", "o C_D4", "ひょ波_D4", "o みょ星_E4", "o びょ星_E4", "o p'星_E4", "ぴょ貝_F4", "o 4'貝_F4", "りょ貝_A4", "o R貝_A4" })]
         [InlineData("ja_presamp",
             new string[] { "- ず", "u t", "と", "お・", "o R" },
-            new string[] { "", "", "", "", "" },
             new string[] { "A3", "A3", "C4", "D4", "D4" },
             new string[] { "", "", "", "", "" },
             new string[] { "- ず_A3", "u t_A3", "と_D4", "o ・_D4", "・ お_D4",  "o R_D4" })]
         [InlineData("ja_presamp",
-            new string[] { "ri", "p", "re", "i", "s" }, // [PRIORITY] p,s
-            new string[] { "", "", "", "", "" },
-            new string[] { "C4", "C4", "C4", "C4", "C4" },
-            new string[] { "", "", "", "", "" },
-            new string[] { "- り_D4", "i p_D4", "p", "れ_D4", "e い_D4", "i s_D4", "s" })]
-        [InlineData("ja_presamp",
             new string[] { "\u304c", "\u304b\u3099", "\u30f4", "\u30a6\u3099" }, // が, が, ヴ, ヴ
-            new string[] { "", "", "", "" },
             new string[] { "A3", "C4", "D4", "E4" },
             new string[] { "", "", "", "" },
             new string[] { "- が_A3", "a が_D4", "a ヴ_D4", "u ヴ_F4" })]
-        public void PhonemizeTest(string singerName, string[] lyrics, string[] alts, string[] tones, string[] colors, string[] aliases) {
-            RunPhonemizeTest(singerName, lyrics, alts, tones, colors, aliases);
+        public void PhonemizeTest(string singerName, string[] lyrics, string[] tones, string[] colors, string[] aliases) {
+            RunPhonemizeTest(singerName, lyrics, RepeatString(lyrics.Length, ""), tones, colors, aliases);
+        }
+
+        [Theory]
+        [InlineData("ja_presamp",
+            new string[] { "ri", "p", "re", "i", "s" }, // [PRIORITY] p,s
+            new string[] { "- り_D4", "i p_D4", "p", "れ_D4", "e い_D4", "i s_D4", "s" })]
+        public void PriorityTest(string singerName, string[] lyrics, string[] aliases) {
+            SameAltsTonesColorsTest(singerName, lyrics, aliases, "", "C4", "");
         }
     }
 }

--- a/OpenUtau.Test/Plugins/JaVcvTest.cs
+++ b/OpenUtau.Test/Plugins/JaVcvTest.cs
@@ -14,30 +14,26 @@ namespace OpenUtau.Plugins {
         [Theory]
         [InlineData("ja_vcv",
             new string[] { "あ", "+", "あ", "-" },
-            new string[] { "", "", "", "" },
             new string[] { "C4", "C4", "C4", "C4" },
             new string[] { "", "", "Clear", "" },
             new string[] { "- あA3", "a あCA3", "-" })]
         [InlineData("ja_vcv",
             new string[] { "お", "にょ", "ひょ", "みょ", "びょ", "ぴょ", "りょ" },
-            new string[] { "", "", "", "", "", "", "" },
             new string[] { "A3", "C4", "D4", "E4", "F4", "G3", "F3" },
             new string[] { "", "Clear", "", "", "Whisper", "", "" },
             new string[] { "- おA3", "o にょCA3", "o ひょD4", "o みょD4", "o びょWD4", "o ぴょA3", "o りょA3" })]
         [InlineData("ja_vcv",
             new string[] { "- ず", "u と", "o R" },
-            new string[] { "", "", "" },
             new string[] { "A3", "C4", "D4" },
             new string[] { "", "", "" },
             new string[] { "- ずA3", "u とA3", "o RD4" })]
         [InlineData("ja_vcv",
             new string[] { "\u304c", "\u304b\u3099", "\u30f4", "\u30a6\u3099" }, // が, が, ヴ, ヴ
-            new string[] { "", "", "", "" },
             new string[] { "A3", "C4", "D4", "E4" },
             new string[] { "", "", "", "" },
             new string[] { "- がA3", "a がA3", "a ヴD4", "u ヴD4" })]
-        public void PhonemizeTest(string singerName, string[] lyrics, string[] alts, string[] tones, string[] colors, string[] aliases) {
-            RunPhonemizeTest(singerName, lyrics, alts, tones, colors, aliases);
+        public void PhonemizeTest(string singerName, string[] lyrics, string[] tones, string[] colors, string[] aliases) {
+            RunPhonemizeTest(singerName, lyrics, RepeatString(lyrics.Length, ""), tones, colors, aliases);
         }
     }
 }

--- a/OpenUtau.Test/Plugins/PhonemizerTestBase.cs
+++ b/OpenUtau.Test/Plugins/PhonemizerTestBase.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -94,6 +95,19 @@ namespace OpenUtau.Plugins {
                 group.Clear();
             }
             return result;
+        }
+
+        protected void SameAltsTonesColorsTest(string singerName, string[] lyrics, string[] aliases, string alt, string tone, string color) {
+            RunPhonemizeTest(singerName, lyrics,
+                RepeatString(lyrics.Length, alt),
+                RepeatString(lyrics.Length, tone),
+                RepeatString(lyrics.Length, color), aliases);
+        }
+
+        protected string[] RepeatString(int count, string s) {
+            string[] array = new string[count];
+            Array.Fill(array, s);
+            return array;
         }
     }
 }


### PR DESCRIPTION
PhonemizerTestBase now has two utility methods.

SameAltsTonesColorsTest: Run phonemize test using the same alts, tones, and colors for all lyrics
RepeatString: Returns array of length `count` where all elements are string `s`

Example usage
```cs
[Theory]
[InlineData("en_delta0",
    new string[] { "my", "test" },
    new string[] { "- maI", "aI t", "tE", "E st-" })]
public void BasicPhonemizingTest(string singerName, string[] lyrics, string[] aliases) {
    SameAltsTonesColorsTest(singerName, lyrics, aliases, "", "C4", "");
}
```