### PR TITLE
Fix Note Properties and Add vibrato drift (RERE)

### DIFF
--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core {
@@ -309,6 +308,31 @@ namespace OpenUtau.Core {
             }
         }
     }
+
+    public class VibratoDriftCommand : VibratoCommand {
+        readonly UNote note;
+        readonly float newDrift;
+        readonly float oldDrift;
+        public VibratoDriftCommand(UVoicePart part, UNote note, float drift) : base(part, note) {
+            this.note = note;
+            newDrift = drift;
+            oldDrift = note.vibrato.drift;
+        }
+        public override string ToString() {
+            return "Change vibrato drift";
+        }
+        public override void Execute() {
+            lock (Part) {
+                note.vibrato.drift = newDrift;
+            }
+        }
+        public override void Unexecute() {
+            lock (Part) {
+                note.vibrato.drift = oldDrift;
+            }
+        }
+    }
+
 
     public class PhonemeOffsetCommand : NoteCommand {
         readonly UNote note;

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -248,6 +248,7 @@ namespace OpenUtau.Core.Editing {
                 docManager.ExecuteCmd(new VibratoFadeInCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoIn));
                 docManager.ExecuteCmd(new VibratoFadeOutCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoOut));
                 docManager.ExecuteCmd(new VibratoShiftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoShift));
+                docManager.ExecuteCmd(new VibratoDriftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoDrift));
                 if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) {
                     docManager.ExecuteCmd(new VibratoLengthCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoLength));
                 } else {

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -230,7 +230,8 @@ namespace OpenUtau.Core.Ustx {
         float _out = NotePresets.Default.DefaultVibrato.VibratoOut;
         // Shift percentage of period length.
         float _shift = NotePresets.Default.DefaultVibrato.VibratoShift;
-        float _drift;
+        // Shift the whole vibrato up and down
+        float _drift = NotePresets.Default.DefaultVibrato.VibratoDrift;
 
         public float length { get => _length; set => _length = Math.Max(0, Math.Min(100, value)); }
         public float period { get => _period; set => _period = Math.Max(5, Math.Min(500, value)); }
@@ -286,7 +287,7 @@ namespace OpenUtau.Core.Ustx {
             float nOut = length / 100f * @out / 100f;
             float nOutPos = 1f - nOut;
             float t = (nPos - nStart) / nPeriod + shift / 100f;
-            float y = (float)Math.Sin(2 * Math.PI * t) * depth;
+            float y = (float)Math.Sin(2 * Math.PI * t) * depth + (depth / 100 * drift);
             if (nPos < nStart) {
                 y = 0;
             } else if (nPos < nInPos) {

--- a/OpenUtau.Core/Util/NotePresets.cs
+++ b/OpenUtau.Core/Util/NotePresets.cs
@@ -46,10 +46,10 @@ namespace OpenUtau.Core.Util {
                 new PortamentoPreset("Snap", 2, -1),
             });
             Default.VibratoPresets.AddRange(new List<VibratoPreset> {
-                new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0),
-                new VibratoPreset("UTAU Default", 65, 180, 35, 20, 20, 0),
-                new VibratoPreset("UTAU Strong", 65, 210, 55, 25, 25, 0),
-                new VibratoPreset("UTAU Weak", 65, 165, 20, 25, 25, 0)
+                new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0, 0),
+                new VibratoPreset("UTAU Default", 65, 180, 35, 20, 20, 0, 0),
+                new VibratoPreset("UTAU Strong", 65, 210, 55, 25, 25, 0, 0),
+                new VibratoPreset("UTAU Weak", 65, 165, 20, 25, 25, 0, 0)
             });
 
             Save();
@@ -60,7 +60,7 @@ namespace OpenUtau.Core.Util {
             public string DefaultLyric = "a";
             public PortamentoPreset DefaultPortamento = new PortamentoPreset("Standard", 80, -40);
             public List<PortamentoPreset> PortamentoPresets = new List<PortamentoPreset> { };
-            public VibratoPreset DefaultVibrato = new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0);
+            public VibratoPreset DefaultVibrato = new VibratoPreset("Standard", 75, 175, 25, 10, 10, 0, 0);
             public List<VibratoPreset> VibratoPresets = new List<VibratoPreset> { };
             public bool AutoVibratoToggle = false;
             public int AutoVibratoNoteDuration = 481;
@@ -88,8 +88,9 @@ namespace OpenUtau.Core.Util {
             public float VibratoIn = 10;
             public float VibratoOut = 10;
             public float VibratoShift = 0;
+            public float VibratoDrift = 0;
 
-            public VibratoPreset(string name, float length, float period, float depth, float fadein, float fadeout, float shift) {
+            public VibratoPreset(string name, float length, float period, float depth, float fadein, float fadeout, float shift, float drift) {
                 Name = name;
                 VibratoLength = length;
                 VibratoPeriod = period;
@@ -97,6 +98,7 @@ namespace OpenUtau.Core.Util {
                 VibratoIn = fadein;
                 VibratoOut = fadeout;
                 VibratoShift = shift;
+                VibratoDrift = drift;
             }
 
             public override string ToString() => Name;

--- a/OpenUtau/Controls/NotePropertiesControl.axaml
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml
@@ -12,20 +12,25 @@
     <Style Selector="Label,TextBox,Slider,ComboBox,CheckBox">
       <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
+    <Style Selector="Slider.fader">
+      <Setter Property="Focusable" Value="True"/>
+    </Style>
   </UserControl.Styles>
-  
+
   <Grid>
     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
       <StackPanel Margin="10">
+        <TextBlock Text="{Binding Title}" HorizontalAlignment="Center"/>
         <TextBlock Text="!!! WORK IN PROGRESS !!!" HorizontalAlignment="Center" Foreground="Red"/>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.lyric}">
+
+        <Expander Header="{DynamicResource notedefaults.lyric}" HorizontalAlignment="Stretch" Margin="5">
           <Grid ColumnDefinitions="143,*">
             <Label Content="{DynamicResource notedefaults.lyric}" Grid.Column="0"/>
-            <TextBox Text="{Binding Lyric}" IsEnabled="{Binding IsNoteSelected}" Grid.Column="1"/>
+            <TextBox Text="{Binding Lyric}" IsEnabled="{Binding IsNoteSelected}" Grid.Column="1" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
           </Grid>
-        </HeaderedContentControl>
+        </Expander>
 
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.portamento}">
+        <Expander Header="{DynamicResource notedefaults.portamento}" HorizontalAlignment="Stretch" Margin="5">
           <StackPanel IsEnabled="{Binding IsNoteSelected}">
             <Grid ColumnDefinitions="123,20,*">
               <Label Content="{DynamicResource notedefaults.preset}"/>
@@ -34,97 +39,113 @@
             </Grid>
             <Grid ColumnDefinitions="123,20,*,20,*">
               <Button Grid.Column="2" Content="{DynamicResource notedefaults.preset.save}"
-                HorizontalAlignment="Stretch" Click="OnSavePortamentoPreset"
-                ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
+                      HorizontalAlignment="Stretch" Click="OnSavePortamentoPreset"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
               <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.remove}"
-                HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedPortamentoPreset}"
-                ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
+                      HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedPortamentoPreset}"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
             </Grid>
             <Grid ColumnDefinitions="130,20,50,20,*">
               <Label Content="{DynamicResource notedefaults.portamento.length}"/>
-              <TextBox Grid.Column="2" Text="{Binding PortamentoLength}" />
+              <TextBox Grid.Column="2" Text="{Binding PortamentoLength}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
               <Slider Grid.Column="4" Classes="fader" Value="{Binding PortamentoLength}" Minimum="2" Maximum="320"
-              TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
             </Grid>
             <Grid ColumnDefinitions="130,20,50,20,*">
               <Label Content="{DynamicResource notedefaults.portamento.start}"/>
-              <TextBox Grid.Column="2" Text="{Binding PortamentoStart}" />
+              <TextBox Grid.Column="2" Text="{Binding PortamentoStart}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
               <Slider Grid.Column="4" Classes="fader" Value="{Binding PortamentoStart}" Minimum="-200" Maximum="200"
-              TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
             </Grid>
           </StackPanel>
-        </HeaderedContentControl>
+        </Expander>
 
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource notedefaults.vibrato}">
+        <Expander Header="{DynamicResource notedefaults.vibrato}" HorizontalAlignment="Stretch" Margin="5">
           <StackPanel IsEnabled="{Binding IsNoteSelected}">
-            <ToggleSwitch IsChecked="{Binding VibratoEnable}" OnContent="{DynamicResource prefs.on}" OffContent="{DynamicResource prefs.off}"/>
-            <StackPanel IsEnabled="{Binding VibratoEnable}">
-              <Grid ColumnDefinitions="123,20,*">
-                <Label Content="{DynamicResource notedefaults.preset}"/>
-                <ComboBox Grid.Column="2" ItemsSource="{Binding VibratoPresets}"
-                  SelectedItem="{Binding ApplyVibratoPreset}" HorizontalAlignment="Stretch" />
-              </Grid>
-              <Grid ColumnDefinitions="123,20,*,20,*">
-                <Button Grid.Column="2" Content="{DynamicResource notedefaults.preset.save}"
-                  HorizontalAlignment="Stretch" Click="OnSaveVibratoPreset"
-                  ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
-                <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.remove}"
-                  HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedVibratoPreset}"
-                  ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.length}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoLength}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoLength}" Minimum="0" Maximum="100"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.period}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoPeriod}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoPeriod}" Minimum="5" Maximum="500"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.depth}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoDepth}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoDepth}" Minimum="5" Maximum="200"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.in}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoIn}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoIn}" Minimum="0" Maximum="100"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.out}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoOut}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoOut}" Minimum="0" Maximum="100"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="130,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
-                <TextBox Grid.Column="2" Text="{Binding VibratoShift}" />
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoShift}" Minimum="0" Maximum="100"
-                TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
-              </Grid>
-              <Grid ColumnDefinitions="123,20,*">
-                <Label Content="{DynamicResource noteproperty.setlongnote}"/>
-                <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>
-              </Grid>
-              <Grid ColumnDefinitions="180,20,50,20,*">
-                <Label Content="{DynamicResource notedefaults.vibrato.autominlength}"/>
-                <TextBox Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Text="{Binding AutoVibratoNoteLength}" />
-                <Slider Grid.Column="4" Classes="fader" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" Minimum="10" Maximum="1920"
-                TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
-              </Grid>
-            </StackPanel>
+            <ToggleSwitch IsChecked="{Binding VibratoEnable, Mode=OneWay}" OnContent="{DynamicResource prefs.on}" OffContent="{DynamicResource prefs.off}"
+                          Click="VibratoEnableClicked"/>
+            <Grid ColumnDefinitions="123,20,*">
+              <Label Content="{DynamicResource notedefaults.preset}"/>
+              <ComboBox Grid.Column="2" ItemsSource="{Binding VibratoPresets}"
+                SelectedItem="{Binding ApplyVibratoPreset}" HorizontalAlignment="Stretch" />
+            </Grid>
+            <Grid ColumnDefinitions="123,20,*,20,*">
+              <Button Grid.Column="2" Content="{DynamicResource notedefaults.preset.save}"
+                      HorizontalAlignment="Stretch" Click="OnSaveVibratoPreset"
+                      ToolTip.Tip="{DynamicResource notedefaults.preset.save.tooltip}"/>
+              <Button Grid.Column="4" Content="{DynamicResource notedefaults.preset.remove}"
+                HorizontalAlignment="Stretch" Command="{Binding RemoveAppliedVibratoPreset}"
+                ToolTip.Tip="{DynamicResource notedefaults.preset.remove.tooltip}"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.length}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoLength}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoLength}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.period}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoPeriod}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoPeriod}" Minimum="5" Maximum="500"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.depth}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoDepth}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoDepth}" Minimum="5" Maximum="200"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.in}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoIn}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoIn}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.out}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoOut}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoOut}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoShift}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoShift}" Minimum="0" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="130,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.drift}"/>
+              <TextBox Grid.Column="2" Text="{Binding VibratoDrift}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding VibratoDrift}" Minimum="-100" Maximum="100"
+                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
+            <Grid ColumnDefinitions="123,20,*">
+              <Label Content="{DynamicResource noteproperty.setlongnote}"/>
+              <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>
+            </Grid>
+            <Grid ColumnDefinitions="180,20,50,20,*">
+              <Label Content="{DynamicResource notedefaults.vibrato.autominlength}"/>
+              <TextBox Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Text="{Binding AutoVibratoNoteLength}" GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+              <Slider Grid.Column="4" Classes="fader" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" Minimum="10" Maximum="1920"
+                      TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"
+                      GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
+            </Grid>
           </StackPanel>
-        </HeaderedContentControl>
+        </Expander>
 
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource exps.caption}">
+        <Expander Header="{DynamicResource exps.caption}" HorizontalAlignment="Stretch" Margin="5">
           <StackPanel Name="ExpressionsPanel" />
-        </HeaderedContentControl>
+        </Expander>
+
       </StackPanel>
     </ScrollViewer>
   </Grid>

--- a/OpenUtau/Controls/NotePropertiesControl.axaml.cs
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Reactive.Linq;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
 using OpenUtau.App.Views;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
-using ReactiveUI;
+using Serilog;
 
 namespace OpenUtau.App.Controls {
     public partial class NotePropertiesControl : UserControl, ICmdSubscriber {
@@ -21,20 +19,45 @@ namespace OpenUtau.App.Controls {
         }
 
         private void LoadPart(UPart? part) {
+            if (NotePropertiesViewModel.PanelControlPressed) {
+                NotePropertiesViewModel.PanelControlPressed = false;
+                DocManager.Inst.EndUndoGroup();
+            }
+            NotePropertiesViewModel.NoteLoading = true;
+
             ViewModel.LoadPart(part);
             ExpressionsPanel.Children.Clear();
             foreach (NotePropertyExpViewModel expVM in ViewModel.Expressions) {
                 var control = new NotePropertyExpression() { DataContext = expVM };
                 ExpressionsPanel.Children.Add(control);
             }
+
+            NotePropertiesViewModel.NoteLoading = false;
+        }
+
+        void OnGotFocus(object sender, GotFocusEventArgs e) {
+            Log.Information("Note property panel got focus");
+            DocManager.Inst.StartUndoGroup();
+            NotePropertiesViewModel.PanelControlPressed = true;
+        }
+        void OnLostFocus(object sender, RoutedEventArgs e) {
+            Log.Information("Note property panel lost focus");
+            NotePropertiesViewModel.PanelControlPressed = false;
+            DocManager.Inst.EndUndoGroup();
+        }
+
+        void VibratoEnableClicked(object sender, RoutedEventArgs e) {
+            ViewModel.SetVibratoEnable();
         }
 
         void OnSavePortamentoPreset(object sender, RoutedEventArgs e) {
-            var dialog = new TypeInDialog() {
-                Title = ThemeManager.GetString("notedefaults.preset.namenew"),
-                onFinish = name => ViewModel.SavePortamentoPreset(name),
-            };
-            //dialog.ShowDialog(this);
+            if (VisualRoot is Window window) {
+                var dialog = new TypeInDialog() {
+                    Title = ThemeManager.GetString("notedefaults.preset.namenew"),
+                    onFinish = name => ViewModel.SavePortamentoPreset(name),
+                };
+                dialog.ShowDialog(window);
+            }
         }
 
         void OnRemovePortamentoPreset(object sender, RoutedEventArgs e) {
@@ -42,11 +65,13 @@ namespace OpenUtau.App.Controls {
         }
 
         void OnSaveVibratoPreset(object sender, RoutedEventArgs e) {
-            var dialog = new TypeInDialog() {
-                Title = ThemeManager.GetString("notedefaults.preset.namenew"),
-                onFinish = name => ViewModel.SaveVibratoPreset(name),
-            };
-            //dialog.ShowDialog(this);
+            if (VisualRoot is Window window) {
+                var dialog = new TypeInDialog() {
+                    Title = ThemeManager.GetString("notedefaults.preset.namenew"),
+                    onFinish = name => ViewModel.SaveVibratoPreset(name),
+                };
+                dialog.ShowDialog(window);
+            }
         }
 
         void OnRemoveVibratoPreset(object sender, RoutedEventArgs e) {
@@ -56,11 +81,7 @@ namespace OpenUtau.App.Controls {
         private void OnKeyDown(object? sender, KeyEventArgs e) {
             switch (e.Key) {
                 case Key.Enter:
-                    //OnFinish(sender, e);
-                    e.Handled = true;
-                    break;
-                case Key.Escape:
-                    //OnCancel(sender, e);
+                    TopLevel.GetTopLevel(this)?.FocusManager?.ClearFocus();
                     e.Handled = true;
                     break;
                 default:
@@ -69,8 +90,24 @@ namespace OpenUtau.App.Controls {
         }
 
         public void OnNext(UCommand cmd, bool isUndo) {
-            if (cmd is LoadPartNotification loadPart) {
-                LoadPart(loadPart.part);
+            if (cmd is UNotification notif) {
+                if (cmd is LoadPartNotification) {
+                    LoadPart(notif.part);
+                } else if (cmd is LoadProjectNotification) {
+                    LoadPart(null);
+                } else if (cmd is SingersRefreshedNotification) {
+                    LoadPart(notif.part);
+                }
+            } else if (cmd is TrackCommand) {
+                if (cmd is RemoveTrackCommand removeTrack) {
+                    if (ViewModel.Part != null && removeTrack.removedParts.Contains(ViewModel.Part)) {
+                        LoadPart(null);
+                    }
+                } else if (cmd is TrackChangeSingerCommand trackChangeSinger) {
+                    if (ViewModel.Part != null && trackChangeSinger.track.TrackNo == ViewModel.Part.trackNo) {
+                        // LoadPart(ViewModel.Part); can't load crl
+                    }
+                }
             }
         }
     }

--- a/OpenUtau/Controls/NotePropertyExpression.axaml
+++ b/OpenUtau/Controls/NotePropertyExpression.axaml
@@ -6,10 +6,13 @@
              x:Class="OpenUtau.App.Controls.NotePropertyExpression">
   <Grid ColumnDefinitions="143,7,50,20,*">
     <Label Content="{Binding Name}" Grid.Column="0" VerticalAlignment="Center"/>
-    <TextBox Text="{Binding Value}" Grid.Column="2" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"/>
+    <TextBox Text="{Binding Value}" Grid.Column="2" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"
+             GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
     <Slider Grid.Column="4" Classes="fader" Value="{Binding Value}" Minimum="{Binding Min}" Maximum="{Binding Max}"
-            TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}" />
+            TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"
+            GotFocus="OnGotFocus" LostFocus="OnLostFocus"/>
     <ComboBox Grid.Column="1" Grid.ColumnSpan="4" ItemsSource="{Binding Options}"
-                SelectedIndex="{Binding SelectedOption}" MinWidth="120" IsVisible="{Binding IsOptions}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}" />
+              SelectedIndex="{Binding SelectedOption}" MinWidth="120" IsVisible="{Binding IsOptions}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"
+              IsDropDownOpen="{Binding DropDownOpen, Mode=OneWayToSource}"/>
   </Grid>
 </UserControl>

--- a/OpenUtau/Controls/NotePropertyExpression.axaml.cs
+++ b/OpenUtau/Controls/NotePropertyExpression.axaml.cs
@@ -1,12 +1,25 @@
-﻿using Avalonia;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
+using OpenUtau.Core;
+using Serilog;
 
 namespace OpenUtau.App.Controls {
     public partial class NotePropertyExpression : UserControl {
         public NotePropertyExpression() {
             InitializeComponent();
+        }
+
+        void OnGotFocus(object sender, GotFocusEventArgs e) {
+            Log.Information("Note property panel got focus");
+            DocManager.Inst.StartUndoGroup();
+            NotePropertiesViewModel.PanelControlPressed = true;
+        }
+        void OnLostFocus(object sender, RoutedEventArgs e) {
+            Log.Information("Note property panel lost focus");
+            NotePropertiesViewModel.PanelControlPressed = false;
+            DocManager.Inst.EndUndoGroup();
         }
 
     }

--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -100,7 +100,7 @@
           </ContextMenu>
         </Button.ContextMenu>
       </Button>
-      <ToggleButton Grid.Row="1" Grid.Column="3" Margin="1" Padding="0" Height="18"
+      <ToggleButton Classes="normal" Grid.Row="1" Grid.Column="3" Margin="1" Padding="0" Height="18"
                     HorizontalAlignment="Stretch"
                     IsChecked="{Binding Mute, Mode=OneWay}" Command="{Binding ToggleMute}">
         <TextBlock Text="M" TextAlignment="Center"/>
@@ -113,7 +113,7 @@
           </ContextMenu>
         </ToggleButton.ContextMenu>
       </ToggleButton>
-      <ToggleButton Grid.Row="2" Grid.Column="3" Margin="1" Padding="0" Height="18"
+      <ToggleButton Classes="normal" Grid.Row="2" Grid.Column="3" Margin="1" Padding="0" Height="18"
                     HorizontalAlignment="Stretch"
                     IsChecked="{Binding Solo, Mode=OneWay}" Command="{Binding ToggleSolo}">
         <TextBlock Text="S" TextAlignment="Center"/>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -168,7 +168,9 @@
   <system:String x:Key="notedefaults.vibrato.out">Fade Out</system:String>
   <system:String x:Key="notedefaults.vibrato.period">Period</system:String>
   <system:String x:Key="notedefaults.vibrato.shift">Shift</system:String>
+  <system:String x:Key="notedefaults.vibrato.drift">Drift</system:String>
 
+  <system:String x:Key="noteproperty">Note Properties</system:String>
   <system:String x:Key="noteproperty.apply">Apply</system:String>
   <system:String x:Key="noteproperty.cancel">Cancel</system:String>
   <system:String x:Key="noteproperty.set">Set</system:String>
@@ -208,7 +210,6 @@
   <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">Remove Tone Suffix</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">Romaji to Hiragana</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">Note Defaults</system:String>
-  <system:String x:Key="pianoroll.menu.noteproperty">Note Properties</system:String>
   <system:String x:Key="pianoroll.menu.notes">Notes</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtaildash">Add tail "-"</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtailrest">Add tail "R"</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -166,7 +166,9 @@
   <system:String x:Key="notedefaults.vibrato.out">フェードアウト</system:String>
   <system:String x:Key="notedefaults.vibrato.period">周期</system:String>
   <system:String x:Key="notedefaults.vibrato.shift">位相</system:String>
+  <system:String x:Key="notedefaults.vibrato.drift">高さ</system:String>
 
+  <system:String x:Key="noteproperty">音符のプロパティ</system:String>
   <system:String x:Key="noteproperty.apply">適用</system:String>
   <system:String x:Key="noteproperty.cancel">キャンセル</system:String>
   <system:String x:Key="noteproperty.set">セット</system:String>
@@ -206,7 +208,6 @@
   <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">音程のSuffixを削除</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">ローマ字→ひらがな</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">デフォルト値を設定</system:String>
-  <system:String x:Key="pianoroll.menu.noteproperty">音符のプロパティ</system:String>
   <system:String x:Key="pianoroll.menu.notes">音符</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtaildash">末尾に"-"を追加</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtailrest">末尾に"R"を追加</system:String>

--- a/OpenUtau/Styles/PianoRollStyles.axaml
+++ b/OpenUtau/Styles/PianoRollStyles.axaml
@@ -1,6 +1,6 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  
+
   <Style Selector="Button,ToggleButton">
     <Setter Property="Focusable" Value="False"/>
   </Style>
@@ -21,28 +21,30 @@
   <Style Selector="ComboBoxItem:selected /template/ ContentPresenter">
     <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrushSemi}"/>
   </Style>
-  
+
   <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
     <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrushSemi}"/>
   </Style>
-  
+
   <Style Selector="Slider.fader">
     <Setter Property="Foreground" Value="{DynamicResource SelectedTrackAccentBrush}"/>
-  </Style>
-  <Style Selector="Slider.fader:pointerover">
-    <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
-      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
+
+    <Style Selector="^:pointerover">
+      <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
+        <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
+      </Style>
+      <Style Selector="^ /template/ Thumb">
+        <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
+      </Style>
     </Style>
-    <Style Selector="^ /template/ Thumb">
-      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
-    </Style>
-  </Style>
-  <Style Selector="Slider.fader:pressed">
-    <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
-      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
-    </Style>
-    <Style Selector="^ /template/ Thumb">
-      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
+
+    <Style Selector="^:pressed">
+      <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
+        <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
+      </Style>
+      <Style Selector="^ /template/ Thumb">
+        <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
+      </Style>
     </Style>
   </Style>
 
@@ -50,12 +52,16 @@
     <Setter Property="BorderBrush" Value="{DynamicResource SelectedTrackAccentBrush}"/>
   </Style>
 
-  <!--
-  <Style Selector="ToggleSwitch:pressed /template/ ">
-    <Setter Property="BorderBrush" Value="{DynamicResource SelectedTrackAccentBrush}"/>
+  <Style Selector="ToggleSwitch">
+    <Style Selector="^:checked /template/ Border#SwitchKnobBounds">
+      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentBrush}" />
+    </Style>
+    <Style Selector="^:checked:pointerover /template/ Border#SwitchKnobBounds">
+      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentLightBrush}" />
+    </Style>
+    <Style Selector="^:checked:pressed /template/ Border#SwitchKnobBounds">
+      <Setter Property="Background" Value="{DynamicResource SelectedTrackAccentDarkBrush}" />
+    </Style>
   </Style>
-  <Style Selector="ToggleSwitch:pressed:pointerover /template/ ">
-    <Setter Property="BorderBrush" Value="{DynamicResource SelectedTrackAccentLightBrush}"/>
-  </Style>
-  -->
+
 </Styles>

--- a/OpenUtau/Styles/Styles.axaml
+++ b/OpenUtau/Styles/Styles.axaml
@@ -96,7 +96,7 @@
     <Setter Property="Background" Value="{DynamicResource BackgroundColorPointerOver}"/>
   </Style>
 
-  <Style Selector="ToggleButton">
+  <Style Selector="ToggleButton.normal">
     <Setter Property="BorderThickness" Value="0"/>
     <Setter Property="FontSize" Value="12"/>
     <Setter Property="Height" Value="20"/>
@@ -105,32 +105,22 @@
     <Setter Property="HorizontalContentAlignment" Value="Center"/>
     <Setter Property="VerticalContentAlignment" Value="Center"/>
     <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
-  </Style>
-  <Style Selector="ToggleButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
-  </Style>
-  <Style Selector="ToggleButton:pressed  /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
-  </Style>
-  <Style Selector="ToggleButton:checked /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushSemi}" />
-  </Style>
-  <Style Selector="ToggleButton:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
-  </Style>
-  <Style Selector="ToggleButton:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
-    <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
-  </Style>
-  <Style Selector="ToggleButton.toolbar Path.filled">
-    <Setter Property="Fill" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-  </Style>
-  <Style Selector="ToggleButton.toolbar Ellipse.stroked">
-    <Setter Property="StrokeThickness" Value="1"/>
-    <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-  </Style>
-  <Style Selector="ToggleButton.toolbar Path.stroked">
-    <Setter Property="StrokeThickness" Value="1"/>
-    <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
+    </Style>
+    <Style Selector="^:pressed  /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
+    </Style>
+    <Style Selector="^:checked /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushSemi}" />
+    </Style>
+    <Style Selector="^:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
+    </Style>
+    <Style Selector="^:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
+    </Style>
   </Style>
 
   <Style Selector="ToggleButton.toolbar">
@@ -141,6 +131,35 @@
     <Setter Property="Padding" Value="4,0,4,2"/>
     <Setter Property="HorizontalContentAlignment" Value="Center"/>
     <Setter Property="VerticalContentAlignment" Value="Center"/>
+    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
+
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
+    </Style>
+    <Style Selector="^:pressed  /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
+    </Style>
+    <Style Selector="^:checked /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushSemi}" />
+    </Style>
+    <Style Selector="^:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrush}" />
+    </Style>
+    <Style Selector="^:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource NeutralAccentBrushPointerOver}" />
+    </Style>
+
+    <Style Selector="^ Path.filled">
+      <Setter Property="Fill" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+    <Style Selector="^ Ellipse.stroked">
+      <Setter Property="StrokeThickness" Value="1"/>
+      <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+    <Style Selector="^ Path.stroked">
+      <Setter Property="StrokeThickness" Value="1"/>
+      <Setter Property="Stroke" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
   </Style>
 
   <Style Selector="ToggleSwitch /template/ Border#SwitchKnobBounds">
@@ -379,5 +398,17 @@
         </ControlTemplate>
       </Setter.Value>
     </Setter>
+  </Style>
+
+  <Style Selector="Expander" >
+    <Setter Property="CornerRadius" Value="5" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="{StaticResource SystemControlForegroundBaseMediumBrush}"/>
+    <Setter Property="Padding" Value="10" />
+    <Setter Property="IsExpanded" Value="True" />
+
+    <Style Selector="^:down /template/ ToggleButton#ExpanderHeader">
+      <Setter Property="BorderBrush" Value="{StaticResource SystemControlForegroundBaseMediumBrush}"/>
+    </Style>
   </Style>
 </Styles>

--- a/OpenUtau/ViewModels/NoteDefaultsViewModel.cs
+++ b/OpenUtau/ViewModels/NoteDefaultsViewModel.cs
@@ -1,16 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Reactive.Linq;
-using System.Text.RegularExpressions;
-using Avalonia;
-using Avalonia.Markup.Xaml.MarkupExtensions;
-using OpenUtau.Audio;
-using OpenUtau.Classic;
-using OpenUtau.Core;
-using OpenUtau.App.Views;
 using OpenUtau.Core.Util;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -27,6 +17,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public float CurrentVibratoIn { get; set; }
         [Reactive] public float CurrentVibratoOut { get; set; }
         [Reactive] public float CurrentVibratoShift { get; set; }
+        [Reactive] public float CurrentVibratoDrift { get; set; }
         [Reactive] public float AutoVibratoNoteLength { get; set; }
         [Reactive] public bool AutoVibratoToggle { get; set; }
         public List<NotePresets.PortamentoPreset>? PortamentoPresets { get; }
@@ -55,6 +46,7 @@ namespace OpenUtau.App.ViewModels {
             CurrentVibratoIn = NotePresets.Default.DefaultVibrato.VibratoIn;
             CurrentVibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
             CurrentVibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
+            CurrentVibratoDrift = NotePresets.Default.DefaultVibrato.VibratoDrift;
             AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
             AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
             PortamentoPresets = NotePresets.Default.PortamentoPresets;
@@ -109,6 +101,11 @@ namespace OpenUtau.App.ViewModels {
                         NotePresets.Default.DefaultVibrato.VibratoShift = Math.Max(0, Math.Min(100, vibratoShift));
                         NotePresets.Save();
                     });
+            this.WhenAnyValue(vm => vm.CurrentVibratoDrift)
+                    .Subscribe(vibratoShift => {
+                        NotePresets.Default.DefaultVibrato.VibratoDrift = Math.Max(-100, Math.Min(100, vibratoShift));
+                        NotePresets.Save();
+                    });
             this.WhenAnyValue(vm => vm.AutoVibratoToggle)
                     .Subscribe(autoVibratoToggle => {
                         NotePresets.Default.AutoVibratoToggle = autoVibratoToggle;
@@ -116,7 +113,7 @@ namespace OpenUtau.App.ViewModels {
                     });
             this.WhenAnyValue(vm => vm.AutoVibratoNoteLength)
                     .Subscribe(autoVibratoNoteLength => {
-                        NotePresets.Default.AutoVibratoNoteDuration = (int) Math.Max(10, autoVibratoNoteLength);
+                        NotePresets.Default.AutoVibratoNoteDuration = (int)Math.Max(10, autoVibratoNoteLength);
                         NotePresets.Save();
                     });
             this.WhenAnyValue(vm => vm.ApplyPortamentoPreset)
@@ -140,12 +137,14 @@ namespace OpenUtau.App.ViewModels {
                         CurrentVibratoIn = Math.Max(0, Math.Min(100, vibratoPreset.VibratoIn));
                         CurrentVibratoOut = Math.Max(0, Math.Min(100, vibratoPreset.VibratoOut));
                         CurrentVibratoShift = Math.Max(0, Math.Min(100, vibratoPreset.VibratoShift));
+                        CurrentVibratoDrift = Math.Max(-100, Math.Min(100, vibratoPreset.VibratoDrift));
                         NotePresets.Default.DefaultVibrato.VibratoLength = CurrentVibratoLength;
                         NotePresets.Default.DefaultVibrato.VibratoPeriod = CurrentVibratoPeriod;
                         NotePresets.Default.DefaultVibrato.VibratoDepth = CurrentVibratoDepth;
                         NotePresets.Default.DefaultVibrato.VibratoIn = CurrentVibratoIn;
                         NotePresets.Default.DefaultVibrato.VibratoOut = CurrentVibratoOut;
                         NotePresets.Default.DefaultVibrato.VibratoShift = CurrentVibratoShift;
+                        NotePresets.Default.DefaultVibrato.VibratoDrift = CurrentVibratoDrift;
                         NotePresets.Save();
                     }
                 });
@@ -171,7 +170,7 @@ namespace OpenUtau.App.ViewModels {
             if (string.IsNullOrEmpty(name)) {
                 return;
             }
-            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, CurrentVibratoLength, CurrentVibratoPeriod, CurrentVibratoDepth, CurrentVibratoIn, CurrentVibratoOut, CurrentVibratoShift));
+            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, CurrentVibratoLength, CurrentVibratoPeriod, CurrentVibratoDepth, CurrentVibratoIn, CurrentVibratoOut, CurrentVibratoShift, CurrentVibratoDrift));
             NotePresets.Save();
         }
 
@@ -193,6 +192,7 @@ namespace OpenUtau.App.ViewModels {
             CurrentVibratoIn = NotePresets.Default.DefaultVibrato.VibratoIn;
             CurrentVibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
             CurrentVibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
+            CurrentVibratoDrift = NotePresets.Default.DefaultVibrato.VibratoDrift;
             AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
             AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
         }

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Reactive;
 using System.Reactive.Linq;
-using Avalonia.Threading;
 using OpenUtau.Core;
 using OpenUtau.Core.Format;
 using OpenUtau.Core.Ustx;
@@ -15,9 +13,10 @@ using SharpCompress;
 
 namespace OpenUtau.App.ViewModels {
     public class NotePropertiesViewModel : ViewModelBase, ICmdSubscriber {
+        public string Title { get => ThemeManager.GetString("noteproperty") + " (" + selectedNotes.Count + " notes)"; }
         [Reactive] public string Lyric { get; set; } = "a";
-        [Reactive] public int PortamentoLength { get; set; }
-        [Reactive] public int PortamentoStart { get; set; }
+        [Reactive] public float PortamentoLength { get; set; }
+        [Reactive] public float PortamentoStart { get; set; }
         [Reactive] public bool VibratoEnable { get; set; }
         [Reactive] public float VibratoLength { get; set; }
         [Reactive] public float VibratoPeriod { get; set; }
@@ -25,16 +24,17 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public float VibratoIn { get; set; }
         [Reactive] public float VibratoOut { get; set; }
         [Reactive] public float VibratoShift { get; set; }
+        [Reactive] public float VibratoDrift { get; set; }
         [Reactive] public float AutoVibratoNoteLength { get; set; }
         [Reactive] public bool AutoVibratoToggle { get; set; }
         [Reactive] public bool IsNoteSelected { get; set; } = false;
 
-        public List<NotePresets.PortamentoPreset>? PortamentoPresets { get; }
+        [Reactive] public ObservableCollection<NotePresets.PortamentoPreset>? PortamentoPresets { get; private set; }
         public NotePresets.PortamentoPreset? ApplyPortamentoPreset {
             get => appliedPortamentoPreset;
             set => this.RaiseAndSetIfChanged(ref appliedPortamentoPreset, value);
         }
-        public List<NotePresets.VibratoPreset>? VibratoPresets { get; }
+        [Reactive] public ObservableCollection<NotePresets.VibratoPreset>? VibratoPresets { get; private set; }
         public NotePresets.VibratoPreset? ApplyVibratoPreset {
             get => appliedVibratoPreset;
             set => this.RaiseAndSetIfChanged(ref appliedVibratoPreset, value);
@@ -42,88 +42,94 @@ namespace OpenUtau.App.ViewModels {
         private NotePresets.PortamentoPreset? appliedPortamentoPreset = NotePresets.Default.DefaultPortamento;
         private NotePresets.VibratoPreset? appliedVibratoPreset = NotePresets.Default.DefaultVibrato;
 
-        private UVoicePart? part;
+        public UVoicePart? Part;
         private HashSet<UNote> selectedNotes = new HashSet<UNote>();
         public List<NotePropertyExpViewModel> Expressions = new List<NotePropertyExpViewModel>();
+        public static bool PanelControlPressed { get; set; } = false;
+        public static bool NoteLoading { get; set; } = false;
+        private static bool AllowNoteEdit { get => PanelControlPressed && !NoteLoading; }
 
         public NotePropertiesViewModel() {
-            PortamentoPresets = NotePresets.Default.PortamentoPresets;
-            VibratoPresets = NotePresets.Default.VibratoPresets;
+            PortamentoPresets = new ObservableCollection<NotePresets.PortamentoPreset>(NotePresets.Default.PortamentoPresets);
+            VibratoPresets = new ObservableCollection<NotePresets.VibratoPreset>(NotePresets.Default.VibratoPresets);
 
-            this.WhenAnyValue(vm => vm.ApplyPortamentoPreset)
-                .WhereNotNull()
-                .Subscribe(portamentoPreset => {
-                    if (portamentoPreset != null) {
-                        PortamentoLength = portamentoPreset.PortamentoLength;
-                        PortamentoStart = portamentoPreset.PortamentoStart;
-                    }
-                });
-            this.WhenAnyValue(vm => vm.ApplyVibratoPreset)
-                .WhereNotNull()
-                .Subscribe(vibratoPreset => {
-                    if (vibratoPreset != null) {
-                        VibratoLength = Math.Max(0, Math.Min(100, vibratoPreset.VibratoLength));
-                        VibratoPeriod = Math.Max(5, Math.Min(500, vibratoPreset.VibratoPeriod));
-                        VibratoDepth = Math.Max(5, Math.Min(200, vibratoPreset.VibratoDepth));
-                        VibratoIn = Math.Max(0, Math.Min(100, vibratoPreset.VibratoIn));
-                        VibratoOut = Math.Max(0, Math.Min(100, vibratoPreset.VibratoOut));
-                        VibratoShift = Math.Max(0, Math.Min(100, vibratoPreset.VibratoShift));
-                    }
-                });
+            SetValueChanges();
 
             MessageBus.Current.Listen<NotesSelectionEvent>()
                 .Subscribe(e => {
+                    if (PanelControlPressed) {
+                        PanelControlPressed = false;
+                        DocManager.Inst.EndUndoGroup();
+                    }
+                    NoteLoading = true;
+
                     selectedNotes.Clear();
                     selectedNotes.UnionWith(e.selectedNotes);
                     selectedNotes.UnionWith(e.tempSelectedNotes);
                     OnSelectNotes();
+
+                    NoteLoading = false;
                 });
 
             DocManager.Inst.AddSubscriber(this);
         }
 
+        // note -> panel
         private void OnSelectNotes() {
-            PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
-            PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
-            AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
-            AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
+            this.RaisePropertyChanged(nameof(Title));
 
             if (selectedNotes.Count > 0) {
                 IsNoteSelected = true;
                 var note = selectedNotes.First();
 
                 Lyric = note.lyric;
+                if (note.pitch.data.Count == 2) {
+                    PortamentoLength = note.pitch.data[1].X - note.pitch.data[0].X;
+                    PortamentoStart = note.pitch.data[0].X;
+                } else {
+                    PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+                    PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+                }
                 VibratoEnable = note.vibrato.length == 0 ? false : true;
-                VibratoLength = note.vibrato.length == 0 ? NotePresets.Default.DefaultVibrato.VibratoLength : note.vibrato.length;
+                VibratoLength = note.vibrato.length;
                 VibratoPeriod = note.vibrato.period;
                 VibratoDepth = note.vibrato.depth;
                 VibratoIn = note.vibrato.@in;
                 VibratoOut = note.vibrato.@out;
                 VibratoShift = note.vibrato.shift;
+                VibratoDrift = note.vibrato.drift;
             } else {
                 IsNoteSelected = false;
                 Lyric = NotePresets.Default.DefaultLyric;
+                PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+                PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+                VibratoEnable = false;
                 VibratoLength = NotePresets.Default.DefaultVibrato.VibratoLength;
                 VibratoPeriod = NotePresets.Default.DefaultVibrato.VibratoPeriod;
                 VibratoDepth = NotePresets.Default.DefaultVibrato.VibratoDepth;
                 VibratoIn = NotePresets.Default.DefaultVibrato.VibratoIn;
                 VibratoOut = NotePresets.Default.DefaultVibrato.VibratoOut;
                 VibratoShift = NotePresets.Default.DefaultVibrato.VibratoShift;
+                VibratoDrift = NotePresets.Default.DefaultVibrato.VibratoDrift;
             }
+            AutoVibratoNoteLength = NotePresets.Default.AutoVibratoNoteDuration;
+            AutoVibratoToggle = NotePresets.Default.AutoVibratoToggle;
+
             AttachExpressions();
         }
 
         public void LoadPart(UPart? part) {
             Expressions.Clear();
             if (part != null && part is UVoicePart) {
-                this.part = part as UVoicePart;
+                this.Part = part as UVoicePart;
 
                 foreach (KeyValuePair<string, UExpressionDescriptor> pair in DocManager.Inst.Project.expressions) {
                     if (pair.Value.type != UExpressionType.Curve) {
-                        var viewModel = new NotePropertyExpViewModel(pair.Value);
+                        var viewModel = new NotePropertyExpViewModel(pair.Value, this);
                         if (pair.Value.abbr == Ustx.CLR) {
                             var track = DocManager.Inst.Project.tracks[part.trackNo];
                             if (track.VoiceColorExp != null && track.VoiceColorExp.options.Length > 0) {
+                                viewModel.Options.Clear();
                                 track.VoiceColorExp.options.ForEach(opt => viewModel.Options.Add(opt));
                             }
                         }
@@ -132,7 +138,7 @@ namespace OpenUtau.App.ViewModels {
                 }
                 AttachExpressions();
             } else {
-                this.part = null;
+                this.Part = null;
             }
         }
 
@@ -171,80 +177,61 @@ namespace OpenUtau.App.ViewModels {
             }
         }
 
-        // presets
-        public void SavePortamentoPreset(string name) {
-            if (string.IsNullOrEmpty(name)) {
-                return;
-            }
-            NotePresets.Default.PortamentoPresets.Add(new NotePresets.PortamentoPreset(name, PortamentoLength, PortamentoStart));
-            NotePresets.Save();
-        }
-        public void RemoveAppliedPortamentoPreset() {
-            if (appliedPortamentoPreset == null) {
-                return;
-            }
-            NotePresets.Default.PortamentoPresets.Remove(appliedPortamentoPreset);
-            NotePresets.Save();
-        }
-        public void SaveVibratoPreset(string name) {
-            if (string.IsNullOrEmpty(name)) {
-                return;
-            }
-            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, VibratoLength, VibratoPeriod, VibratoDepth, VibratoIn, VibratoOut, VibratoShift));
-            NotePresets.Save();
-        }
-        public void RemoveAppliedVibratoPreset() {
-            if (appliedVibratoPreset == null) {
-                return;
-            }
-            NotePresets.Default.VibratoPresets.Remove(appliedVibratoPreset);
-            NotePresets.Save();
-        }
-
         #region ICmdSubscriber
         public void OnNext(UCommand cmd, bool isUndo) {
             var note = selectedNotes.FirstOrDefault();
-            if (note == null) { return; }
+            if (note == null || AllowNoteEdit) { return; }
 
-            if (cmd is NoteCommand) {
-                if (cmd is ChangeNoteLyricCommand changeNoteLyricCommand) {
-                    if (changeNoteLyricCommand.Notes.Contains(note)) {
+            if (cmd is NoteCommand noteCommand) {
+                if (cmd is ChangeNoteLyricCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
                         Lyric = note.lyric;
                     }
-                } else if (cmd is VibratoLengthCommand vibratoLengthCommand) {
-                    if (vibratoLengthCommand.Notes.Contains(note)) {
-                        if (note.vibrato.length == 0) {
-                            VibratoEnable = false;
-                            VibratoLength = NotePresets.Default.DefaultVibrato.VibratoLength;
-                        } else {
+                } else if (cmd is VibratoLengthCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        if (note.vibrato.length > 0) {
                             VibratoEnable = true;
-                            VibratoLength = note.vibrato.length;
+                        } else {
+                            VibratoEnable = false;
                         }
+                        VibratoLength = note.vibrato.length;
                     }
-                } else if (cmd is VibratoFadeInCommand vibratoFadeInCommand) {
-                    if (vibratoFadeInCommand.Notes.Contains(note)) {
+                } else if (cmd is VibratoFadeInCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
                         VibratoIn = note.vibrato.@in;
                     }
-                } else if (cmd is VibratoFadeOutCommand vibratoFadeOutCommand) {
-                    if (vibratoFadeOutCommand.Notes.Contains(note)) {
+                } else if (cmd is VibratoFadeOutCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
                         VibratoOut = note.vibrato.@out;
                     }
-                } else if (cmd is VibratoDepthCommand vibratoDepthCommand) {
-                    if (vibratoDepthCommand.Notes.Contains(note)) {
+                } else if (cmd is VibratoDepthCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
                         VibratoDepth = note.vibrato.depth;
                     }
-                } else if (cmd is VibratoPeriodCommand vibratoPeriodCommand) {
-                    if (vibratoPeriodCommand.Notes.Contains(note)) {
+                } else if (cmd is VibratoPeriodCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
                         VibratoPeriod = note.vibrato.period;
                     }
-                } else if (cmd is VibratoShiftCommand vibratoShiftCommand) {
-                    if (vibratoShiftCommand.Notes.Contains(note)) {
+                } else if (cmd is VibratoShiftCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
                         VibratoShift = note.vibrato.shift;
+                    }
+                } else if (cmd is VibratoDriftCommand) {
+                    if (noteCommand.Notes.Contains(note)) {
+                        VibratoDrift = note.vibrato.drift;
                     }
                 }
             } else if (cmd is ExpCommand) {
                 if (cmd is PitchExpCommand pitchExpCommand) {
-                    // 
+                    if (pitchExpCommand.Note == null || pitchExpCommand.Note == note) {
+                        if (note.pitch.data.Count == 2) {
+                            PortamentoLength = note.pitch.data[1].X - note.pitch.data[0].X;
+                            PortamentoStart = note.pitch.data[0].X;
+                        } else {
+                            PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+                            PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+                        }
+                    }
                 } else if (cmd is SetPhonemeExpressionCommand || cmd is ResetExpressionsCommand) {
                     AttachExpressions();
                 }
@@ -252,70 +239,261 @@ namespace OpenUtau.App.ViewModels {
         }
         #endregion
 
-        /*public void Finish() {
-            if (notesViewModel.Part != null) {
-                UVoicePart part = notesViewModel.Part;
-                List<UNote> selectedNotes = notesViewModel.Selection.ToList();
-
-                DocManager.Inst.StartUndoGroup();
-
-                if (SetLyric) {
-                    foreach (UNote note in selectedNotes) {
-                        if (note.lyric != Lyric) {
-                            DocManager.Inst.ExecuteCmd(new ChangeNoteLyricCommand(part, note, Lyric));
-                        }
-                    }
-                }
-                if (SetPortamento) {
-                    foreach (UNote note in selectedNotes) {
-                        var pitch = new UPitch();
-                        pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
-                        pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
-                        DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(part, note, pitch));
-                    }
-                }
-                if (SetVibrato) {
-                    foreach (UNote note in selectedNotes) {
-                        if(VibratoEnable && VibratoLength != 0) {
-                            if (!AutoVibratoToggle || (AutoVibratoToggle && note.duration >= AutoVibratoNoteLength)) {
-                                DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(part, note, VibratoLength));
-                                DocManager.Inst.ExecuteCmd(new VibratoFadeInCommand(part, note, VibratoIn));
-                                DocManager.Inst.ExecuteCmd(new VibratoFadeOutCommand(part, note, VibratoOut));
-                                DocManager.Inst.ExecuteCmd(new VibratoDepthCommand(part, note, VibratoDepth));
-                                DocManager.Inst.ExecuteCmd(new VibratoPeriodCommand(part, note, VibratoPeriod));
-                                DocManager.Inst.ExecuteCmd(new VibratoShiftCommand(part, note, VibratoShift));
-                            } else {
-                                DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(part, note, 0));
-                            }
-                        } else if (note.vibrato.length != 0) {
-                            DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(part, note, 0));
-                        }
-                    }
-                }
-                foreach (NotePropertyExpViewModel expVM in Expressions) {
-                    if (expVM.Set) {
-                        float value;
-                        if (expVM.IsNumerical) {
-                            value = expVM.Value;
-                        } else if (expVM.IsOptions) {
-                            value = expVM.SelectedOption;
-                        } else {
-                            continue;
-                        }
-                        var track = notesViewModel.Project.tracks[notesViewModel.Part.trackNo];
-                        foreach (UNote note in selectedNotes) {
-                            foreach (UPhoneme phoneme in notesViewModel.Part.phonemes) {
-                                if (phoneme.Parent == note) {
-                                    DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(notesViewModel.Project, track, notesViewModel.Part, phoneme, expVM.abbr, value));
+        // panel -> note
+        private void SetValueChanges() {
+            this.WhenAnyValue(vm => vm.Lyric)
+                .Subscribe(lyric => {
+                    if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                        if (!string.IsNullOrEmpty(lyric)) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.lyric != lyric) {
+                                    DocManager.Inst.ExecuteCmd(new ChangeNoteLyricCommand(Part, note, lyric));
                                 }
                             }
                         }
                     }
-                }
+                });
+            this.WhenAnyValue(vm => vm.PortamentoLength)
+                .Subscribe(value => {
+                    if (value >= 2 && value <= 320) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            var pitch = new UPitch() { snapFirst = true };
+                            pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
+                            pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
+                            foreach (UNote note in selectedNotes) {
+                                DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, pitch));
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.PortamentoStart)
+                .Subscribe(value => {
+                    if (value >= -200 && value <= 200) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            var pitch = new UPitch() { snapFirst = true };
+                            pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
+                            pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
+                            foreach (UNote note in selectedNotes) {
+                                DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, pitch));
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoLength)
+                .Subscribe(value => {
+                    if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                        if (value >= 0 && value <= 100) {
+                            UNote first = selectedNotes.First();
+                            foreach (UNote note in selectedNotes) {
+                                if (note != first && AutoVibratoToggle && note.duration < AutoVibratoNoteLength) {
+                                    if (note.vibrato.length != 0) {
+                                        DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, 0));
+                                    }
+                                } else {
+                                    if (note.vibrato.length != value) {
+                                        DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, value));
+                                    }
+                                }
+                            }
+                            if (first.vibrato.length > 0) {
+                                VibratoEnable = true;
+                            } else {
+                                VibratoEnable = false;
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoPeriod)
+                .Subscribe(value => {
+                    if (value >= 5 && value <= 500) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.period != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoPeriodCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoDepth)
+                .Subscribe(value => {
+                    if (value >= 5 && value <= 200) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.depth != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoDepthCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoIn)
+                .Subscribe(value => {
+                    if (value >= 0 && value <= 100) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.@in != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoFadeInCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoOut)
+                .Subscribe(value => {
+                    if (value >= 0 && value <= 100) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.@out != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoFadeOutCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoShift)
+                .Subscribe(value => {
+                    if (value >= 0 && value <= 100) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.shift != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoShiftCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
+            this.WhenAnyValue(vm => vm.VibratoDrift)
+                .Subscribe(value => {
+                    if (value >= -100 && value <= 100) {
+                        if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                            foreach (UNote note in selectedNotes) {
+                                if (note.vibrato.drift != value) {
+                                    DocManager.Inst.ExecuteCmd(new VibratoDriftCommand(Part, note, value));
+                                }
+                            }
+                        }
+                    }
+                });
 
+            this.WhenAnyValue(vm => vm.ApplyPortamentoPreset)
+                .WhereNotNull()
+                .Subscribe(portamentoPreset => {
+                    if (portamentoPreset != null && Part != null && selectedNotes.Count > 0) {
+                        DocManager.Inst.StartUndoGroup();
+                        PortamentoLength = portamentoPreset.PortamentoLength;
+                        PanelControlPressed = true;
+                        PortamentoStart = portamentoPreset.PortamentoStart;
+                        PanelControlPressed = false;
+                        DocManager.Inst.EndUndoGroup();
+                    }
+                });
+            this.WhenAnyValue(vm => vm.ApplyVibratoPreset)
+                .WhereNotNull()
+                .Subscribe(vibratoPreset => {
+                    if (vibratoPreset != null && Part != null && selectedNotes.Count > 0) {
+                        DocManager.Inst.StartUndoGroup();
+                        PanelControlPressed = true;
+                        VibratoLength = Math.Max(0, Math.Min(100, vibratoPreset.VibratoLength));
+                        VibratoPeriod = Math.Max(5, Math.Min(500, vibratoPreset.VibratoPeriod));
+                        VibratoDepth = Math.Max(5, Math.Min(200, vibratoPreset.VibratoDepth));
+                        VibratoIn = Math.Max(0, Math.Min(100, vibratoPreset.VibratoIn));
+                        VibratoOut = Math.Max(0, Math.Min(100, vibratoPreset.VibratoOut));
+                        VibratoShift = Math.Max(0, Math.Min(100, vibratoPreset.VibratoShift));
+                        VibratoDrift = Math.Max(-100, Math.Min(100, vibratoPreset.VibratoDrift));
+                        PanelControlPressed = false;
+                        DocManager.Inst.EndUndoGroup();
+                    }
+                });
+        }
+        public void SetVibratoEnable() {
+            if (Part != null && selectedNotes.Count > 0) {
+                DocManager.Inst.StartUndoGroup();
+                bool enable = VibratoEnable;
+                UNote first = selectedNotes.First();
+
+                foreach (UNote note in selectedNotes) {
+                    if (enable) {
+                        if (note.vibrato.length != 0) {
+                            DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, 0));
+                        }
+                    } else {
+                        if (note != first && AutoVibratoToggle && note.duration < AutoVibratoNoteLength) {
+                            if (note.vibrato.length != 0) {
+                                DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, 0));
+                            }
+                        } else {
+                            if (note.vibrato.length != NotePresets.Default.DefaultVibrato.VibratoLength) {
+                                DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, NotePresets.Default.DefaultVibrato.VibratoLength));
+                            }
+                        }
+                    }
+                }
                 DocManager.Inst.EndUndoGroup();
             }
-        }*/
+        }
+        public void SetNumericalExpressionsChanges(string abbr, float value) {
+            if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
+                var track = DocManager.Inst.Project.tracks[Part.trackNo];
+
+                foreach (UNote note in selectedNotes) {
+                    foreach (UPhoneme phoneme in Part.phonemes) {
+                        if (phoneme.Parent == note) {
+                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, Part, phoneme, abbr, value));
+                        }
+                    }
+                }
+            }
+        }
+        public void SetOptionalExpressionsChanges(string abbr, int value) {
+            if (!NoteLoading && Part != null && selectedNotes.Count > 0) {
+                var track = DocManager.Inst.Project.tracks[Part.trackNo];
+                DocManager.Inst.StartUndoGroup();
+
+                foreach (UNote note in selectedNotes) {
+                    foreach (UPhoneme phoneme in Part.phonemes) {
+                        if (phoneme.Parent == note) {
+                            DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, track, Part, phoneme, abbr, value));
+                        }
+                    }
+                }
+                DocManager.Inst.EndUndoGroup();
+            }
+        }
+
+        // presets
+        public void SavePortamentoPreset(string name) {
+            if (string.IsNullOrEmpty(name)) {
+                return;
+            }
+            NotePresets.Default.PortamentoPresets.Add(new NotePresets.PortamentoPreset(name, (int)PortamentoLength, (int)PortamentoStart));
+            NotePresets.Save();
+            PortamentoPresets = new ObservableCollection<NotePresets.PortamentoPreset>(NotePresets.Default.PortamentoPresets);
+        }
+        public void RemoveAppliedPortamentoPreset() {
+            if (appliedPortamentoPreset == null) {
+                return;
+            }
+            NotePresets.Default.PortamentoPresets.Remove(appliedPortamentoPreset);
+            NotePresets.Save();
+            PortamentoPresets = new ObservableCollection<NotePresets.PortamentoPreset>(NotePresets.Default.PortamentoPresets);
+        }
+        public void SaveVibratoPreset(string name) {
+            if (string.IsNullOrEmpty(name)) {
+                return;
+            }
+            NotePresets.Default.VibratoPresets.Add(new NotePresets.VibratoPreset(name, VibratoLength, VibratoPeriod, VibratoDepth, VibratoIn, VibratoOut, VibratoShift, VibratoDrift));
+            NotePresets.Save();
+            VibratoPresets = new ObservableCollection<NotePresets.VibratoPreset>(NotePresets.Default.VibratoPresets);
+        }
+        public void RemoveAppliedVibratoPreset() {
+            if (appliedVibratoPreset == null) {
+                return;
+            }
+            NotePresets.Default.VibratoPresets.Remove(appliedVibratoPreset);
+            NotePresets.Save();
+            VibratoPresets = new ObservableCollection<NotePresets.VibratoPreset>(NotePresets.Default.VibratoPresets);
+        }
     }
 
     public class NotePropertyExpViewModel : ViewModelBase {
@@ -331,8 +509,11 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public bool IsNoteSelected { get; set; } = false;
         [Reactive] public float Value { get; set; }
         [Reactive] public int SelectedOption { get; set; }
+        [Reactive] public bool DropDownOpen { get; set; }
 
-        public NotePropertyExpViewModel(UExpressionDescriptor descriptor) {
+        private NotePropertiesViewModel parentViewmodel;
+
+        public NotePropertyExpViewModel(UExpressionDescriptor descriptor, NotePropertiesViewModel parent) {
             Name = descriptor.name;
             defaultValue = descriptor.defaultValue;
             abbr = descriptor.abbr;
@@ -345,6 +526,25 @@ namespace OpenUtau.App.ViewModels {
                 IsOptions = true;
                 descriptor.options.ForEach(opt => Options.Add(opt));
                 SelectedOption = (int)defaultValue;
+            }
+
+            parentViewmodel = parent;
+
+            if (IsNumerical) {
+                this.WhenAnyValue(vm => vm.Value)
+                    .Subscribe(value => {
+                        if (value >= Min && value <= Max) {
+                            parentViewmodel.SetNumericalExpressionsChanges(abbr, value);
+                        }
+                    });
+            }
+            if (IsOptions) {
+                this.WhenAnyValue(vm => vm.SelectedOption)
+                    .Subscribe(value => {
+                        if (value >= 0 && DropDownOpen) {
+                            parentViewmodel.SetOptionalExpressionsChanges(abbr, value);
+                        }
+                    });
             }
         }
         public override string ToString() {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -796,7 +796,7 @@ namespace OpenUtau.App.ViewModels {
                                         DocManager.Inst.ExecuteCmd(new VibratoFadeInCommand(Part, note, copyNote.vibrato.@in));
                                         DocManager.Inst.ExecuteCmd(new VibratoFadeOutCommand(Part, note, copyNote.vibrato.@out));
                                         DocManager.Inst.ExecuteCmd(new VibratoShiftCommand(Part, note, copyNote.vibrato.shift));
-                                        // DocManager.Inst.ExecuteCmd(new VibratoDriftCommand(Part, note, copyNote.vibrato.drift));
+                                        DocManager.Inst.ExecuteCmd(new VibratoDriftCommand(Part, note, copyNote.vibrato.drift));
                                     }
                                     break;
                                 default:

--- a/OpenUtau/Views/ExpressionsDialog.axaml
+++ b/OpenUtau/Views/ExpressionsDialog.axaml
@@ -13,6 +13,10 @@
   <Design.DataContext>
     <vm:ExpressionsViewModel/>
   </Design.DataContext>
+  <Window.Styles>
+    <StyleInclude Source="/Styles/PianoRollStyles.axaml"/>
+  </Window.Styles>
+
   <Grid Margin="{Binding $parent.WindowDecorationMargin}">
     <Border Margin="10,10,10,40" Width="150" HorizontalAlignment="Left">
       <ListBox ItemsSource="{Binding Expressions}" SelectedItem="{Binding Expression}">

--- a/OpenUtau/Views/NoteDefaultsDialog.axaml
+++ b/OpenUtau/Views/NoteDefaultsDialog.axaml
@@ -99,14 +99,20 @@
                       </Grid>
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
-                      <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
-                      <TextBox Grid.Column="2" Text="{Binding CurrentVibratoShift}" />
-                      <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoShift}" Minimum="0" Maximum="100"
-                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                    <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
+                    <TextBox Grid.Column="2" Text="{Binding CurrentVibratoShift}" />
+                    <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoShift}" Minimum="0" Maximum="100"
+                    TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
+                  </Grid>
+                  <Grid ColumnDefinitions="180,20,50,20,*">
+                    <Label Content="{DynamicResource notedefaults.vibrato.drift}"/>
+                    <TextBox Grid.Column="2" Text="{Binding CurrentVibratoDrift}" />
+                    <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoDrift}" Minimum="-100" Maximum="100"
+                    TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="173,20,*">
-                      <Label Content="{DynamicResource notedefaults.vibrato.autotoggle}"/>
-                      <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>
+                    <Label Content="{DynamicResource notedefaults.vibrato.autotoggle}"/>
+                    <CheckBox Grid.Column="2" IsChecked="{Binding AutoVibratoToggle}"/>
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.autominlength}"/>

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -187,7 +187,7 @@
                 HorizontalAlignment="Right">
       <Border BorderThickness="1" CornerRadius="4" ClipToBounds="True"
               BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}">
-        <ToggleButton Background="Transparent" IsChecked="{Binding ZoomInMel}">
+        <ToggleButton Classes="normal" Background="Transparent" IsChecked="{Binding ZoomInMel}">
           <Path Fill="{DynamicResource SystemControlForegroundBaseHighBrush}"
                 Data="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z">
             <Path.RenderTransform>


### PR DESCRIPTION
This is equivalent to #792.

New Features:
- Textboxes and sliders now work
![image](https://github.com/stakira/OpenUtau/assets/130257355/42735cfc-4196-4b5a-b915-ec13a7d22ab7)

- Vibrato drift (move height)
This is a parameter that has existed internally in ustx up to now, but has not been used.
Currently the only way to change this parameter is to manipulate the note property.
![image](https://github.com/stakira/OpenUtau/assets/130257355/474e2ad3-dbb2-47bb-b083-a062f61e6e6f)

Not yet implemented:
- Right click on the slider does not work
PointerPressed does not work well on sliders, so Focus is used instead, and it cannot determine if it is a right click or not.
- Update text box when lost focus instead of immediately
To resolve this, we need to install Avalonia.Xaml.Behaviors package.

Internal changes:
- Fix toggle button style
To correct the appearance of expanders.