### PR TITLE
Allow to change keyboard color in PianoRoll Window

### DIFF
--- a/OpenUtau/Colors/Brushes.axaml
+++ b/OpenUtau/Colors/Brushes.axaml
@@ -114,6 +114,8 @@
                    Color="#90CAF9" Opacity="0.5"/>
   <SolidColorBrush x:Key="SelectedTrackAccentDarkBrush"
                    Color="#1E88E5" />
+  <SolidColorBrush x:Key="SelectedTrackCenterKeyBrush"
+                   Color="#C8E5FC" />
 
   <LinearGradientBrush x:Key="WhiteKeyBrush" StartPoint="0%,50%" EndPoint="100%,50%">
     <LinearGradientBrush.GradientStops>

--- a/OpenUtau/Controls/TrackBackground.cs
+++ b/OpenUtau/Controls/TrackBackground.cs
@@ -75,6 +75,7 @@ namespace OpenUtau.App.Controls {
                 bool isAltTrack = IsAltTrack(track) ^ (ThemeManager.IsDarkMode && !IsKeyboard);
                 bool isCenterKey = IsKeyboard && IsCenterKey(track);
                 var brush = isCenterKey ? ThemeManager.CenterKeyBrush
+                    : IsKeyboard ? (isAltTrack ? ThemeManager.BlackKeyBrush : ThemeManager.WhiteKeyBrush)
                     : isAltTrack ? Foreground : Background;
                 context.DrawRectangle(
                     brush,

--- a/OpenUtau/ThemeManager.cs
+++ b/OpenUtau/ThemeManager.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Styling;
 using OpenUtau.App.Controls;
+using OpenUtau.Core.Util;
 using ReactiveUI;
 
 namespace OpenUtau.App {
@@ -51,24 +52,24 @@ namespace OpenUtau.App {
         public static IBrush ExpActiveNameBrush = Brushes.White;
 
         public static List<TrackColor> TrackColors = new List<TrackColor>(){
-                new TrackColor("Pink", "#F06292", "#E91E63", "#F48FB1"),
-                new TrackColor("Red", "#EF5350", "#E53935", "#E57373"),
-                new TrackColor("Orange", "#FF8A65", "#FF5722", "#FFAB91"),
-                new TrackColor("Yellow", "#FBC02D", "#F9A825", "#FDD835"),
-                new TrackColor("Light Green", "#CDDC39", "#AFB42B", "#DCE775"),
-                new TrackColor("Green", "#66BB6A", "#43A047", "#A5D6A7"),
-                new TrackColor("Light Blue", "#4FC3F7", "#03A9F4", "#81D4FA"),
-                new TrackColor("Blue", "#4EA6EA", "#1E88E5", "#90CAF9"),
-                new TrackColor("Purple", "#BA68C8", "#9C27B0", "#CE93D8"),
-                new TrackColor("Pink2", "#E91E63", "#C2185B", "#F06292"),
-                new TrackColor("Red2", "#D32F2F", "#B71C1C", "#EF5350"),
-                new TrackColor("Orange2", "#FF5722", "#E64A19", "#FF8A65"),
-                new TrackColor("Yellow2", "#FF8F00", "#FF6F00", "#FFB300"),
-                new TrackColor("Light Green2", "#AFB42B", "#827717", "#CDDC39"),
-                new TrackColor("Green2", "#2E7D32", "#1B5E20", "#4CAF50"),
-                new TrackColor("Light Blue2", "#1976D2", "#0D47A1", "#2196F3"),
-                new TrackColor("Blue2", "#3949AB", "#283593", "#5C6BC0"),
-                new TrackColor("Purple2", "#7B1FA2", "#4A148C", "#9C27B0"),
+                new TrackColor("Pink", "#F06292", "#EC407A", "#F48FB1", "#FAC7D8"),
+                new TrackColor("Red", "#EF5350", "#E53935", "#E57373", "#F2B9B9"),
+                new TrackColor("Orange", "#FF8A65", "#FF7043", "#FFAB91", "#FFD5C8"),
+                new TrackColor("Yellow", "#FBC02D", "#F9A825", "#FDD835", "#FEF1B6"),
+                new TrackColor("Light Green", "#CDDC39", "#C0CA33", "#DCE775", "#F2F7CE"),
+                new TrackColor("Green", "#66BB6A", "#43A047", "#A5D6A7", "#D2EBD3"),
+                new TrackColor("Light Blue", "#4FC3F7", "#29B6F6", "#81D4FA", "#C0EAFD"),
+                new TrackColor("Blue", "#4EA6EA", "#1E88E5", "#90CAF9", "#C8E5FC"),
+                new TrackColor("Purple", "#BA68C8", "#AB47BC", "#CE93D8", "#E7C9EC"),
+                new TrackColor("Pink2", "#E91E63", "#C2185B", "#F06292", "#F8B1C9"),
+                new TrackColor("Red2", "#D32F2F", "#B71C1C", "#EF5350", "#F7A9A8"),
+                new TrackColor("Orange2", "#FF5722", "#E64A19", "#FF7043", "#FFB8A1"),
+                new TrackColor("Yellow2", "#FF8F00", "#FF7F00", "#FFB300", "#FFE097"),
+                new TrackColor("Light Green2", "#AFB42B", "#9E9D24", "#CDDC39", "#E6EE9C"),
+                new TrackColor("Green2", "#2E7D32", "#1B5E20", "#43A047", "#A1D0A3"),
+                new TrackColor("Light Blue2", "#1976D2", "#0D47A1", "#2196F3", "#90CBF9"),
+                new TrackColor("Blue2", "#3949AB", "#283593", "#5C6BC0", "#AEB5E0"),
+                new TrackColor("Purple2", "#7B1FA2", "#4A148C", "#AB47BC", "#D5A3DE"),
             };
 
         public static void LoadTheme() {
@@ -135,55 +136,118 @@ namespace OpenUtau.App {
                 FinalPitchBrush = (IBrush)outVar!;
                 FinalPitchPen = new Pen(FinalPitchBrush, 1);
             }
-            if (resDict.TryGetResource("WhiteKeyBrush", themeVariant, out outVar)) {
-                WhiteKeyBrush = (IBrush)outVar!;
-            }
-            if (resDict.TryGetResource("WhiteKeyNameBrush", themeVariant, out outVar)) {
-                WhiteKeyNameBrush = (IBrush)outVar!;
-            }
-            if (resDict.TryGetResource("CenterKeyBrush", themeVariant, out outVar)) {
-                CenterKeyBrush = (IBrush)outVar!;
-            }
-            if (resDict.TryGetResource("CenterKeyNameBrush", themeVariant, out outVar)) {
-                CenterKeyNameBrush = (IBrush)outVar!;
-            }
-            if (resDict.TryGetResource("BlackKeyBrush", themeVariant, out outVar)) {
-                BlackKeyBrush = (IBrush)outVar!;
-            }
-            if (resDict.TryGetResource("BlackKeyNameBrush", themeVariant, out outVar)) {
-                BlackKeyNameBrush = (IBrush)outVar!;
-            }
-            if (!IsDarkMode) {
-                ExpBrush = WhiteKeyBrush;
-                ExpNameBrush = WhiteKeyNameBrush;
-                ExpActiveBrush = BlackKeyBrush;
-                ExpActiveNameBrush = BlackKeyNameBrush;
-                ExpShadowBrush = CenterKeyBrush;
-                ExpShadowNameBrush = CenterKeyNameBrush;
-            } else {
-                ExpBrush = BlackKeyBrush;
-                ExpNameBrush = BlackKeyNameBrush;
-                ExpActiveBrush = WhiteKeyBrush;
-                ExpActiveNameBrush = WhiteKeyNameBrush;
-                ExpShadowBrush = CenterKeyBrush;
-                ExpShadowNameBrush = CenterKeyNameBrush;
-            }
+            SetKeyboardBrush();
             TextLayoutCache.Clear();
             MessageBus.Current.SendMessage(new ThemeChangedEvent());
         }
 
-        public static void ChangeTrackColor(string color) {
+        public static void ChangePianorollColor(string color) {
             if (Application.Current == null) {
                 return;
             }
             try {
                 IResourceDictionary resDict = Application.Current.Resources;
                 TrackColor tcolor = GetTrackColor(color);
+                
                 resDict["SelectedTrackAccentBrush"] = tcolor.AccentColor;
                 resDict["SelectedTrackAccentLightBrush"] = tcolor.AccentColorLight;
                 resDict["SelectedTrackAccentLightBrushSemi"] = tcolor.AccentColorLightSemi;
                 resDict["SelectedTrackAccentDarkBrush"] = tcolor.AccentColorDark;
+                resDict["SelectedTrackCenterKeyBrush"] = tcolor.AccentColorCenterKey;
+
+                SetKeyboardBrush();
             } catch { }
+            MessageBus.Current.SendMessage(new ThemeChangedEvent());
+        }
+        private static void SetKeyboardBrush() {
+            if (Application.Current == null) {
+                return;
+            }
+            IResourceDictionary resDict = Application.Current.Resources;
+            object? outVar;
+            var themeVariant = ThemeVariant.Default;
+
+            if (Preferences.Default.UseTrackColor) {
+                if (IsDarkMode) {
+                    if (resDict.TryGetResource("SelectedTrackAccentBrush", themeVariant, out outVar)) {
+                        CenterKeyNameBrush = (IBrush)outVar!;
+                        WhiteKeyBrush = (IBrush)outVar!;
+                    }
+                    if (resDict.TryGetResource("SelectedTrackCenterKeyBrush", themeVariant, out outVar)) {
+                        CenterKeyBrush = (IBrush)outVar!;
+                    }
+                    if (resDict.TryGetResource("WhiteKeyNameBrush", themeVariant, out outVar)) {
+                        WhiteKeyNameBrush = (IBrush)outVar!;
+                    }
+                    if (resDict.TryGetResource("BlackKeyBrush", themeVariant, out outVar)) {
+                        BlackKeyBrush = (IBrush)outVar!;
+                    }
+                    if (resDict.TryGetResource("BlackKeyNameBrush", themeVariant, out outVar)) {
+                        BlackKeyNameBrush = (IBrush)outVar!;
+                    }
+                    ExpBrush = BlackKeyBrush;
+                    ExpNameBrush = BlackKeyNameBrush;
+                    ExpActiveBrush = WhiteKeyBrush;
+                    ExpActiveNameBrush = WhiteKeyNameBrush;
+                    ExpShadowBrush = CenterKeyBrush;
+                    ExpShadowNameBrush = CenterKeyNameBrush;
+                } else { // LightMode
+                    if (resDict.TryGetResource("SelectedTrackAccentBrush", themeVariant, out outVar)) {
+                        CenterKeyNameBrush = (IBrush)outVar!;
+                        WhiteKeyNameBrush = (IBrush)outVar!;
+                        BlackKeyBrush = (IBrush)outVar!;
+                    }
+                    if (resDict.TryGetResource("SelectedTrackCenterKeyBrush", themeVariant, out outVar)) {
+                        CenterKeyBrush = (IBrush)outVar!;
+                    }
+                    if (resDict.TryGetResource("WhiteKeyBrush", themeVariant, out outVar)) {
+                        WhiteKeyBrush = (IBrush)outVar!;
+                    }
+                    if (resDict.TryGetResource("BlackKeyNameBrush", themeVariant, out outVar)) {
+                        BlackKeyNameBrush = (IBrush)outVar!;
+                    }
+                    ExpBrush = WhiteKeyBrush;
+                    ExpNameBrush = WhiteKeyNameBrush;
+                    ExpActiveBrush = BlackKeyBrush;
+                    ExpActiveNameBrush = BlackKeyNameBrush;
+                    ExpShadowBrush = CenterKeyBrush;
+                    ExpShadowNameBrush = CenterKeyNameBrush;
+                }
+            } else { // DefColor
+                if (resDict.TryGetResource("WhiteKeyBrush", themeVariant, out outVar)) {
+                    WhiteKeyBrush = (IBrush)outVar!;
+                }
+                if (resDict.TryGetResource("WhiteKeyNameBrush", themeVariant, out outVar)) {
+                    WhiteKeyNameBrush = (IBrush)outVar!;
+                }
+                if (resDict.TryGetResource("CenterKeyBrush", themeVariant, out outVar)) {
+                    CenterKeyBrush = (IBrush)outVar!;
+                }
+                if (resDict.TryGetResource("CenterKeyNameBrush", themeVariant, out outVar)) {
+                    CenterKeyNameBrush = (IBrush)outVar!;
+                }
+                if (resDict.TryGetResource("BlackKeyBrush", themeVariant, out outVar)) {
+                    BlackKeyBrush = (IBrush)outVar!;
+                }
+                if (resDict.TryGetResource("BlackKeyNameBrush", themeVariant, out outVar)) {
+                    BlackKeyNameBrush = (IBrush)outVar!;
+                }
+                if (!IsDarkMode) {
+                    ExpBrush = WhiteKeyBrush;
+                    ExpNameBrush = WhiteKeyNameBrush;
+                    ExpActiveBrush = BlackKeyBrush;
+                    ExpActiveNameBrush = BlackKeyNameBrush;
+                    ExpShadowBrush = CenterKeyBrush;
+                    ExpShadowNameBrush = CenterKeyNameBrush;
+                } else {
+                    ExpBrush = BlackKeyBrush;
+                    ExpNameBrush = BlackKeyNameBrush;
+                    ExpActiveBrush = WhiteKeyBrush;
+                    ExpActiveNameBrush = WhiteKeyNameBrush;
+                    ExpShadowBrush = CenterKeyBrush;
+                    ExpShadowNameBrush = CenterKeyNameBrush;
+                }
+            }
         }
 
         public static string GetString(string key) {
@@ -211,14 +275,16 @@ namespace OpenUtau.App {
         public SolidColorBrush AccentColorDark { get; set; } // Pressed
         public SolidColorBrush AccentColorLight { get; set; } // PointerOver
         public SolidColorBrush AccentColorLightSemi { get; set; } // BackGround
+        public SolidColorBrush AccentColorCenterKey { get; set; } // Keyboard
 
-        public TrackColor(string name, string accentColor, string darkColor, string lightColor) {
+        public TrackColor(string name, string accentColor, string darkColor, string lightColor, string centerKey) {
             Name = name;
             AccentColor = SolidColorBrush.Parse(accentColor);
             AccentColorDark = SolidColorBrush.Parse(darkColor);
             AccentColorLight = SolidColorBrush.Parse(lightColor);
             AccentColorLightSemi = SolidColorBrush.Parse(lightColor);
             AccentColorLightSemi.Opacity = 0.5;
+            AccentColorCenterKey = SolidColorBrush.Parse(centerKey);
         }
     }
 }

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -458,14 +458,14 @@ namespace OpenUtau.App.ViewModels {
         private void LoadTrackColor(UPart? part, UProject? project) {
             if (part == null || project == null) {
                 TrackAccentColor = ThemeManager.GetTrackColor("Blue").AccentColor;
-                ThemeManager.ChangeTrackColor("Blue");
+                ThemeManager.ChangePianorollColor("Blue");
                 return;
             }
             TrackAccentColor = ThemeManager.GetTrackColor(project.tracks[part.trackNo].TrackColor).AccentColor;
             string name = Preferences.Default.UseTrackColor
                 ? project.tracks[part.trackNo].TrackColor
                 : "Blue";
-            ThemeManager.ChangeTrackColor(name);
+            ThemeManager.ChangePianorollColor(name);
         }
 
         private void UnloadPart() {

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -55,8 +55,6 @@
                  LargeChange="{Binding ViewportTracks}"
                  SmallChange="{Binding SmallChangeY}" PointerWheelChanged="VScrollPointerWheelChanged"/>
       <c:TrackBackground Grid.Column="0" Grid.Row="2" IsPianoRoll="True" IsKeyboard="True"
-                         Foreground="{DynamicResource BlackKeyBrush}"
-                         Background="{DynamicResource WhiteKeyBrush}"
                          DataContext="{Binding NotesViewModel}"
                          TrackHeight="{Binding TrackHeight}"
                          TrackOffset="{Binding TrackOffset}"


### PR DESCRIPTION
This is part of #774.
New feature:
- Keyboard color
![image](https://github.com/stakira/OpenUtau/assets/130257355/c3215a5f-5136-4ec9-be9d-1333cbd473e2)
By changing the color of keyboard, we can more easily recognize which track we are currently operating on.
Not only does this allow us to color the look any way we want, but it also reduces mistakes when dealing with many similar tracks (unisons, choruses, etc.).
This is only changed when preference is changed; default is off.
![image](https://github.com/stakira/OpenUtau/assets/130257355/b757d592-6896-47bc-b725-16469655b117)

Minor fix:
- Fine tune the track colors

Toggle switch color fix for note properties panel is included only in #844.