### PR TITLE
[Singers window] Add button to show readme.txt

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -360,6 +360,8 @@
   <system:String x:Key="singers.otoview.showall">Show All</system:String>
   <system:String x:Key="singers.otoview.zoomin">Zoom In</system:String>
   <system:String x:Key="singers.otoview.zoomout">Zoom Out</system:String>
+  <system:String x:Key="singers.readme">Open readme.txt</system:String>
+  <system:String x:Key="singers.readme.notfound">readme.txt not found.</system:String>
   <system:String x:Key="singers.refresh">Refresh</system:String>
   <system:String x:Key="singers.setdefaultphonemizer">Set Default Phonemizer</system:String>
   <system:String x:Key="singers.setencoding">Set Encoding</system:String>

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -93,6 +93,8 @@
       </Button>
       <TextBox Text="{Binding SearchAlias}" Watermark="{DynamicResource singers.editoto.searchalias}" Margin="0"
                MinWidth="160" HorizontalAlignment="Stretch" Focusable="True" IsVisible="{Binding UseSearchAlias}" />
+      <Button Margin="0" Content="{DynamicResource singers.readme}"
+              IsVisible="{Binding IsClassic}" Click="OnOpenReadme"/>
     </StackPanel>
     <StackPanel Grid.Row="0" Grid.Column="2" Spacing="10" Margin="0" Height="20"
                 Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom">

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -93,6 +93,9 @@
       </Button>
       <TextBox Text="{Binding SearchAlias}" Watermark="{DynamicResource singers.editoto.searchalias}" Margin="0"
                MinWidth="160" HorizontalAlignment="Stretch" Focusable="True" IsVisible="{Binding UseSearchAlias}" />
+    </StackPanel>
+    <StackPanel Grid.Row="0" Spacing="5" Margin="0,0,0,0" Height="20"
+            Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
       <Button Margin="0" Content="{DynamicResource singers.readme}" Click="OnOpenReadme"/>
     </StackPanel>
     <StackPanel Grid.Row="0" Grid.Column="2" Spacing="10" Margin="0" Height="20"

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -93,8 +93,7 @@
       </Button>
       <TextBox Text="{Binding SearchAlias}" Watermark="{DynamicResource singers.editoto.searchalias}" Margin="0"
                MinWidth="160" HorizontalAlignment="Stretch" Focusable="True" IsVisible="{Binding UseSearchAlias}" />
-      <Button Margin="0" Content="{DynamicResource singers.readme}"
-              IsVisible="{Binding IsClassic}" Click="OnOpenReadme"/>
+      <Button Margin="0" Content="{DynamicResource singers.readme}" Click="OnOpenReadme"/>
     </StackPanel>
     <StackPanel Grid.Row="0" Grid.Column="2" Spacing="10" Margin="0" Height="20"
                 Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom">

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -195,7 +195,7 @@ namespace OpenUtau.App.Views {
         void OnOpenReadme(object sender, RoutedEventArgs e) {
             var viewModel = (DataContext as SingersViewModel)!;
             if (viewModel.Singer != null) {
-                var readme = $@"{viewModel.Singer.Location}\readme.txt";
+                var readme = Path.Join(viewModel.Singer.Location, "readme.txt");
                 if (File.Exists(readme)) {
                     var p = new Process();
                     p.StartInfo = new ProcessStartInfo(readme) {

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -188,6 +189,27 @@ namespace OpenUtau.App.Views {
                     e.ToString(),
                     ThemeManager.GetString("errors.caption"),
                     MessageBox.MessageBoxButtons.Ok);
+            }
+        }
+
+        void OnOpenReadme(object sender, RoutedEventArgs e) {
+            var viewModel = (DataContext as SingersViewModel)!;
+            if (viewModel.Singer != null) {
+                var readme = $@"{viewModel.Singer.Location}\readme.txt";
+                if (File.Exists(readme)) {
+                    var p = new Process();
+                    p.StartInfo = new ProcessStartInfo(readme) {
+                        UseShellExecute = true
+                    };
+                    p.Start();
+                } else {
+                    MessageBox.Show(
+                        this,
+                        ThemeManager.GetString("singers.readme.notfound"),
+                        ThemeManager.GetString("errors.caption"),
+                        MessageBox.MessageBoxButtons.Ok);
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
There's always been a way to show the character.txt/character.yaml, but there was never a way to directly view the readme file. Since the readme often contains important information (such as a ToS, usage tips, etc.), I've decided to add a button to open this file.

To limit clutter on the Singers window, the readme file will open in the default external application of the operating system. If a readme.txt does not exist, a popup window will appear with the text "readme.txt not found".

![readme.txt button](https://i.ibb.co/M861c3H/Readme-Button.png)

![readme.txt not found dialog](https://i.ibb.co/XJ1rRtY/Readme-Not-Found.png)

![Showing readme.txt in external program](https://i.ibb.co/87PFhnY/Readme-Txt-Show.png)