### PR TITLE
[Singer window] Play sample on click + [Wave.cs] Support reading AIFF format

### DIFF
--- a/OpenUtau.Core/Classic/ClassicSinger.cs
+++ b/OpenUtau.Core/Classic/ClassicSinger.cs
@@ -28,6 +28,7 @@ namespace OpenUtau.Classic {
         public override float PortraitOpacity => voicebank.PortraitOpacity;
         public override int PortraitHeight => voicebank.PortraitHeight;
         public override string DefaultPhonemizer => voicebank.DefaultPhonemizer;
+        public override string Sample => voicebank.Sample == null ? null : Path.Combine(Location, voicebank.Sample);
         public override Encoding TextFileEncoding => voicebank.TextFileEncoding;
         public override IList<USubbank> Subbanks => subbanks;
         public override IList<UOto> Otos => otos;

--- a/OpenUtau.Core/Classic/VoiceBank.cs
+++ b/OpenUtau.Core/Classic/VoiceBank.cs
@@ -16,6 +16,7 @@ namespace OpenUtau.Classic {
         public string Voice;
         public string Web;
         public string Version;
+        public string Sample;
         public string OtherInfo;
         public string DefaultPhonemizer;
         public Encoding TextFileEncoding;
@@ -34,6 +35,7 @@ namespace OpenUtau.Classic {
             Voice = null;
             Web = null;
             Version = null;
+            Sample = null;
             OtherInfo = null;
             TextFileEncoding = null;
             SingerType = USingerType.Classic;

--- a/OpenUtau.Core/Classic/VoicebankConfig.cs
+++ b/OpenUtau.Core/Classic/VoicebankConfig.cs
@@ -46,6 +46,7 @@ namespace OpenUtau.Classic {
         public string Voice;
         public string Web;
         public string Version;
+        public string Sample;
         public string DefaultPhonemizer;
         public SymbolSet SymbolSet { get; set; }
         public Subbank[] Subbanks { get; set; }

--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -158,6 +158,7 @@ namespace OpenUtau.Classic {
                         } else if (s[0].StartsWith("voice") || s[0] == "cv") {
                             voicebank.Voice = s[1];
                         } else if (s[0] == "sample") {
+                            voicebank.Sample = s[1];
                         } else if (s[0] == "web") {
                             voicebank.Web = s[1];
                         } else if (s[0] == "version") {
@@ -200,6 +201,9 @@ namespace OpenUtau.Classic {
             }
             if (!string.IsNullOrWhiteSpace(bankConfig.Version)) {
                 bank.Version = bankConfig.Version;
+            }
+            if (!string.IsNullOrWhiteSpace(bankConfig.Sample)) {
+                bank.Sample = bankConfig.Sample;
             }
             if (!string.IsNullOrWhiteSpace(bankConfig.DefaultPhonemizer)) {
                 bank.DefaultPhonemizer = bankConfig.DefaultPhonemizer;

--- a/OpenUtau.Core/Enunu/EnunuSinger.cs
+++ b/OpenUtau.Core/Enunu/EnunuSinger.cs
@@ -27,6 +27,7 @@ namespace OpenUtau.Core.Enunu {
         public override string Portrait => voicebank.Portrait == null ? null : Path.Combine(Location, voicebank.Portrait);
         public override float PortraitOpacity => voicebank.PortraitOpacity;
         public override int PortraitHeight => voicebank.PortraitHeight;
+        public override string Sample => voicebank.Sample == null ? null : Path.Combine(Location, voicebank.Sample);
         public override string DefaultPhonemizer => voicebank.DefaultPhonemizer;
         public override Encoding TextFileEncoding => voicebank.TextFileEncoding;
         public override IList<USubbank> Subbanks => subbanks;
@@ -189,6 +190,12 @@ namespace OpenUtau.Core.Enunu {
             return string.IsNullOrEmpty(Portrait)
                 ? null
                 : File.ReadAllBytes(Portrait);
+        }
+
+        public override byte[] LoadSample() {
+            return string.IsNullOrEmpty(Sample)
+                ? null
+                : File.ReadAllBytes(Sample);
         }
     }
 }

--- a/OpenUtau.Core/Format/Wave.cs
+++ b/OpenUtau.Core/Format/Wave.cs
@@ -44,7 +44,7 @@ namespace OpenUtau.Core.Format {
             if (tag == "fLaC") {
                 return new FlacReader(filepath);
             }
-            if (ext == ".aiff") {
+            if (ext == ".aiff" || ext == ".aif" || ext == ".aifc") {
                 return new AiffFileReader(filepath);
             }
             throw new Exception("Unsupported audio file format.");

--- a/OpenUtau.Core/Format/Wave.cs
+++ b/OpenUtau.Core/Format/Wave.cs
@@ -44,6 +44,9 @@ namespace OpenUtau.Core.Format {
             if (tag == "fLaC") {
                 return new FlacReader(filepath);
             }
+            if (ext == ".aiff") {
+                return new AiffFileReader(filepath);
+            }
             throw new Exception("Unsupported audio file format.");
         }
 

--- a/OpenUtau.Core/Ustx/USinger.cs
+++ b/OpenUtau.Core/Ustx/USinger.cs
@@ -205,6 +205,7 @@ namespace OpenUtau.Core.Ustx {
         public virtual string Portrait { get; }
         public virtual float PortraitOpacity { get; }
         public virtual int PortraitHeight { get; }
+        public virtual string Sample { get; }
         public virtual string DefaultPhonemizer { get; }
         public virtual Encoding TextFileEncoding => Encoding.UTF8;
         public virtual IList<USubbank> Subbanks { get; }
@@ -246,6 +247,7 @@ namespace OpenUtau.Core.Ustx {
 
         public virtual IEnumerable<UOto> GetSuggestions(string text) { return emptyOtos; }
         public virtual byte[] LoadPortrait() => null;
+        public virtual byte[] LoadSample() => null;
         public override string ToString() => Name;
 
         public static USinger CreateMissing(string name) {

--- a/OpenUtau.Test/Classic/VoicebankConfigTest.cs
+++ b/OpenUtau.Test/Classic/VoicebankConfigTest.cs
@@ -14,6 +14,7 @@ namespace OpenUtau.Classic {
             return new VoicebankConfig() {
                 PortraitOpacity = 0.75f,
                 PortraitHeight = 675,
+                Sample = "sample.wav",
                 SymbolSet = new SymbolSet() {
                     Preset = SymbolSetPreset.hiragana,
                 },

--- a/OpenUtau.Test/Classic/VoicebankConfigTest.cs
+++ b/OpenUtau.Test/Classic/VoicebankConfigTest.cs
@@ -56,6 +56,7 @@ namespace OpenUtau.Classic {
             //"" evaluates to " in verbatim string literals
             Assert.Equal(@"portrait_opacity: 0.75
 portrait_height: 675
+sample: sample.wav
 symbol_set:
   preset: hiragana
   head: '-'

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -360,6 +360,7 @@
   <system:String x:Key="singers.otoview.showall">Show All</system:String>
   <system:String x:Key="singers.otoview.zoomin">Zoom In</system:String>
   <system:String x:Key="singers.otoview.zoomout">Zoom Out</system:String>
+  <system:String x:Key="singers.playsample">Play sample</system:String>
   <system:String x:Key="singers.refresh">Refresh</system:String>
   <system:String x:Key="singers.setdefaultphonemizer">Set Default Phonemizer</system:String>
   <system:String x:Key="singers.setencoding">Set Encoding</system:String>

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="640"
         x:Class="OpenUtau.App.Views.SingersDialog"
         Icon="/Assets/open-utau.ico"
-        Title="{DynamicResource singers.caption}" Width="1000" MinWidth="800" MinHeight="640"
+        Title="{DynamicResource singers.caption}" Width="1000" MinWidth="850" MinHeight="640"
         WindowStartupLocation="CenterScreen"
         ExtendClientAreaToDecorationsHint="False" KeyDown="OnKeyDown">
   <Design.DataContext>
@@ -28,9 +28,9 @@
       <RowDefinition Height="10"/>
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="1*"/>
+      <ColumnDefinition Width="1*" MinWidth="495"/>
       <ColumnDefinition Width="10"/>
-      <ColumnDefinition Width="1*"/>
+      <ColumnDefinition Width="1*" MinWidth="340"/>
     </Grid.ColumnDefinitions>
     <Image Grid.Row="0" Width="100" Height="100" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,10,0,0" Source="{Binding Avatar}"/>
     <ComboBox Grid.Row="0" x:Name="name" HorizontalAlignment="Stretch" Margin="120,10,0,0" VerticalAlignment="Top"
@@ -93,6 +93,9 @@
       </Button>
       <TextBox Text="{Binding SearchAlias}" Watermark="{DynamicResource singers.editoto.searchalias}" Margin="0"
                MinWidth="160" HorizontalAlignment="Stretch" Focusable="True" IsVisible="{Binding UseSearchAlias}" />
+    </StackPanel>
+    <StackPanel Grid.Row="0" Spacing="5" Margin="0,0,0,0" Height="20"
+            Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
       <Button Margin="0" Content="{DynamicResource singers.playsample}" Click="OnPlaySample"/>
     </StackPanel>
     <StackPanel Grid.Row="0" Grid.Column="2" Spacing="10" Margin="0" Height="20"

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -93,6 +93,7 @@
       </Button>
       <TextBox Text="{Binding SearchAlias}" Watermark="{DynamicResource singers.editoto.searchalias}" Margin="0"
                MinWidth="160" HorizontalAlignment="Stretch" Focusable="True" IsVisible="{Binding UseSearchAlias}" />
+      <Button Margin="0" Content="{DynamicResource singers.playsample}" Click="OnPlaySample"/>
     </StackPanel>
     <StackPanel Grid.Row="0" Grid.Column="2" Spacing="10" Margin="0" Height="20"
                 Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom">

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -206,7 +206,7 @@ namespace OpenUtau.App.Views {
                     var path = viewModel.Singer.Location;
                     string[] files = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).ToArray();
                     Random rnd = new Random(Guid.NewGuid().GetHashCode());
-                    int choice = rnd.Next(0, files.Length);
+                    int choice = rnd.Next(0, files.Length - 1);
                     string soundFile = files[choice];
                     if (soundFile.EndsWith(".wav") | soundFile.EndsWith(".flac") | soundFile.EndsWith(".mp3") | soundFile.EndsWith(".aiff") | soundFile.EndsWith(".ogg") | soundFile.EndsWith(".opus")) {
                         var playSound = Wave.OpenFile(soundFile);

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -196,7 +196,7 @@ namespace OpenUtau.App.Views {
 
         public void OnPlaySample(object sender, RoutedEventArgs e) {
             var viewModel = (DataContext as SingersViewModel)!;
-            var waveOut = new WaveOutEvent();
+            var waveOut = new NAudio.Wave.WaveOutEvent();
             if (OS.IsWindows()) {
                 if (viewModel.Singer != null) {
                     var sample = viewModel.Singer.Sample;

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -6,9 +6,11 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
+using NAudio.Wave;
 using NWaves.Audio;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
+using OpenUtau.Core.Format;
 using OpenUtau.Core.Ustx;
 using Serilog;
 
@@ -188,6 +190,30 @@ namespace OpenUtau.App.Views {
                     e.ToString(),
                     ThemeManager.GetString("errors.caption"),
                     MessageBox.MessageBoxButtons.Ok);
+            }
+        }
+
+        public void OnPlaySample(object sender, RoutedEventArgs e) {
+            var viewModel = (DataContext as SingersViewModel)!;
+            var waveOut = new WaveOutEvent();
+            if (viewModel.Singer != null) {
+                var sample = viewModel.Singer.Sample;
+                if (sample != null && File.Exists(sample)) {
+                    var playSample = Wave.OpenFile(sample);
+                    waveOut.Init(playSample);
+                    waveOut.Play();
+                } else {
+                    var path = viewModel.Singer.Location;
+                    string[] files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
+                    Random rnd = new Random(Guid.NewGuid().GetHashCode());
+                    int choice = rnd.Next(0, files.Length);
+                    string soundFile = files[choice];
+                    if (soundFile.EndsWith(".wav") || soundFile.EndsWith(".mp3") || soundFile.EndsWith(".aiff") || soundFile.EndsWith(".flac") || soundFile.EndsWith(".ogg") || soundFile.EndsWith(".opus")) {
+                        var playSound = Wave.OpenFile(soundFile);
+                        waveOut.Init(playSound);
+                        waveOut.Play();
+                    }
+                }
             }
         }
 

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -196,49 +196,23 @@ namespace OpenUtau.App.Views {
 
         public void OnPlaySample(object sender, RoutedEventArgs e) {
             var viewModel = (DataContext as SingersViewModel)!;
-            if (OS.IsWindows()) {
-                if (viewModel.Singer != null) {
-                    var sample = viewModel.Singer.Sample;
-                    var waveOut = new NAudio.Wave.WaveOutEvent();
-                    if (sample != null && File.Exists(sample)) {
-                        var playSample = Wave.OpenFile(sample);
-                        waveOut.Init(playSample);
-                        waveOut.Play();
-                    } else {
-                        var path = viewModel.Singer.Location;
-                        string[] files = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).ToArray();
-                        Random rnd = new Random(Guid.NewGuid().GetHashCode());
-                        int choice = rnd.Next(0, files.Length - 1);
-                        string soundFile = files[choice];
-                        if (soundFile.EndsWith(".wav") | soundFile.EndsWith(".flac") | soundFile.EndsWith(".mp3") | soundFile.EndsWith(".aiff") | soundFile.EndsWith(".ogg") | soundFile.EndsWith(".opus")) {
-                            var playSound = Wave.OpenFile(soundFile);
-                            waveOut.Init(playSound);
-                            waveOut.Play();
-                        }
-                    }
-                }
-            } else {
-                if (viewModel.Singer != null) {
-                    var sample = viewModel.Singer.Sample;
-                    if (File.Exists(sample)) {
-                        var p = new Process();
-                        p.StartInfo = new ProcessStartInfo(sample) {
-                            UseShellExecute = true
-                        };
-                        p.Start();
-                    } else {
-                        var path = viewModel.Singer.Location;
-                        string[] files = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).ToArray();
-                        Random rnd = new Random(Guid.NewGuid().GetHashCode());
-                        int choice = rnd.Next(0, files.Length - 1);
-                        string soundFile = files[choice];
-                        if (soundFile.EndsWith(".wav") | soundFile.EndsWith(".flac") | soundFile.EndsWith(".mp3") | soundFile.EndsWith(".aiff") | soundFile.EndsWith(".ogg") | soundFile.EndsWith(".opus")) {
-                            var p = new Process();
-                            p.StartInfo = new ProcessStartInfo(soundFile) {
-                                UseShellExecute = true
-                            };
-                            p.Start();
-                        }
+            var portAudio = new Audio.PortAudioOutput();
+            if (viewModel.Singer != null) {
+                var sample = viewModel.Singer.Sample;
+                if (sample != null && File.Exists(sample)) {
+                    var playSample = Wave.OpenFile(sample);
+                    portAudio.Init(playSample.ToSampleProvider());
+                    portAudio.Play();
+                } else {
+                    var path = viewModel.Singer.Location;
+                    string[] files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
+                    Random rnd = new Random(Guid.NewGuid().GetHashCode());
+                    int choice = rnd.Next(0, files.Length - 1);
+                    string soundFile = files[choice];
+                    if (soundFile.EndsWith(".wav") || soundFile.EndsWith(".mp3") || soundFile.EndsWith(".aiff") || soundFile.EndsWith(".flac") || soundFile.EndsWith(".ogg") || soundFile.EndsWith(".opus")) {
+                        var playSound = Wave.OpenFile(soundFile);
+                        portAudio.Init(playSound.ToSampleProvider());
+                        portAudio.Play();
                     }
                 }
             }

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -204,11 +204,11 @@ namespace OpenUtau.App.Views {
                     waveOut.Play();
                 } else {
                     var path = viewModel.Singer.Location;
-                    string[] files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
+                    string[] files = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).ToArray();
                     Random rnd = new Random(Guid.NewGuid().GetHashCode());
-                    int choice = rnd.Next(0, files.Length - 1);
+                    int choice = rnd.Next(0, files.Length);
                     string soundFile = files[choice];
-                    if (soundFile.EndsWith(".wav") || soundFile.EndsWith(".mp3") || soundFile.EndsWith(".aiff") || soundFile.EndsWith(".flac") || soundFile.EndsWith(".ogg") || soundFile.EndsWith(".opus")) {
+                    if (soundFile.EndsWith(".wav") | soundFile.EndsWith(".flac") | soundFile.EndsWith(".mp3") | soundFile.EndsWith(".aiff") | soundFile.EndsWith(".ogg") | soundFile.EndsWith(".opus")) {
                         var playSound = Wave.OpenFile(soundFile);
                         waveOut.Init(playSound);
                         waveOut.Play();

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -114,6 +114,11 @@ namespace OpenUtau.App.Views {
             var dialog = new EditSubbanksDialog();
             dialog.ViewModel.SetSinger(viewModel.Singer!);
             dialog.RefreshSinger = () => viewModel.RefreshSinger();
+            var playBack = PlaybackManager.Inst.AudioOutput;
+            var playbackState = playBack.PlaybackState;
+            if (playbackState == PlaybackState.Playing) {
+                playBack.Stop();
+            }
             await dialog.ShowDialog(this);
         }
 

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -196,10 +196,10 @@ namespace OpenUtau.App.Views {
 
         public void OnPlaySample(object sender, RoutedEventArgs e) {
             var viewModel = (DataContext as SingersViewModel)!;
-            var waveOut = new NAudio.Wave.WaveOutEvent();
             if (OS.IsWindows()) {
                 if (viewModel.Singer != null) {
                     var sample = viewModel.Singer.Sample;
+                    var waveOut = new NAudio.Wave.WaveOutEvent();
                     if (sample != null && File.Exists(sample)) {
                         var playSample = Wave.OpenFile(sample);
                         waveOut.Init(playSample);

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -196,22 +197,48 @@ namespace OpenUtau.App.Views {
         public void OnPlaySample(object sender, RoutedEventArgs e) {
             var viewModel = (DataContext as SingersViewModel)!;
             var waveOut = new WaveOutEvent();
-            if (viewModel.Singer != null) {
-                var sample = viewModel.Singer.Sample;
-                if (sample != null && File.Exists(sample)) {
-                    var playSample = Wave.OpenFile(sample);
-                    waveOut.Init(playSample);
-                    waveOut.Play();
-                } else {
-                    var path = viewModel.Singer.Location;
-                    string[] files = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).ToArray();
-                    Random rnd = new Random(Guid.NewGuid().GetHashCode());
-                    int choice = rnd.Next(0, files.Length - 1);
-                    string soundFile = files[choice];
-                    if (soundFile.EndsWith(".wav") | soundFile.EndsWith(".flac") | soundFile.EndsWith(".mp3") | soundFile.EndsWith(".aiff") | soundFile.EndsWith(".ogg") | soundFile.EndsWith(".opus")) {
-                        var playSound = Wave.OpenFile(soundFile);
-                        waveOut.Init(playSound);
+            if (OS.IsWindows()) {
+                if (viewModel.Singer != null) {
+                    var sample = viewModel.Singer.Sample;
+                    if (sample != null && File.Exists(sample)) {
+                        var playSample = Wave.OpenFile(sample);
+                        waveOut.Init(playSample);
                         waveOut.Play();
+                    } else {
+                        var path = viewModel.Singer.Location;
+                        string[] files = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).ToArray();
+                        Random rnd = new Random(Guid.NewGuid().GetHashCode());
+                        int choice = rnd.Next(0, files.Length - 1);
+                        string soundFile = files[choice];
+                        if (soundFile.EndsWith(".wav") | soundFile.EndsWith(".flac") | soundFile.EndsWith(".mp3") | soundFile.EndsWith(".aiff") | soundFile.EndsWith(".ogg") | soundFile.EndsWith(".opus")) {
+                            var playSound = Wave.OpenFile(soundFile);
+                            waveOut.Init(playSound);
+                            waveOut.Play();
+                        }
+                    }
+                }
+            } else {
+                if (viewModel.Singer != null) {
+                    var sample = viewModel.Singer.Sample;
+                    if (File.Exists(sample)) {
+                        var p = new Process();
+                        p.StartInfo = new ProcessStartInfo(sample) {
+                            UseShellExecute = true
+                        };
+                        p.Start();
+                    } else {
+                        var path = viewModel.Singer.Location;
+                        string[] files = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories).ToArray();
+                        Random rnd = new Random(Guid.NewGuid().GetHashCode());
+                        int choice = rnd.Next(0, files.Length - 1);
+                        string soundFile = files[choice];
+                        if (soundFile.EndsWith(".wav") | soundFile.EndsWith(".flac") | soundFile.EndsWith(".mp3") | soundFile.EndsWith(".aiff") | soundFile.EndsWith(".ogg") | soundFile.EndsWith(".opus")) {
+                            var p = new Process();
+                            p.StartInfo = new ProcessStartInfo(soundFile) {
+                                UseShellExecute = true
+                            };
+                            p.Start();
+                        }
                     }
                 }
             }

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -119,6 +119,11 @@ namespace OpenUtau.App.Views {
 
         void OnSelectedSingerChanged(object sender, SelectionChangedEventArgs e) {
             OtoPlot.WaveFile = null;
+            var playBack = PlaybackManager.Inst.AudioOutput;
+            var playbackState = playBack.PlaybackState;
+            if (playbackState == PlaybackState.Playing) {
+                playBack.Stop();
+            }
         }
 
         void OnSelectedOtoChanged(object sender, SelectionChangedEventArgs e) {

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -206,7 +206,7 @@ namespace OpenUtau.App.Views {
                     var path = viewModel.Singer.Location;
                     string[] files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
                     Random rnd = new Random(Guid.NewGuid().GetHashCode());
-                    int choice = rnd.Next(0, files.Length);
+                    int choice = rnd.Next(0, files.Length - 1);
                     string soundFile = files[choice];
                     if (soundFile.EndsWith(".wav") || soundFile.EndsWith(".mp3") || soundFile.EndsWith(".aiff") || soundFile.EndsWith(".flac") || soundFile.EndsWith(".ogg") || soundFile.EndsWith(".opus")) {
                         var playSound = Wave.OpenFile(soundFile);

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -214,21 +214,21 @@ namespace OpenUtau.App.Views {
                     }
                 } else {
                     var path = viewModel.Singer.Location;
-                    string[] files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
+                    string[] files = Directory.EnumerateFiles(path, "*.wav", SearchOption.AllDirectories)
+                            .Union(Directory.EnumerateFiles(path, "*.mp3", SearchOption.AllDirectories))
+                            .Union(Directory.EnumerateFiles(path, "*.flac", SearchOption.AllDirectories))
+                            .Union(Directory.EnumerateFiles(path, "*.aiff", SearchOption.AllDirectories))
+                            .Union(Directory.EnumerateFiles(path, "*.ogg", SearchOption.AllDirectories))
+                            .Union(Directory.EnumerateFiles(path, "*.opus", SearchOption.AllDirectories))
+                            .ToArray();
                     Random rnd = new Random(Guid.NewGuid().GetHashCode());
                     int choice = rnd.Next(0, files.Length - 1);
-                    string[] extensions = new[] { "wav", "mp3", "flac", "aiff", "ogg", "opus" };
-                    var extension = Path.GetExtension(path);
                     string soundFile = files[choice];
-                    foreach (var ext in extensions) {
-                        if (ext.Contains(extension) && soundFile.EndsWith(ext)) {
-                            var playSound = Wave.OpenFile(soundFile);
-                            playBack.Init(playSound.ToSampleProvider());
-                            playBack.Play();
-                            if (playbackState == PlaybackState.Playing) {
-                                playBack.Stop();
-                            }
-                        }
+                    var playSound = Wave.OpenFile(soundFile);
+                    playBack.Init(playSound.ToSampleProvider());
+                    playBack.Play();
+                    if (playbackState == PlaybackState.Playing) {
+                        playBack.Stop();
                     }
                 }
             }


### PR DESCRIPTION
This adds a button to play the sample file of a voicebank (doesn't have to be a wav file, as long as it's a supported audio format). If a sample is not configured, it will play a random file from the voicebank folder (including subfolders). Upon clicking the button again and/or when the Singer window is closed, the sample will stop playing. It will also stop playing upon switching the singer and when opening the Voice Color menu.

This PR also adds support for reading AIFF audio files; I had coded this extension into the sample player, only to find out that OpenUtau did not support it (which is why the two are combined in one PR). Some known UTAU-compatible voicebanks (such as the old Macloids) are known to use AIFF as their audio format of choice; since it's a common format on Mac (and is supported on other platforms as well), I decided it was a good idea to make OpenUtau support it. This will aid cross-platform support. (Only a few resamplers support AIFF, but this is up to the end user.)

[Short demonstration video with sound](https://drive.google.com/file/d/1zAVLMtrKWzCa6vqa3Zu92aILoHF7KkuA/view?usp=sharing)

[Randomized audio file demonstration](https://drive.google.com/file/d/1ttYhCcJpUoH11JBz3FWMcOcvLNoMLJrI/view?usp=sharing)