### PR TITLE
Add github codespace support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+"name": "openutau-devcontainer",
+"image": "mcr.microsoft.com/devcontainers/dotnet:6.0",  // Any generic, debian-based image.
+"features": {
+    "ghcr.io/devcontainers/features/desktop-lite:1": {}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,7 @@
-"name": "openutau-devcontainer",
-"image": "mcr.microsoft.com/devcontainers/dotnet:6.0",  // Any generic, debian-based image.
-"features": {
-    "ghcr.io/devcontainers/features/desktop-lite:1": {}
+{
+    "name": "openutau-devcontainer",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:6.0",  // Any generic, debian-based image.
+    "features": {
+        "ghcr.io/devcontainers/features/desktop-lite:1": {}
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,12 @@
     "image": "mcr.microsoft.com/devcontainers/dotnet:6.0",  // Any generic, debian-based image.
     "features": {
         "ghcr.io/devcontainers/features/desktop-lite:1": {}
-    }
+    },
+    "customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csdevkit"
+			]
+		}
+	}
 }


### PR DESCRIPTION
After this change, developers without a Linux device can develop on Github codespace's online Linux environment.