### PR TITLE
editing macro: Insert slur lyric

### DIFF
--- a/OpenUtau.Core/Editing/LyricBatchEdits.cs
+++ b/OpenUtau.Core/Editing/LyricBatchEdits.cs
@@ -170,4 +170,31 @@ namespace OpenUtau.Core.Editing {
             }
         }
     }
+
+    public class InsertSlur : BatchEdit{
+        public virtual string Name => name;
+        private string name;
+
+        public InsertSlur() {
+            name = "pianoroll.menu.lyrics.insertslur";
+        }
+
+        public void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager) {
+            if(selectedNotes.Count == 0){
+                return;
+            }
+            var startPos = selectedNotes.First().position;
+            Queue<string> lyricsQueue = new Queue<string>();
+            docManager.StartUndoGroup(true);
+            foreach(var note in part.notes.Where(n => n.position >= startPos)){
+                lyricsQueue.Enqueue(note.lyric);
+                if(selectedNotes.Contains(note)){
+                    docManager.ExecuteCmd(new ChangeNoteLyricCommand(part, note, "+~"));
+                } else {
+                    docManager.ExecuteCmd(new ChangeNoteLyricCommand(part, note, lyricsQueue.Dequeue()));
+                }
+            }
+            docManager.EndUndoGroup();
+        }
+    }
 }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -203,6 +203,7 @@
   <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">Replace "-" with "+"</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.edit">Edit Lyrics</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.hiraganatoromaji">Hiragana to Romaji</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.insertslur">Insert slur lyric</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.javcvtocv">Japanese VCV to CV</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.movesuffixtovoicecolor">Move Suffix to VoiceColor</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.removelettersuffix">Remove Letter Suffix</system:String>

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -176,6 +176,7 @@ namespace OpenUtau.App.ViewModels {
                 new MoveSuffixToVoiceColor(),
                 new RemovePhoneticHint(),
                 new DashToPlus(),
+                new InsertSlur(),
             }.Select(edit => new MenuItemViewModel() {
                 Header = ThemeManager.GetString(edit.Name),
                 Command = noteBatchEditCommand,


### PR DESCRIPTION
Lyrics available on the internet don't contain slurs. After batch inputting lyric, we often need to insert slur notes and right shift the following lyrics. 
Users can select multiple notes when running this editing macro. The lyrics of these notes will become `+~` and the lyrics of the other notes will be right shifted by the number of selected notes before them.
![image](https://github.com/stakira/OpenUtau/assets/54425948/1636cc96-30e8-4996-b747-8b08f6530bdd)
