### PR TITLE
[Portrait height] Set default int to 0 (no default height if below 800px)

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankConfig.cs
+++ b/OpenUtau.Core/Classic/VoicebankConfig.cs
@@ -41,7 +41,7 @@ namespace OpenUtau.Classic {
         public string Image;
         public string Portrait;
         public float PortraitOpacity = 0.67f;
-        public int PortraitHeight = 800;
+        public int PortraitHeight = 0;
         public string Author;
         public string Voice;
         public string Web;

--- a/OpenUtau.Core/Vogen/VogenSingerLoader.cs
+++ b/OpenUtau.Core/Vogen/VogenSingerLoader.cs
@@ -20,7 +20,7 @@ namespace OpenUtau.Core.Vogen {
         public string avatar;
         public string portrait;
         public float portraitOpacity = 0.67f;
-        public int portraitHeight = 800;
+        public int portraitHeight = 0;
         public string web;
         public string misc;
     }


### PR DESCRIPTION
Right now, the default ``int`` value is 800, which is not ideal for portraits that are smaller in height. This fixes it so that their actual height is used, if not defined otherwise.