### PR TITLE
Add import / export prefix.map

### DIFF
--- a/OpenUtau/FilePicker.cs
+++ b/OpenUtau/FilePicker.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
@@ -37,6 +39,9 @@ namespace OpenUtau.App {
         };
         public static FilePickerFileType APP { get; } = new("APP") {
             Patterns = new[] { "*.app" },
+        };
+        public static FilePickerFileType PrefixMap { get; } = new("Prefix Map") {
+            Patterns = new[] { "*.map" },
         };
 
         public async static Task<string?> OpenFile(
@@ -88,13 +93,24 @@ namespace OpenUtau.App {
                 ?.FirstOrDefault();
         }
 
-        public async static Task<string?> SaveFile(
-            Window window, string titleKey, params FilePickerFileType[] types) {
+        public async static Task<string?> SaveFile
+            (Window window, string titleKey, params FilePickerFileType[] types) {
+            return await SaveFile(window, titleKey, null, null, types);
+        }
+
+        public async static Task<string?> SaveFile
+            (Window window, string titleKey, string? startLocation, string? filename, params FilePickerFileType[] types) {
+            var location = startLocation == null
+                ? null
+                : await window.StorageProvider.TryGetFolderFromPathAsync(startLocation);
+
             var file = await window.StorageProvider.SaveFilePickerAsync(
                  new FilePickerSaveOptions {
                      Title = ThemeManager.GetString(titleKey),
                      FileTypeChoices = types,
                      ShowOverwritePrompt = true,
+                     SuggestedStartLocation = location,
+                     SuggestedFileName = filename,
                  });
             return file?.TryGetLocalPath();
         }

--- a/OpenUtau/FilePicker.cs
+++ b/OpenUtau/FilePicker.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -378,6 +378,8 @@
   <system:String x:Key="singers.subbanks.color.remove">Remove Color</system:String>
   <system:String x:Key="singers.subbanks.color.rename">Rename</system:String>
   <system:String x:Key="singers.subbanks.edit">Edit Subbanks</system:String>
+  <system:String x:Key="singers.subbanks.export">Export prefix.map</system:String>
+  <system:String x:Key="singers.subbanks.import">Import prefix.map</system:String>
   <system:String x:Key="singers.subbanks.reset">Reset</system:String>
   <system:String x:Key="singers.subbanks.save">Save</system:String>
   <system:String x:Key="singers.subbanks.selectall">Select All</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -361,6 +361,8 @@
   <system:String x:Key="singers.subbanks.color.remove">Colorを削除</system:String>
   <system:String x:Key="singers.subbanks.color.rename">名前を変更</system:String>
   <system:String x:Key="singers.subbanks.edit">サブバンクを編集</system:String>
+  <system:String x:Key="singers.subbanks.export">prefix.mapをエクスポート</system:String>
+  <system:String x:Key="singers.subbanks.import">prefix.mapをインポート</system:String>
   <system:String x:Key="singers.subbanks.reset">リセット</system:String>
   <system:String x:Key="singers.subbanks.save">保存</system:String>
   <system:String x:Key="singers.subbanks.selectall">すべて選択</system:String>

--- a/OpenUtau/ViewModels/EditSubbanksViewModel.cs
+++ b/OpenUtau/ViewModels/EditSubbanksViewModel.cs
@@ -69,7 +69,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public string Prefix { get; set; }
         [Reactive] public string Suffix { get; set; }
 
-        public USinger? singer;
+        public USinger? Singer { get; private set; }
 
         public EditSubbanksViewModel() {
             Colors = new ObservableCollectionExtended<VoiceColor>();
@@ -83,18 +83,18 @@ namespace OpenUtau.App.ViewModels {
         }
 
         public void SetSinger(USinger singer) {
-            this.singer = singer;
+            this.Singer = singer;
             LoadSubbanks();
         }
 
         public void LoadSubbanks() {
-            if (singer == null) {
+            if (Singer == null) {
                 return;
             }
             try {
                 Colors.Clear();
                 var colors = new Dictionary<string, List<Subbank>>();
-                foreach (var subbank in singer.Subbanks) {
+                foreach (var subbank in Singer.Subbanks) {
                     if (!colors.TryGetValue(subbank.Color ?? string.Empty, out var subbanks)) {
                         subbanks = new List<Subbank>();
                         colors[subbank.Color ?? string.Empty] = subbanks;
@@ -161,10 +161,10 @@ namespace OpenUtau.App.ViewModels {
         }
 
         public void SaveSubbanks() {
-            if (singer == null) {
+            if (Singer == null) {
                 return;
             }
-            var yamlFile = Path.Combine(singer.Location, "character.yaml");
+            var yamlFile = Path.Combine(Singer.Location, "character.yaml");
             VoicebankConfig? bankConfig = null;
             try {
                 // Load from character.yaml

--- a/OpenUtau/ViewModels/EditSubbanksViewModel.cs
+++ b/OpenUtau/ViewModels/EditSubbanksViewModel.cs
@@ -69,7 +69,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public string Prefix { get; set; }
         [Reactive] public string Suffix { get; set; }
 
-        private USinger? singer;
+        public USinger? singer;
 
         public EditSubbanksViewModel() {
             Colors = new ObservableCollectionExtended<VoiceColor>();

--- a/OpenUtau/Views/EditSubbanksDialog.axaml
+++ b/OpenUtau/Views/EditSubbanksDialog.axaml
@@ -12,8 +12,8 @@
         ExtendClientAreaToDecorationsHint="False">
   <Grid ColumnDefinitions="*,10,160" Margin="10">
     <DataGrid Name="SuffixGrid" Grid.Column="0" SelectionMode="Extended" IsReadOnly="True"
-              CanUserReorderColumns="False" CanUserSortColumns="False"
-              ItemsSource="{Binding Rows}" AutoGenerateColumns="False">
+              CanUserReorderColumns="False" CanUserSortColumns="False" AutoGenerateColumns="False"
+              ItemsSource="{Binding Rows}" SelectionChanged="OnSelectionChanged">
       <DataGrid.Columns>
         <DataGridTextColumn Header="{StaticResource singers.subbanks.tone}" Width="*" Binding="{Binding Tone}"/>
         <DataGridTextColumn Header="{StaticResource oto.prefix}" Width="*" Binding="{Binding Prefix}"/>
@@ -39,10 +39,12 @@
           <TextBox Margin="0,4" Text="{Binding Suffix}"/>
           <Button Content="{DynamicResource singers.subbanks.set}" HorizontalAlignment="Stretch" Click="OnSet"/>
           <Button Content="{DynamicResource singers.subbanks.clear}" HorizontalAlignment="Stretch" Click="OnClear"/>
+          <Button Content="{DynamicResource singers.subbanks.import}" HorizontalAlignment="Stretch" Click="OnImportMap"/>
         </StackPanel>
         <StackPanel VerticalAlignment="Bottom" Grid.Row="4">
           <Button Content="{DynamicResource singers.subbanks.reset}" HorizontalAlignment="Stretch" Command="{Binding LoadSubbanks}"/>
           <Button Content="{DynamicResource singers.subbanks.save}" HorizontalAlignment="Stretch" Click="OnSave"/>
+          <Button Content="{DynamicResource singers.subbanks.export}" HorizontalAlignment="Stretch" Click="OnExportMap"/>
           <Button Content="{DynamicResource singers.subbanks.cancel}" Margin="0,4,0,0" HorizontalAlignment="Stretch" Click="OnCancel"/>
         </StackPanel>
       </Grid>

--- a/OpenUtau/Views/EditSubbanksDialog.axaml.cs
+++ b/OpenUtau/Views/EditSubbanksDialog.axaml.cs
@@ -1,8 +1,14 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+using SharpCompress.Common;
+using Tmds.DBus.Protocol;
 
 namespace OpenUtau.App.Views {
     public partial class EditSubbanksDialog : Window {
@@ -58,6 +64,59 @@ namespace OpenUtau.App.Views {
 
         void OnClear(object sender, RoutedEventArgs e) {
             ViewModel.Clear(SuffixGrid.SelectedItems);
+        }
+
+        async void OnImportMap(object sender, RoutedEventArgs args) {
+            if (ViewModel.singer == null || ViewModel.Rows == null) {
+                return;
+            }
+            var file = await FilePicker.OpenFile(this, "singers.subbanks.import", ViewModel.singer.Location, FilePicker.PrefixMap);
+            if (!string.IsNullOrEmpty(file)) {
+                try {
+                    using (var reader = new StreamReader(file, Encoding.GetEncoding("shift_jis"))) {
+                        while (reader.Peek() != -1) {
+                            var line = reader.ReadLine()!.Trim();
+                            var s = line.Split('\t');
+                            if (s.Length == 3) {
+                                var row = ViewModel.Rows.First(row => row.Tone == s[0]);
+                                if(row != null) {
+                                    row.Prefix = s[1];
+                                    row.Suffix = s[2];
+                                }
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("Failed to save prefix map", e));
+                }
+            }
+        }
+
+        async void OnExportMap(object sender, RoutedEventArgs args) {
+            if (ViewModel.singer == null) {
+                return;
+            }
+            if (ViewModel.Colors.Count > 0 && ViewModel.Colors.First(c => c.Name == string.Empty) is VoiceColor main) {
+                var file = await FilePicker.SaveFile(this, "singers.subbanks.export", ViewModel.singer.Location, "prefix.map", FilePicker.PrefixMap);
+                if (!string.IsNullOrEmpty(file)) {
+                    try {
+                        using (var writer = new StreamWriter(file, false, Encoding.GetEncoding("shift_jis"))) {
+                            foreach (var row in main.Rows) {
+                                writer.WriteLine($"{row.Tone}\t{row.Prefix}\t{row.Suffix}");
+                            }
+                        }
+                    } catch (Exception e) {
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("Failed to save prefix map", e));
+                    }
+                }
+            }
+        }
+
+        void OnSelectionChanged(object sender, SelectionChangedEventArgs e) {
+            if(SuffixGrid.SelectedItems.Count > 0 && SuffixGrid.SelectedItems[0] is VoiceColorRow row) {
+                ViewModel.Prefix = row.Prefix;
+                ViewModel.Suffix = row.Suffix;
+            }
         }
 
         protected override void OnClosed(EventArgs e) {

--- a/OpenUtau/Views/EditSubbanksDialog.axaml.cs
+++ b/OpenUtau/Views/EditSubbanksDialog.axaml.cs
@@ -84,7 +84,7 @@ namespace OpenUtau.App.Views {
                         }
                     }
                 } catch (Exception e) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("Failed to save prefix map", e));
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("Failed to load prefix map", e));
                 }
             }
         }

--- a/OpenUtau/Views/EditSubbanksDialog.axaml.cs
+++ b/OpenUtau/Views/EditSubbanksDialog.axaml.cs
@@ -6,9 +6,6 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
-using OpenUtau.Core.Ustx;
-using SharpCompress.Common;
-using Tmds.DBus.Protocol;
 
 namespace OpenUtau.App.Views {
     public partial class EditSubbanksDialog : Window {
@@ -67,10 +64,10 @@ namespace OpenUtau.App.Views {
         }
 
         async void OnImportMap(object sender, RoutedEventArgs args) {
-            if (ViewModel.singer == null || ViewModel.Rows == null) {
+            if (ViewModel.Singer == null || ViewModel.Rows == null) {
                 return;
             }
-            var file = await FilePicker.OpenFile(this, "singers.subbanks.import", ViewModel.singer.Location, FilePicker.PrefixMap);
+            var file = await FilePicker.OpenFile(this, "singers.subbanks.import", ViewModel.Singer.Location, FilePicker.PrefixMap);
             if (!string.IsNullOrEmpty(file)) {
                 try {
                     using (var reader = new StreamReader(file, Encoding.GetEncoding("shift_jis"))) {
@@ -93,11 +90,11 @@ namespace OpenUtau.App.Views {
         }
 
         async void OnExportMap(object sender, RoutedEventArgs args) {
-            if (ViewModel.singer == null) {
+            if (ViewModel.Singer == null) {
                 return;
             }
             if (ViewModel.Colors.Count > 0 && ViewModel.Colors.First(c => c.Name == string.Empty) is VoiceColor main) {
-                var file = await FilePicker.SaveFile(this, "singers.subbanks.export", ViewModel.singer.Location, "prefix.map", FilePicker.PrefixMap);
+                var file = await FilePicker.SaveFile(this, "singers.subbanks.export", ViewModel.Singer.Location, "prefix.map", FilePicker.PrefixMap);
                 if (!string.IsNullOrEmpty(file)) {
                     try {
                         using (var writer = new StreamWriter(file, false, Encoding.GetEncoding("shift_jis"))) {


### PR DESCRIPTION
New Features:
- Export main voice color as prefix.map
- Import prefix.map and set it to the current field
Useful when adding new voice color.
- Reflect current value in text box when selecting rows
If multiple rows are selected, the first row is used.
![image](https://github.com/stakira/OpenUtau/assets/130257355/5aef6ddf-23c6-48f0-83b2-4d39b925c050)
