### PR TITLE
fix openutau crash when trying to play sample for enunu or vogen singer

### DIFF
--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -245,6 +245,9 @@ namespace OpenUtau.App.Views {
                     }
                 } else {
                     var path = viewModel.Singer.Location;
+                    if(!Directory.Exists(path)){
+                        return;
+                    }
                     string[] files = Directory.EnumerateFiles(path, "*.wav", SearchOption.AllDirectories)
                             .Union(Directory.EnumerateFiles(path, "*.mp3", SearchOption.AllDirectories))
                             .Union(Directory.EnumerateFiles(path, "*.flac", SearchOption.AllDirectories))
@@ -252,6 +255,9 @@ namespace OpenUtau.App.Views {
                             .Union(Directory.EnumerateFiles(path, "*.ogg", SearchOption.AllDirectories))
                             .Union(Directory.EnumerateFiles(path, "*.opus", SearchOption.AllDirectories))
                             .ToArray();
+                    if(files.Length==0){
+                        return;
+                    }
                     Random rnd = new Random(Guid.NewGuid().GetHashCode());
                     int choice = rnd.Next(0, files.Length - 1);
                     string soundFile = files[choice];


### PR DESCRIPTION
Before this fix, if the voicebank location isn't a folder (vogen), or the voicebank doesn't contain any audio file (nnsvs), openutau will crash.