### PR TITLE
Editing macro: Reset phoneme aliases

### DIFF
--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -287,6 +287,29 @@ namespace OpenUtau.Core.Editing {
         }
     }
 
+    public class ResetAliases : BatchEdit {
+        public virtual string Name => name;
+
+        private string name;
+
+        public ResetAliases() {
+            name = "pianoroll.menu.notes.reset.aliases";
+        }
+
+        public void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager) {
+            var notes = selectedNotes.Count > 0 ? selectedNotes : part.notes.ToList();
+            docManager.StartUndoGroup(true);
+            foreach (var note in notes) {
+                foreach (var o in note.phonemeOverrides) {
+                    if (o.phoneme!=null) {
+                        docManager.ExecuteCmd(new ChangePhonemeAliasCommand(part, note, o.index, null));
+                    }
+                }
+            }
+            docManager.EndUndoGroup();
+        }
+    }
+
     public class LengthenCrossfade : BatchEdit {
         public virtual string Name => name;
         private string name;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -225,6 +225,7 @@
   <system:String x:Key="pianoroll.menu.notes.quantize15">Quantize to 1/128</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize30">Quantize to 1/64</system:String>
   <system:String x:Key="pianoroll.menu.notes.autolegato">Auto Legato</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.aliases">Reset phoneme aliases</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.exps">Reset all expressions</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">Reset phoneme timings</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">Reset pitch bends</system:String>

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -161,6 +161,7 @@ namespace OpenUtau.App.ViewModels {
                 new ClearVibratos(),
                 new ResetVibratos(),
                 new ClearTimings(),
+                new ResetAliases(),
                 new BakePitch(),
             }.Select(edit => new MenuItemViewModel() {
                 Header = ThemeManager.GetString(edit.Name),


### PR DESCRIPTION
This PR adds an editing macro to reset all the manual phoneme aliases edits.
![image](https://github.com/stakira/OpenUtau/assets/54425948/354ef650-c164-4b00-8258-4a760076177d)
