### PR TITLE
fix piano roll keyboard shortcuts blocking text box input

### DIFF
--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -835,14 +835,6 @@ namespace OpenUtau.App.Views {
         #endregion
 
         void OnKeyDown(object sender, KeyEventArgs args) {
-            if (LyricBox != null && LyricBox.IsVisible) {
-                args.Handled = false;
-                return;
-            }
-            if (SearchBar != null && SearchBar.IsVisible && SearchBar.box.IsFocused) {
-                args.Handled = false;
-                return;
-            }
             var notesVm = ViewModel.NotesViewModel;
             if (notesVm.Part == null) {
                 args.Handled = false;

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -849,6 +849,13 @@ namespace OpenUtau.App.Views {
                 return;
             }
 
+            if (FocusManager != null && FocusManager.GetFocusedElement() is TextBox focusedTextBox) {
+                if (focusedTextBox.IsEnabled && focusedTextBox.IsEffectivelyVisible && focusedTextBox.IsFocused) {
+                    args.Handled = false;
+                    return;
+                }
+            }
+
             // returns true if handled
             args.Handled = OnKeyExtendedHandler(args);
         }


### PR DESCRIPTION
stops piano roll shortcuts from blocking text box input

fixes a bug in the note properties window where text box inputs get eaten by the piano roll keyboard shortcuts.

https://github.com/stakira/OpenUtau/assets/45115987/f16e7553-084a-4023-8d00-1286c3491e70



