### PR TITLE
Show location for vogen voicebank

### DIFF
--- a/OpenUtau/ViewModels/SingersViewModel.cs
+++ b/OpenUtau/ViewModels/SingersViewModel.cs
@@ -223,7 +223,14 @@ namespace OpenUtau.App.ViewModels {
         public void OpenLocation() {
             try {
                 if (Singer != null) {
-                    OS.OpenFolder(Singer.Location);
+                    var location = Singer.Location;
+                    if(File.Exists(location)) {
+                        //Vogen voicebank is a singlefile
+                        OS.GotoFile(location);
+                    } else {
+                        //classic or ENUNU voicebank is a folder
+                        OS.OpenFolder(location);
+                    }
                 }
             } catch (Exception e) {
                 DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(e));


### PR DESCRIPTION
Before this change, the "Location" button doesn't work for vogen singers. After this change, when clicking on the "Location" button for vogen singers, the .vogeon file will be shown inside the system file explorer.