### PR TITLE
fix note bend entanglement when changing portamento in note properties

### DIFF
--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -264,12 +264,10 @@ namespace OpenUtau.App.ViewModels {
                 .Subscribe(value => {
                     if (value >= 2 && value <= 320) {
                         if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
-                            foreach (UNote note in selectedNotes) {
-                                var pitch = new UPitch() { snapFirst = true };
-                                pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
-                                pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
-                                DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, pitch));
-                            }
+                            var pitch = new UPitch() { snapFirst = true };
+                            pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
+                            pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
+                            DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, selectedNotes, pitch));
                         }
                     }
                 });
@@ -277,12 +275,10 @@ namespace OpenUtau.App.ViewModels {
                 .Subscribe(value => {
                     if (value >= -200 && value <= 200) {
                         if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
-                            foreach (UNote note in selectedNotes) {
-                                var pitch = new UPitch() { snapFirst = true };
-                                pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
-                                pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
-                                DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, pitch));
-                            }
+                            var pitch = new UPitch() { snapFirst = true };
+                            pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
+                            pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
+                            DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, selectedNotes, pitch));
                         }
                     }
                 });

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -264,10 +264,10 @@ namespace OpenUtau.App.ViewModels {
                 .Subscribe(value => {
                     if (value >= 2 && value <= 320) {
                         if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
-                            var pitch = new UPitch() { snapFirst = true };
-                            pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
-                            pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
                             foreach (UNote note in selectedNotes) {
+                                var pitch = new UPitch() { snapFirst = true };
+                                pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
+                                pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
                                 DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, pitch));
                             }
                         }
@@ -277,10 +277,10 @@ namespace OpenUtau.App.ViewModels {
                 .Subscribe(value => {
                     if (value >= -200 && value <= 200) {
                         if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
-                            var pitch = new UPitch() { snapFirst = true };
-                            pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
-                            pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
                             foreach (UNote note in selectedNotes) {
+                                var pitch = new UPitch() { snapFirst = true };
+                                pitch.AddPoint(new PitchPoint(PortamentoStart, 0));
+                                pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0));
                                 DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, pitch));
                             }
                         }


### PR DESCRIPTION
fixes a bug where note bends become "entangled" when changing portamento properties in the note properties window

https://github.com/stakira/OpenUtau/assets/45115987/597a501d-ac11-498b-a3b4-e0db6c58f529

