### PR TITLE
ctrl-click to add note into selection without deselecting the other notes

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -511,17 +511,24 @@ namespace OpenUtau.App.ViewModels {
         }
 
         public void ToggleSelectNote(UNote note) {
+            /// <summary>
+            /// Change the selection state of a note without affecting the selection state of the other notes.
+            /// Add it to selection if it isn't selected, or deselect it if it is already selected.
+            /// </summary>
             if (Part == null) {
                 return;
             }
             if (Selection.Contains(note)) {
                 DeselectNote(note);
             } else {
-                SelectNote(note);
+                SelectNote(note, false);
             }
         }
 
         public void SelectNote(UNote note) {
+            /// <summary>
+            /// Select a note and deselect all the other notes.
+            /// </summary>
             SelectNote(note, true);
         }
         public void SelectNote(UNote note, bool deselectExisting) {


### PR DESCRIPTION
Before this change, we can't ctrl-click to select non-consecutive notes. When we ctrl-click on a unselected note, the other notes will be deselected. We can only box select all the notes between the first and the last note we want, and ctrl-click to deselect unwanted notes, and we have to do this process again if we deselected one more note by mistake.

After this change, we can ctrl-click to add note into selection without deselect the other notes, making it easier to select non-consecutive notes.