### PR TITLE
[WIP: Do not merge] Prefer VCV when using same subbank

### DIFF
--- a/OpenUtau.Test/Plugins/EnToJaTest.cs
+++ b/OpenUtau.Test/Plugins/EnToJaTest.cs
@@ -43,6 +43,9 @@ namespace OpenUtau.Plugins {
         [InlineData("ja_vcv",
             new string[] { "", "Clear", },
             new string[] { "- てA3", "e すCA3", "u とA3", "o うぉA3", "o どA3", "o ずA3" })]
+        [InlineData("ja_presamp",
+            new string[] { "", "星", },
+            new string[] { "- て_D4", "e s星_B3", "と_D4", "o うぉ_D4", "o d_D4", "ず_D4" })]
         // Colors are per-phoneme
         public void VoiceColorTest(string singerName, string[] colors, string[] aliases) {
             RunPhonemizeTest(singerName, new string[] { "test", "words" },
@@ -56,6 +59,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- てA3", "e すA3", "u てA3", "e んA3", "n RA3" })]
         [InlineData("ja_cv",
             new string[] { "て", "す", "て", "ん" })]
+        [InlineData("ja_presamp",
+            new string[] { "- て_D4", "e s_D4", "て_D4", "e n_D4" })]
         // Should have one て only, not become てえ
         public void SyllableExtendTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
@@ -69,6 +74,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- おA3", "o りゅA3", "u きゅA3", "u つA3", "u んA3", "n RA3" })]
         [InlineData("ja_cv",
             new string[] { "お", "りゅ", "きゅ", "つ", "ん" })]
+        [InlineData("ja_presamp",
+            new string[] { "- お_D4", "o りゅ_D4", "u きゅ_D4", "u つ_D4", "u n_D4" })] // preferring VCV with same tone/color
         public void SyllableSpecialClusterTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "all", "you", "cute", "soon" });
@@ -81,6 +88,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- あA3", "a すA3", "u たA3", "a うA3" })]
         [InlineData("ja_cv",
             new string[] { "あ", "す", "た", "う" })]
+        [InlineData("ja_presamp",
+            new string[] { "- あ_D4", "a s_D4", "た_D4", "a w_D4" })]
         public void SyllableClusterTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "a", "star" });
@@ -93,6 +102,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- ヴA3", "u RA3" })]
         [InlineData("ja_cv",
             new string[] { "ふ" })]
+        [InlineData("ja_presamp",
+            new string[] { "- ヴ_D4", "u R_D4" })]
         public void SyllableConditionalAltTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "vu" });
@@ -105,6 +116,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- てぃA3", "i RA3" })]
         [InlineData("ja_cv",
             new string[] { "て", "い" })]
+        [InlineData("ja_presamp",
+            new string[] { "- てぃ_D4", "i R_D4" })]
         public void SyllableExtraCvTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "tea" });
@@ -117,6 +130,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- あA3", "a RA3" })]
         [InlineData("ja_cv",
             new string[] { "あ" })]
+        [InlineData("ja_presamp",
+            new string[] { "- あ_D4", "a R_D4" })]
         public void EndingVowelTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "a" });
@@ -129,6 +144,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- えA3", "e んA3", "n RA3" })]
         [InlineData("ja_cv",
             new string[] { "え", "ん" })]
+        [InlineData("ja_presamp",
+            new string[] { "- え_D4", "e n_D4" })]
         public void EndingNasalTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "an" });
@@ -141,6 +158,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- ばA3", "a うA3", "u んA3", "n RA3" })]
         [InlineData("ja_cv",
             new string[] { "ば", "う", "ん" })]
+        [InlineData("ja_presamp",
+            new string[] { "- ば_D4", "a w_D4", "- ん_D4", "n R_D4" })] // TODO: make this nicer
         public void EndingClusterNasalTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "barn" });
@@ -153,6 +172,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- あA3", "a ぷA3" })]
         [InlineData("ja_cv",
             new string[] { "あ", "ぷ" })]
+        [InlineData("ja_presamp",
+            new string[] { "- あ_D4", "a p_D4" })]
         public void EndingSingleConsonantTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "up" });
@@ -165,6 +186,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- あA3", "a ヴA3" })]
         [InlineData("ja_cv",
             new string[] { "あ", "ふ" })]
+        [InlineData("ja_presamp",
+            new string[] { "- あ_D4", "a v_D4" })]
         public void EndingConditionalAltTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "of" });
@@ -177,6 +200,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- あA3", "a んA3", "n どA3" })]
         [InlineData("ja_cv",
             new string[] { "あ", "ん", "ど" })]
+        [InlineData("ja_presamp",
+            new string[] { "- あ_D4", "a n_D4", "ど_D4" })]
         public void EndingClusterTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "and" });
@@ -189,6 +214,8 @@ namespace OpenUtau.Plugins {
             new string[] { "- えA3", "e つA3" })]
         [InlineData("ja_cv",
             new string[] { "え", "つ" })]
+        [InlineData("ja_presamp",
+            new string[] { "- え_D4", "e ts_D4", "つ_D4" })]
         public void EndingSpecialClusterTest(string singerName, string[] aliases) {
             SameAltsTonesColorsTest(singerName, aliases,
                 new string[] { "its" });
@@ -229,6 +256,26 @@ namespace OpenUtau.Plugins {
             new string[] { "- お_C4", "o ry_C4", "りゅ_C4" })]
         public void SyllableDigraphVCTest(string[] lyrics, string[] aliases) {
             SameAltsTonesColorsTest("ja_cvvc", aliases, lyrics);
+        }
+
+        [Theory]
+        [InlineData(
+            new string[] { "you", "too" },
+            new string[] { "C4", "C4" },
+            new string[] { "", "" },
+            new string[] { "- ゆ_D4", "u とぅ_D4", "u R_D4" })] // same tone/color uses VCV
+        [InlineData(
+            new string[] { "you", "too" },
+            new string[] { "C4", "C3" },
+            new string[] { "", "" },
+            new string[] { "- ゆ_D4", "u t_D4", "とぅ_A3", "u R_A3" })] // diff tone uses CVVC
+        [InlineData(
+            new string[] { "you", "too" },
+            new string[] { "C4", "C4" },
+            new string[] { "", "波" },
+            new string[] { "- ゆ_D4", "u t波_D4", "とぅ_D4", "u R_D4" })] // diff color uses CVVC (test api misaligns colors, verify in UI)
+        public void PreferVCVTest(string[] lyrics, string[] tones, string[] colors, string[] aliases) {
+            RunPhonemizeTest("ja_presamp", lyrics, RepeatString(lyrics.Length, ""), tones, colors, aliases);
         }
 
         private void SameAltsTonesColorsTest(string singerName, string[] aliases, string[] lyrics) { 


### PR DESCRIPTION
EN to JA phonemizer
- Prefer VCV when there is 1 consonant and prev/next note use the same subbank

Syllable based phonemizer
- Add phoneme attributes to Syllable and Ending
- Add overloaded method of `AreTonesFromTheSameSubbank` which accepts voice color