### PR TITLE
singer name localization

### DIFF
--- a/OpenUtau.Core/Classic/ClassicSinger.cs
+++ b/OpenUtau.Core/Classic/ClassicSinger.cs
@@ -13,6 +13,7 @@ namespace OpenUtau.Classic {
     public class ClassicSinger : USinger {
         public override string Id => voicebank.Id;
         public override string Name => voicebank.Name;
+        public override Dictionary<string, string> LocalizedNames => voicebank.LocalizedNames;
         public override USingerType SingerType => voicebank.SingerType;
         public override string BasePath => voicebank.BasePath;
         public override string Author => voicebank.Author;

--- a/OpenUtau.Core/Classic/VoiceBank.cs
+++ b/OpenUtau.Core/Classic/VoiceBank.cs
@@ -8,6 +8,7 @@ namespace OpenUtau.Classic {
         public string BasePath;
         public string File;
         public string Name;
+        public Dictionary<string, string> LocalizedNames = new Dictionary<string, string>();
         public string Image;
         public string Portrait;
         public float PortraitOpacity;
@@ -27,6 +28,7 @@ namespace OpenUtau.Classic {
 
         public void Reload() {
             Name = null;
+            LocalizedNames.Clear();
             Image = null;
             Portrait = null;
             PortraitOpacity = 0;

--- a/OpenUtau.Core/Classic/VoicebankConfig.cs
+++ b/OpenUtau.Core/Classic/VoicebankConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using OpenUtau.Core;
 
@@ -36,6 +37,7 @@ namespace OpenUtau.Classic {
 
     public class VoicebankConfig {
         public string Name;
+        public Dictionary<string, string> LocalizedNames;
         public string SingerType;
         public string TextFileEncoding;
         public string Image;

--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -189,6 +189,11 @@ namespace OpenUtau.Classic {
             if (!string.IsNullOrWhiteSpace(bankConfig.Name)) {
                 bank.Name = bankConfig.Name;
             }
+            if (bankConfig.LocalizedNames != null) {
+                foreach (var kv in bankConfig.LocalizedNames) {
+                    bank.LocalizedNames[kv.Key] = kv.Value;
+                }
+            }
             if (!string.IsNullOrWhiteSpace(bankConfig.Image)) {
                 bank.Image = bankConfig.Image;
             }

--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -13,6 +13,7 @@ namespace OpenUtau.Core.DiffSinger {
     class DiffSingerSinger : USinger {
         public override string Id => voicebank.Id;
         public override string Name => voicebank.Name;
+        public override Dictionary<string, string> LocalizedNames => voicebank.LocalizedNames;
         public override USingerType SingerType => voicebank.SingerType;
         public override string BasePath => voicebank.BasePath;
         public override string Author => voicebank.Author;

--- a/OpenUtau.Core/Enunu/EnunuSinger.cs
+++ b/OpenUtau.Core/Enunu/EnunuSinger.cs
@@ -13,6 +13,7 @@ namespace OpenUtau.Core.Enunu {
     public class EnunuSinger : USinger {
         public override string Id => voicebank.Id;
         public override string Name => voicebank.Name;
+        public override Dictionary<string, string> LocalizedNames => voicebank.LocalizedNames;
         public override USingerType SingerType => voicebank.SingerType;
         public override string BasePath => voicebank.BasePath;
         public override string Author => voicebank.Author;

--- a/OpenUtau.Core/SingerManager.cs
+++ b/OpenUtau.Core/SingerManager.cs
@@ -38,7 +38,7 @@ namespace OpenUtau.Core {
                     .ToDictionary(g => g.Key, g => g.First());
                 SingerGroups = singers
                     .GroupBy(s => s.SingerType)
-                    .ToDictionary(s => s.Key, s => s.LocalizedOrderBy(singer => singer.Name).ToList());
+                    .ToDictionary(s => s.Key, s => s.LocalizedOrderBy(singer => singer.LocalizedName).ToList());
                 stopWatch.Stop();
                 Log.Information($"Search all singers: {stopWatch.Elapsed}");
             } catch (Exception e) {

--- a/OpenUtau.Core/Ustx/USinger.cs
+++ b/OpenUtau.Core/Ustx/USinger.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 using OpenUtau.Classic;
+using OpenUtau.Core.Util;
 
 namespace OpenUtau.Core.Ustx {
     public class UOto : INotifyPropertyChanged {
@@ -191,6 +192,7 @@ namespace OpenUtau.Core.Ustx {
 
         public virtual string Id { get; }
         public virtual string Name => name;
+        public virtual Dictionary<string, string> LocalizedNames { get; }
         public virtual USingerType SingerType { get; }
         public virtual string BasePath { get; }
         public virtual string Author { get; }
@@ -230,6 +232,23 @@ namespace OpenUtau.Core.Ustx {
         private string name;
 
         public string DisplayName { get { return Found ? name : $"[Missing] {name}"; } }
+
+        public string LocalizedName { 
+            get {
+                if(LocalizedNames == null) {
+                    return Name;
+                }
+                string language = Preferences.Default.SortingOrder;
+                if(String.IsNullOrEmpty(language)){
+                    language = Preferences.Default.Language;
+                }
+                if(LocalizedNames.TryGetValue(language, out var localizedName)){
+                    return localizedName;
+                } else {
+                    return Name;
+                }
+            }
+        }
 
         public virtual void EnsureLoaded() { }
         public virtual void Reload() { }

--- a/OpenUtau.Core/Vogen/VogenSinger.cs
+++ b/OpenUtau.Core/Vogen/VogenSinger.cs
@@ -8,6 +8,7 @@ namespace OpenUtau.Core.Vogen {
     class VogenSinger : USinger {
         public override string Id => meta.id;
         public override string Name => meta.name;
+        public override Dictionary<string, string> LocalizedNames => new Dictionary<string, string>();
         public override USingerType SingerType => USingerType.Vogen;
         public override string BasePath => basePath;
         public override string Author => meta.builtBy;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -293,7 +293,7 @@
   <system:String x:Key="prefs.appearance.lang">Language</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>
   <system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>
-  <system:String x:Key="prefs.appearance.sortorder">Singer sorting order</system:String>
+  <system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>
   <system:String x:Key="prefs.appearance.theme">Theme</system:String>
   <system:String x:Key="prefs.appearance.theme.dark">Dark</system:String>
   <system:String x:Key="prefs.appearance.theme.light">Light</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -274,7 +274,7 @@
   <system:String x:Key="prefs.appearance.lang">语言</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">在钢琴窗上显示其他音轨的音符</system:String>
   <system:String x:Key="prefs.appearance.showportrait">在钢琴窗上显示歌手背景图</system:String>
-  <system:String x:Key="prefs.appearance.sortorder">歌手排序方式</system:String>
+  <system:String x:Key="prefs.appearance.sortorder">歌手名称显示语言</system:String>
   <system:String x:Key="prefs.appearance.theme">主题</system:String>
   <system:String x:Key="prefs.appearance.theme.dark">暗</system:String>
   <system:String x:Key="prefs.appearance.theme.light">亮</system:String>

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -247,9 +247,9 @@ namespace OpenUtau.App.ViewModels {
             items.AddRange(Preferences.Default.RecentSingers
                 .Select(id => SingerManager.Inst.Singers.Values.FirstOrDefault(singer => singer.Id == id))
                 .OfType<USinger>()
-                .LocalizedOrderBy(singer => singer.Name)
+                .LocalizedOrderBy(singer => singer.LocalizedName)
                 .Select(singer => new MenuItemViewModel() {
-                    Header = singer.Name,
+                    Header = singer.LocalizedName,
                     Command = SelectSingerCommand,
                     CommandParameter = singer,
                 }));
@@ -259,7 +259,7 @@ namespace OpenUtau.App.ViewModels {
                     Header = $"{key} ...",
                     Items = SingerManager.Inst.SingerGroups[key]
                         .Select(singer => new MenuItemViewModel() {
-                            Header = singer.Name,
+                            Header = singer.LocalizedName,
                             Command = SelectSingerCommand,
                             CommandParameter = singer,
                         }).ToArray(),

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -34,7 +34,13 @@
     </Grid.ColumnDefinitions>
     <Image Grid.Row="0" Width="100" Height="100" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,10,0,0" Source="{Binding Avatar}"/>
     <ComboBox Grid.Row="0" x:Name="name" HorizontalAlignment="Stretch" Margin="120,10,0,0" VerticalAlignment="Top"
-              ItemsSource="{Binding Singers}" SelectedItem="{Binding Singer}" SelectionChanged="OnSelectedSingerChanged"/>
+              ItemsSource="{Binding Singers}" SelectedItem="{Binding Singer}" SelectionChanged="OnSelectedSingerChanged">
+      <ComboBox.ItemTemplate>
+        <DataTemplate>
+          <TextBlock Text="{Binding LocalizedName}"/>
+        </DataTemplate>
+      </ComboBox.ItemTemplate>    
+    </ComboBox>
     <Border Grid.Row="0" Margin="120,40,0,30">
       <ScrollViewer>
         <TextBlock x:Name="info" TextWrapping="Wrap" Text="{Binding Info}"/>


### PR DESCRIPTION
This PR allows voicebank developers declare how to call their voicebanks in different languages in character.yaml. For example:

```yaml
name: Namine Ritsu
localized_names:
  ja-JP: 波音リツ
  zh-CN: 波音律
```

available language codes: `en-US`, `de-DE`, `es-ES`, `es-MX`, `fi-FI`, `fr-FR`, `id-ID`, `it-IT`, `ja-JP`, `ko-KR`, `nl-NL`, `pl-PL`, `pt-BR`, `ru-RU`, `th-TH`, `vi-VN`, `zh-CN`, `zh-TW`