### PR TITLE
[DiffSinger] Fix invalid tensor in memory when errors occur during *.emb loading

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
@@ -37,10 +37,11 @@ namespace OpenUtau.Core.DiffSinger
                 if(dsConfig.speakers == null) {
                     return null;
                 } else {
-                    speakerEmbeds = np.zeros<float>(dsConfig.hiddenSize, dsConfig.speakers.Count);
+                    var embeds = np.zeros<float>(dsConfig.hiddenSize, dsConfig.speakers.Count);
                     foreach(var spkId in Enumerable.Range(0, dsConfig.speakers.Count)) {
-                        speakerEmbeds[":", spkId] = loadSpeakerEmbed(dsConfig.speakers[spkId]);
+                        embeds[":", spkId] = loadSpeakerEmbed(dsConfig.speakers[spkId]);
                     }
+                    speakerEmbeds = embeds;
                 }
             }
             return speakerEmbeds;


### PR DESCRIPTION
In the previous implementation, when an exception is raised during loading *.emb files from disk (for example, file not found), the loop is immediately interrupted and the wrong speaker embedding tensor, which was filled with zeros at the beginning, remains in memory as a member variable. This makes DiffSinger produce wrong and noisy results.

After this fix, the embedding tensor will not be stored as member variable until all *.emb files are loaded correctly.