### PR TITLE
[DiffSinger] Fix note pitch masked unexpectedly when applying nearest interpolation

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -162,21 +162,13 @@ namespace OpenUtau.Core.DiffSinger
                 .Prepend((float)phrase.notes[0].tone)
                 .ToArray();
             //get the index of groups of consecutive rest notes
-            int restGroupStart = 0;
-            var restGroups = new List<Tuple<int,int>>{};
-            foreach(int noteIndex in Enumerable.Range(1,note_rest.Count - 1)) {
-                if(!note_rest[noteIndex-1] && note_rest[noteIndex]) {
-                    //start a new rest group
-                    restGroupStart = noteIndex;
-                }
-                if(note_rest[noteIndex-1] && !note_rest[noteIndex]) {
-                    //end the current rest group
-                    restGroups.Add(new Tuple<int,int>(restGroupStart,noteIndex));
-                }
-            }
-            if(!note_rest[^1]) {
-                //end the last rest group
-                restGroups.Add(new Tuple<int,int>(restGroupStart,note_rest.Count));
+            var restGroups = new List<Tuple<int,int>>();
+            for (var i = 0; i < note_rest.Count; ++i) {
+                if (!note_rest[i]) continue;
+                var j = i + 1;
+                for (; j < note_rest.Count && note_rest[j]; ++j) { }
+                restGroups.Add(new Tuple<int, int>(i, j));
+                i = j;
             }
             //Set tone for each rest group
             foreach(var restGroup in restGroups){


### PR DESCRIPTION
When applying nearest interpolation in some cases, the previous wrong implementation to collect index groups of continuous rest notes can unexpectedly mask non-rest note pitches. This leads to wrong results when generating DiffSinger auto-pitch.

Before this fix:
<img width="1327" alt="image" src="https://github.com/stakira/OpenUtau/assets/70186231/be2d30ba-54e9-4d08-b1da-c6caf48b7cb0">

After this fix:
<img width="1320" alt="image" src="https://github.com/stakira/OpenUtau/assets/70186231/733d29f7-8a29-4e0b-8f03-9c531f2ea26d">

**The bug affects all DiffSinger voicebanks with pitch predictor. This PR is urgent and should be merged as soon as possible.**
