### PR TITLE
Support resizing notes from their heads

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModelHitTest.cs
+++ b/OpenUtau/ViewModels/NotesViewModelHitTest.cs
@@ -12,6 +12,7 @@ namespace OpenUtau.App.ViewModels {
         public UPhoneme phoneme;
         public bool hitBody;
         public bool hitResizeArea;
+        public bool hitResizeAreaFromStart;
         public bool hitX;
     }
 
@@ -72,12 +73,17 @@ namespace OpenUtau.App.ViewModels {
                 result.note = note;
                 result.hitX = true;
                 var tone = viewModel.PointToTone(point);
-                if (tone == note.tone) {
-                    result.hitBody = true;
-                    double x = viewModel.TickToneToPoint(note.End, tone).X;
-                    result.hitResizeArea = point.X <= x && point.X > x - ViewConstants.ResizeMargin;
-                    break;
+                if (tone != note.tone) {
+                    continue;
                 }
+                result.hitBody = true;
+                double x1 = viewModel.TickToneToPoint(note.position, note.tone).X;
+                double x2 = viewModel.TickToneToPoint(note.End, tone).X;
+                var hitLeftResizeArea = point.X >= x1 && point.X < x1 + ViewConstants.ResizeMargin;
+                var hitRightResizeArea = point.X <= x2 && point.X > x2 - ViewConstants.ResizeMargin;
+                result.hitResizeAreaFromStart = hitLeftResizeArea && !hitRightResizeArea;  // prefer resizing from end
+                result.hitResizeArea = hitLeftResizeArea || hitRightResizeArea;  // hit either of the areas
+                break;
             }
             return result;
         }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -364,7 +364,8 @@ namespace OpenUtau.App.Views {
                 if (noteHitInfo.hitResizeArea) {
                     editState = new NoteResizeEditState(
                         control, ViewModel, this, noteHitInfo.note,
-                        args.KeyModifiers == KeyModifiers.Alt);
+                        args.KeyModifiers == KeyModifiers.Alt,
+                        fromStart: noteHitInfo.hitResizeAreaFromStart);
                     Cursor = ViewConstants.cursorSizeWE;
                 } else if (args.KeyModifiers == cmdKey) {
                     ViewModel.NotesViewModel.ToggleSelectNote(noteHitInfo.note);


### PR DESCRIPTION
This PR supports resizing notes from their heads.
- Each note now has two resizing areas: its tail and its head. When the two areas overlap (when the note is extremely short), the tail area is the preferred area to be regarded as hit.
- `NoteHitInfo` gets a new attribute `hitResizeAreaFromStart`. When its `hitResizeArea` is set to true, this attribute will help determine whether the note is being resized from the head or the tail.
- Attribute `resizeNext` of `NoteResizeEditState` is generalized to `resizeNeighbor` to support similar behavior when resizing with Alt pressed from either the head and the tail.
- Batch resizing (resize when there are multiple note selections) from the heads is also implemented.

Demo:

https://github.com/stakira/OpenUtau/assets/70186231/ea09fa4d-3958-4fd3-8033-43c36ce17ec1

