### PR TITLE
Don't show save dialog for new project

### DIFF
--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -118,7 +118,7 @@ namespace OpenUtau.Core {
 
         public bool ChangesSaved {
             get {
-                return (Project.Saved || Project.tracks.Count == 0) &&
+                return (Project.Saved || (Project.tracks.Count <= 1 && Project.parts.Count == 0)) &&
                     (undoQueue.Count > 0 && savedPoint == undoQueue.Last() || undoQueue.Count == 0 && savedPoint == null);
             }
         }


### PR DESCRIPTION
Fixed to not show a dialog asking to save the project when trying to close a freshly created project.