### PR TITLE
Fix TextBox font

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -458,7 +458,6 @@
   <system:String x:Key="tracks.trackcolor">Change track color</system:String>
 
   <FontFamily x:Key="ui.fontfamily">Segoe UI,San Francisco,Helvetica Neue</FontFamily>
-  <FontFamily x:Key="ui.textbox.fontfamily">Microsoft YaHei,Simsun,苹方-简,宋体-简</FontFamily>
 
   <system:String x:Key="updater.caption">Check for Update</system:String>
   <system:String x:Key="updater.description">Open singing synthesis platform</system:String>

--- a/OpenUtau/Styles/Styles.axaml
+++ b/OpenUtau/Styles/Styles.axaml
@@ -62,7 +62,6 @@
     <Setter Property="Padding" Value="4,1"/>
     <Setter Property="Margin" Value="0,0,0,4"/>
     <Setter Property="FontSize" Value="12"/>
-    <Setter Property="FontFamily" Value="{DynamicResource ui.fontfamily}"/>
     <Setter Property="VerticalAlignment" Value="Top"/>
     <Setter Property="SelectionForegroundBrush" Value="White"/>
   </Style>

--- a/OpenUtau/Styles/Styles.axaml
+++ b/OpenUtau/Styles/Styles.axaml
@@ -62,7 +62,7 @@
     <Setter Property="Padding" Value="4,1"/>
     <Setter Property="Margin" Value="0,0,0,4"/>
     <Setter Property="FontSize" Value="12"/>
-    <Setter Property="FontFamily" Value="{DynamicResource ui.textbox.fontfamily}"/>
+    <Setter Property="FontFamily" Value="{DynamicResource ui.fontfamily}"/>
     <Setter Property="VerticalAlignment" Value="Top"/>
     <Setter Property="SelectionForegroundBrush" Value="White"/>
   </Style>


### PR DESCRIPTION
The font used for the text boxes is a bit hard to read in Japanese, so changed to the same font as the text and labels.
It may depend on the environment, but it will not have any adverse effect.
This is largely a personal preference, so please merge if necessary.
![image](https://github.com/stakira/OpenUtau/assets/130257355/701ed2cf-89a6-415d-9053-477bf2b4ba71)
