### PR TITLE
Editing macro: fix overlapping notes

### DIFF
--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -142,6 +142,46 @@ namespace OpenUtau.Core.Editing {
         }
     }
 
+    public class FixOverlap: BatchEdit {
+        /// <summary>
+        /// Fix overlapping notes.
+        /// If multiple notes start at the same time, only the one with the highest tone will be kept
+        /// If one notes's end is overlapped by another note, the end will be moved to the start of the next note
+        /// </summary>
+        public virtual string Name => name;
+
+        private string name;
+
+        public FixOverlap() {
+            name = $"pianoroll.menu.notes.fixoverlap";
+        }
+
+        public void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager) {
+            var notes = selectedNotes.Count > 0 ? selectedNotes : part.notes.ToList();
+            if(notes.Count == 0){
+                return;
+            }
+            docManager.StartUndoGroup();
+            var currentNote = notes[0];
+            foreach(var note in notes.Skip(1)){
+                if(note.position == currentNote.position){
+                    if(note.tone > currentNote.tone){
+                        docManager.ExecuteCmd(new RemoveNoteCommand(part, currentNote));
+                        currentNote = note;
+                    }else{
+                        docManager.ExecuteCmd(new RemoveNoteCommand(part, note));
+                    }
+                }else if(note.position < currentNote.End){
+                    docManager.ExecuteCmd(new ResizeNoteCommand(part, currentNote, note.position - currentNote.End));
+                    currentNote = note;
+                }else{
+                    currentNote = note;
+                }
+            }
+            docManager.EndUndoGroup();
+        }
+    }
+
     public class HanziToPinyin : BatchEdit {
         public virtual string Name => name;
 

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -221,8 +221,10 @@
   <system:String x:Key="pianoroll.menu.notes">Notes</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtaildash">Add tail "-"</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtailrest">Add tail "R"</system:String>
+  <system:String x:Key="pianoroll.menu.notes.autolegato">Auto Legato</system:String>
   <system:String x:Key="pianoroll.menu.notes.bakepitch">Convert PITD to pitch control points</system:String>
   <system:String x:Key="pianoroll.menu.notes.clear.vibratos">Clear vibratos</system:String>
+  <system:String x:Key="pianoroll.menu.notes.fixoverlap">Fix overlapping notes</system:String>
   <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">Hanzi to pinyin</system:String>
   <system:String x:Key="pianoroll.menu.notes.lengthencrossfade">Lengthen crossfades</system:String>
   <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">Load rendered pitch</system:String>
@@ -230,7 +232,6 @@
   <system:String x:Key="pianoroll.menu.notes.octaveup">Move an octave up</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize15">Quantize to 1/128</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize30">Quantize to 1/64</system:String>
-  <system:String x:Key="pianoroll.menu.notes.autolegato">Auto Legato</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.aliases">Reset phoneme aliases</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.exps">Reset all expressions</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">Reset phoneme timings</system:String>

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -155,6 +155,7 @@ namespace OpenUtau.App.ViewModels {
                 new QuantizeNotes(15),
                 new QuantizeNotes(30),
                 new AutoLegato(),
+                new FixOverlap(),
                 new HanziToPinyin(),
                 new ResetPitchBends(),
                 new ResetAllExpressions(),


### PR DESCRIPTION
If multiple notes start at the same time, only the one with the highest tone will be kept
If one notes's end is overlapped by another note, the end will be moved to the start of the next note

Though similar to auto legato, this editing macro only trim notes that are too long. It won't fill up the space between notes. It will also remove the notes that start at the same time with another note but have a lower tone.

![image](https://github.com/stakira/OpenUtau/assets/54425948/a27c9341-3fab-498d-ba0f-101b7d4a9aea)

![image](https://github.com/stakira/OpenUtau/assets/54425948/ead397a0-7bf9-4c40-8747-4ea311cb1138)
