### PR TITLE
[WIP] Add oudep dependency download center

### DIFF
--- a/OpenUtau.Core/Util/WebFileDownloader.cs
+++ b/OpenUtau.Core/Util/WebFileDownloader.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace OpenUtau.Core.Util {
+    public static class WebFileDownloader {
+        /// <summary>
+        /// downloads file from [address] in web, and saves as [filename] in "Cache" folder.
+        /// returns true if file download completed successfully, otherwise false.
+        /// it's async process, so must call .Wait() when use.
+        /// </summary>
+        public static async Task DownLoadFileAsyncInCache(string address, string filename)
+        {
+            WebClient client = new WebClient();
+            Uri uri = new Uri(address);
+            bool isSuccessed = false;
+            bool isCompleted = false;
+
+            client.DownloadProgressChanged += new DownloadProgressChangedEventHandler(DownloadProgressCallback4);
+
+            await client.DownloadFileTaskAsync(uri, Path.Combine(PathManager.Inst.CachePath, filename)).ConfigureAwait(false);
+
+        }
+        
+
+        private static void DownloadProgressCallback4(object sender, DownloadProgressChangedEventArgs e)
+        {
+            // Displays the operation identifier, and the transfer progress.
+            DocManager.Inst.ExecuteCmd(new ProgressBarNotification(e.ProgressPercentage, $"Please Wait... OU is Downloading Dependency from web: {Math.Round(e.BytesReceived / Math.Pow(1024, 2), 2)}MB / {Math.Round(e.TotalBytesToReceive / Math.Pow(1024, 2), 2)}MB."));
+            
+        }
+    }
+
+}


### PR DESCRIPTION
**TODO:** 
- implement `(dependency) download center` for **all oudep dependencies**, (like in UVR & SynthV)
- Currently this is called as "download center", but if there are better name, please write a comment. 👀
- In final, it should open `download center` automatically when OU lacks specific dependency (by using exception handling), so user can select and download dependencies with ease.

<br>

**1.  Should have these features:**
   - Can show "all available dependencies' list" to user.
   - Can show status of "which dependencies are installed (or not)", like (nsf_hifigan  Uninstalled   [info]  [download]).
  **Download buttons of "already installed dependency" should be blocked, so user cannot click them.**
   - When user clicks specific dependency's download button, It should confirm to user by message window, like *"Will you download dependency XXX?(total: XXMb)"*. 
   - Can show downloaded status, like *(50% -- 50Mb/ 100Mb)*. (showing progress bar will be great for user experience)
   - Can perform more than one download at once, also OU's other process should not be blocked while downloading. (should use async process.)
>
   - Can categorize dependencies, like "Diffsinger / Vogen / ENUNU... etc." (good to use combobox)

<br>

**2. It Will use `download center.yaml` for management.**
- So **exactly** what `download center` perform is : 
    - Print dependencies' informations in `download center.yaml` into user view
    - Connect download link(in `download center.yaml`) with each dependency's download button.

<br>

**3.`download center.yaml` should contain:**
- oudep's name (like "nsf_hifigan")
- oudep's category (like "diffsinger")
- oudep's brief information (like "use when rendering diffsinger's voice...blahblah")
- oudep's file size(Mb) (like 10Mb)
- oudep's version (like 1.0.0)
- oudep's direct download link (github, google drive... anything.)