### PR TITLE
[SyllableBasedPhonemizer API] Make alias extension restriction to same subbank optional

### DIFF
--- a/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
@@ -634,8 +634,7 @@ namespace OpenUtau.Plugin.Builtin {
         /// <param name="syllable"></param>
         /// <returns></returns>
         protected bool CanMakeAliasExtension(Syllable syllable) {
-            return syllable.canAliasBeExtended && syllable.prevV == syllable.v && syllable.cc.Length == 0
-                && AreTonesFromTheSameSubbank(syllable.tone, syllable.vowelTone);
+            return syllable.canAliasBeExtended && syllable.prevV == syllable.v && syllable.cc.Length == 0;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR makes it so that aliases can now also be extended across different subbanks in syllable-based phonemizers. Note that the option to restrict it to only the same subbank has not been removed; I've simply made it so that it will be up to the phonemizer developers to decide.

The reason I am making this PR is because the current spec can cause issues when extending diphthongs in certain languages (including English) across different pitches and/or voice colors.

In order to re-implement the previous spec into a phonemizer, the code should look something like this:
```
if (CanMakeAliasExtension(syllable) && AreTonesFromTheSameSubbank(syllable.tone, syllable.vowelTone))
```
or, in negative form:
```
if (!CanMakeAliasExtension(syllable) || !AreTonesFromTheSameSubbank(syllable.tone, syllable.vowelTone))
```