### PR TITLE
Add support for a custom vocoder for DiffSinger singer

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -131,6 +131,10 @@ namespace OpenUtau.Core.DiffSinger {
 
         public DsVocoder getVocoder() {
             if(vocoder is null) {
+                if(File.Exists(Path.Join(Location, "dsvocoder", "vocoder.yaml"))) {
+                    vocoder = new DsVocoder(Path.Join(Location, "dsvocoder"));
+                    return vocoder;
+                }
                 vocoder = new DsVocoder(dsConfig.vocoder);
             }
             return vocoder;


### PR DESCRIPTION
Add support for custom vocoders for DiffSinger models. This does not overwrite the current vocoder system, but instead first checks for a "dsvocoder" folder that would contain "vocoder.yaml" and would point to an ONNX model of the vocoder IF the vocoder line in the main "dsconfig.yaml" file is null.