### PR TITLE
Make the URL in message box look like hyperlink

### DIFF
--- a/OpenUtau/Views/MessageBox.axaml
+++ b/OpenUtau/Views/MessageBox.axaml
@@ -14,6 +14,33 @@
       <RowDefinition Height="50"/>
     </Grid.RowDefinitions>
     <TextBlock Margin="20" Grid.Row="0" HorizontalAlignment="Center" VerticalAlignment="Center" Name="Text" TextWrapping="Wrap" MaxWidth="560"/>
+    <StackPanel Margin="20" Grid.Row="0" HorizontalAlignment="Center" VerticalAlignment="Center" Name="TextPanel" MaxWidth="560">
+      <StackPanel.Styles>
+        <Style Selector="TextBlock">
+          <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+        <Style Selector="Button">
+          <Setter Property="Foreground" Value="Blue" />
+          <Setter Property="Padding" Value="0" />
+          <Setter Property="Cursor" Value="Hand" />
+          <Setter Property="BorderThickness" Value="0" />
+          <Setter Property="Background" Value="Transparent" />
+          <Setter Property="Template">
+            <ControlTemplate>
+              <ContentPresenter Content="{TemplateBinding Content}">
+                <ContentPresenter.Styles>
+                  <Style Selector="TextBlock">
+                    <Setter Property="Foreground" Value="{TemplateBinding Foreground}"/>
+                    <Setter Property="FontSize" Value="{TemplateBinding FontSize}"/>
+                    <Setter Property="TextDecorations" Value="Underline"/>
+                  </Style>
+                </ContentPresenter.Styles>
+              </ContentPresenter>
+            </ControlTemplate>
+          </Setter>
+        </Style>
+      </StackPanel.Styles> 
+    </StackPanel>
     <StackPanel Grid.Row="1" HorizontalAlignment="Center" Orientation="Horizontal" Name="Buttons">
       <StackPanel.Styles>
         <Style Selector="Button">

--- a/OpenUtau/Views/MessageBox.axaml.cs
+++ b/OpenUtau/Views/MessageBox.axaml.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
+using Serilog;
 
 namespace OpenUtau.App.Views {
     public partial class MessageBox : Window {
@@ -54,7 +57,8 @@ namespace OpenUtau.App.Views {
             var msgbox = new MessageBox() {
                 Title = title
             };
-            msgbox.Text.Text = text;
+            msgbox.Text.IsVisible = false;
+            msgbox.SetTextWithLink(text, msgbox.TextPanel);
 
             var res = MessageBoxResult.Ok;
 
@@ -121,6 +125,34 @@ namespace OpenUtau.App.Views {
 
         public static bool LoadingIsActive() {
             return loadingDialog != null && loadingDialog.IsActive;
+        }
+
+        private void SetTextWithLink(string text, StackPanel textPanel) {
+            // @"http(s)?://([\w-]+\.)+[\w-]+(/[A-Z0-9-.,_/?%&=]*)?"
+            var regex = new Regex(@"(\r\n|\n| )http(s)?://[^(\r\n|\n| )]+", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            var match = regex.Match(text);
+            if (match.Success) {
+                textPanel.Children.Add(new TextBlock { Text = text.Substring(0, match.Index) });
+                var hyperlink = new Button();
+                hyperlink.Content = match.Value.Trim();
+                hyperlink.Click += OnUrlClick;
+                textPanel.Children.Add(hyperlink);
+
+                SetTextWithLink(text.Substring(match.Index + match.Length), textPanel);
+            } else {
+                if (!string.IsNullOrEmpty(text)) {
+                    textPanel.Children.Add(new TextBlock { Text = text });
+                }
+            }
+        }
+        private void OnUrlClick(object? sender, RoutedEventArgs e) {
+            try {
+                if (sender is Button button && button.Content is string url) {
+                    OS.OpenWeb(url);
+                }
+            } catch (Exception ex) {
+                Log.Error(ex, "Failed to open url");
+            }
         }
     }
 }


### PR DESCRIPTION
![image](https://github.com/stakira/OpenUtau/assets/130257355/189ec53a-f9c4-4d80-86c4-ea2561ad2cfb)

Avalonia does not support hyperlinks, so the buttons just look like that.
The URL is always preceded and followed by a new line.