### PR TITLE
Improved stability of rendering

### DIFF
--- a/OpenUtau.Core/Classic/WorldlineRenderer.cs
+++ b/OpenUtau.Core/Classic/WorldlineRenderer.cs
@@ -10,7 +10,6 @@ using OpenUtau.Core.Format;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.SignalChain;
 using OpenUtau.Core.Ustx;
-using Serilog;
 
 namespace OpenUtau.Classic {
     public class WorldlineRenderer : IRenderer {
@@ -58,12 +57,8 @@ namespace OpenUtau.Classic {
                 string progressInfo = $"Track {trackNo + 1}: {this} {string.Join(" ", phrase.phones.Select(p => p.phoneme))}";
                 progress.Complete(0, progressInfo);
                 if (File.Exists(wavPath)) {
-                    try {
-                        using (var waveStream = Wave.OpenFile(wavPath)) {
-                            result.samples = Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
-                        }
-                    } catch (Exception e) {
-                        Log.Error(e, "Failed to render.");
+                    using (var waveStream = Wave.OpenFile(wavPath)) {
+                        result.samples = Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
                     }
                 }
                 if (result.samples == null) {

--- a/OpenUtau.Core/Classic/WorldlineResampler.cs
+++ b/OpenUtau.Core/Classic/WorldlineResampler.cs
@@ -3,7 +3,6 @@ using NAudio.Wave;
 using OpenUtau.Core;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.SignalChain;
-using OpenUtau.Core.Ustx;
 using Serilog;
 
 namespace OpenUtau.Classic {

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -803,23 +803,7 @@ namespace OpenUtau.App.Views {
         }
 
         void PlayOrPause() {
-            try {
-                viewModel.PlaybackViewModel.PlayOrPause();
-            } catch (Core.Render.NoResamplerException) {
-                MessageBox.Show(
-                   this,
-                   ThemeManager.GetString("dialogs.noresampler.message"),
-                   ThemeManager.GetString("dialogs.noresampler.caption"),
-                   MessageBox.MessageBoxButtons.Ok);
-            } catch (Core.Render.NoWavtoolException) {
-                MessageBox.Show(
-                   this,
-                   ThemeManager.GetString("dialogs.noresampler.message"),
-                   ThemeManager.GetString("dialogs.noresampler.caption"),
-                   MessageBox.MessageBoxButtons.Ok);
-            } catch (Exception e) {
-                MessageBox.ShowError(this, e);
-            }
+            viewModel.PlaybackViewModel.PlayOrPause();
         }
 
         public void HScrollPointerWheelChanged(object sender, PointerWheelEventArgs args) {
@@ -1226,7 +1210,19 @@ namespace OpenUtau.App.Views {
 
         public void OnNext(UCommand cmd, bool isUndo) {
             if (cmd is ErrorMessageNotification notif) {
-                MessageBox.ShowError(this, notif.message, notif.e);
+                switch (notif.e) {
+                    case Core.Render.NoResamplerException:
+                    case Core.Render.NoWavtoolException:
+                        MessageBox.Show(
+                           this,
+                           ThemeManager.GetString("dialogs.noresampler.message"),
+                           ThemeManager.GetString("dialogs.noresampler.caption"),
+                           MessageBox.MessageBoxButtons.Ok);
+                        break;
+                    default:
+                        MessageBox.ShowError(this, notif.message, notif.e);
+                        break;
+                }
             } else if (cmd is LoadingNotification loadingNotif && loadingNotif.window == typeof(MainWindow)) {
                 if (loadingNotif.startLoading) {
                     MessageBox.ShowLoading(this);

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -930,11 +930,7 @@ namespace OpenUtau.App.Views {
                 #region document keys
                 case Key.Space:
                     if (isNone) {
-                        try {
-                            playVm.PlayOrPause();
-                        } catch (Exception e) {
-                            MessageBox.ShowError(this, e);
-                        }
+                        playVm.PlayOrPause();
                         return true;
                     }
                     break;


### PR DESCRIPTION
Changes:
- Fixed parent methods could not know exceptions handled by deep methods
- Fixed double display of error dialog due to catching and re-throwing exceptions several times
- Fixed UI thread cannot catch exceptions because playback is an asynchronous process

Verified:
- When exceptions is thrown during pre-rendering, write error in log without error dialog
- When exceptions is thrown during playback, show an error dialog and stop playback
- When exceptions is thrown during export of mixdown or tracks, show an error dialog and do not export