### PR TITLE
Fix diffsinger phoneme misplace if lyric contains space; separate diffsinger Chinese phonemizer

### DIFF
--- a/OpenUtau.Core/BaseChinesePhonemizer.cs
+++ b/OpenUtau.Core/BaseChinesePhonemizer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Core.G2p;
 using OpenUtau.Api;
@@ -19,7 +20,22 @@ namespace OpenUtau.Core {
         }
 
         public static string[] Romanize(IEnumerable<string> lyrics) {
-            return ZhG2p.MandarinInstance.Convert(lyrics.ToList(), false, true).Split(" ");
+            var lyricsArray = lyrics.ToArray();
+            var hanziLyrics = lyricsArray
+                .Where(ZhG2p.MandarinInstance.IsHanzi)
+                .ToList();
+            var pinyinResult = ZhG2p.MandarinInstance.Convert(hanziLyrics, false, false).ToLower().Split();
+            if(pinyinResult == null) {
+                return lyricsArray;
+            }
+            var pinyinIndex = 0;
+            for(int i=0; i < lyricsArray.Length; i++) {
+                if (lyricsArray[i].Length == 1 && ZhG2p.MandarinInstance.IsHanzi(lyricsArray[i])) {
+                    lyricsArray[i] = pinyinResult[pinyinIndex];
+                    pinyinIndex++;
+                }
+            }
+            return lyricsArray;
         }
 
         public static void RomanizeNotes(Note[][] groups) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerChinesePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerChinesePhonemizer.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+using OpenUtau.Api;
+
+namespace OpenUtau.Core.DiffSinger
+{
+    [Phonemizer("DiffSinger Chinese Phonemizer", "DIFFS ZH", language: "ZH")]
+    public class DiffSingerChinesePhonemizer : DiffSingerBasePhonemizer
+    {
+        protected override string[] Romanize(IEnumerable<string> lyrics) {
+            return BaseChinesePhonemizer.Romanize(lyrics);
+        }
+    }
+}

--- a/OpenUtau.Core/DiffSinger/DiffSingerG2pPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerG2pPhonemizer.cs
@@ -29,7 +29,7 @@ namespace OpenUtau.Core.DiffSinger
         }
     }
 
-    public abstract class DiffSingerG2pPhonemizer : DiffSingerPhonemizer
+    public abstract class DiffSingerG2pPhonemizer : DiffSingerBasePhonemizer
     {
         protected virtual string GetDictionaryName()=>"dsdict.yaml";
 

--- a/OpenUtau.Core/DiffSinger/DiffSingerPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPhonemizer.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-
 using OpenUtau.Api;
 
 namespace OpenUtau.Core.DiffSinger
@@ -7,8 +5,5 @@ namespace OpenUtau.Core.DiffSinger
     [Phonemizer("DiffSinger Phonemizer", "DIFFS")]
     public class DiffSingerPhonemizer : DiffSingerBasePhonemizer
     {
-        protected override string[] Romanize(IEnumerable<string> lyrics) {
-            return BaseChinesePhonemizer.Romanize(lyrics);
-        }
     }
 }

--- a/OpenUtau.Core/G2p/ZhG2p.cs
+++ b/OpenUtau.Core/G2p/ZhG2p.cs
@@ -107,6 +107,21 @@ namespace OpenUtau.Core.G2p {
             }
         }
 
+        public bool IsHanzi(string input){
+            ///<summary>
+            /// Whether the input string is a single hanzi.
+            ///</summary>
+            return WordDict.ContainsKey(input) || TransDict.ContainsKey(input);
+        }
+
+        public bool IsHanziOrNum(string input){
+            return IsHanzi(input) || NumMap.ContainsKey(input);
+        }
+
+        public bool IsHanzi(string input, bool convertNum){
+            return IsHanzi(input) || (convertNum && NumMap.ContainsKey(input));
+        }
+
         public string Convert(string input, bool tone, bool covertNum) {
             return Convert(SplitString(input), tone, covertNum);
         }


### PR DESCRIPTION
- Before this PR, if the lyric is space-separated phoneme list, the phonemizer result will be misplaced. 
![image](https://github.com/stakira/OpenUtau/assets/54425948/6c4300e4-3618-4607-b534-9ee9930f44dd)
This bug is fixed in this PR. 

- Add a separate diffsinger Chinese phonemizer and remove the hanzi to pinyin converter from the default diffsinger phonemizer to prevent similar bugs in the future.