### PR TITLE
[Help wanted] Support asynchronous batch edits

### DIFF
--- a/OpenUtau.Core/Editing/BatchEdit.cs
+++ b/OpenUtau.Core/Editing/BatchEdit.cs
@@ -1,9 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core.Editing {
     public interface BatchEdit {
         string Name { get; }
+        bool IsAsync => false;
         void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager);
+
+        void RunAsync(
+            UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager,
+            Action<int, int> setProgressCallback, CancellationToken cancellationToken) {
+            Run(project, part, selectedNotes, docManager);
+        }
     }
 }

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
 
@@ -395,6 +396,8 @@ namespace OpenUtau.Core.Editing {
     public class LoadRenderedPitch : BatchEdit {
         public virtual string Name => name;
 
+        public bool IsAsync => true;
+
         private string name;
 
         public LoadRenderedPitch() {
@@ -402,6 +405,14 @@ namespace OpenUtau.Core.Editing {
         }
 
         public void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager) {
+            RunAsync(
+                project, part, selectedNotes, docManager,
+                (current, total) => { }, CancellationToken.None);
+        }
+
+        public void RunAsync(
+            UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager,
+            Action<int, int> setProgressCallback, CancellationToken cancellationToken) {
             var renderer = project.tracks[part.trackNo].RendererSettings.Renderer;
             if (renderer == null || !renderer.SupportsRenderPitch) {
                 docManager.ExecuteCmd(new ErrorMessageNotification("Not supported"));
@@ -409,12 +420,15 @@ namespace OpenUtau.Core.Editing {
             }
             var notes = selectedNotes.Count > 0 ? selectedNotes : part.notes.ToList();
             var positions = notes.Select(n => n.position + part.position).ToHashSet();
-            var phrases = part.renderPhrases.Where(phrase => phrase.notes.Any(n => positions.Contains(phrase.position + n.position)));
-            docManager.StartUndoGroup(true);
+            var phrases = part.renderPhrases.Where(phrase => phrase.notes.Any(n => positions.Contains(phrase.position + n.position))).ToArray();
             float minPitD = -1200;
             if (project.expressions.TryGetValue(Format.Ustx.PITD, out var descriptor)) {
                 minPitD = descriptor.min;
             }
+
+            int finished = 0;
+            setProgressCallback(0, phrases.Length);
+            var commands = new List<SetCurveCommand>();
             foreach (var phrase in phrases) {
                 var result = renderer.LoadRenderedPitch(phrase);
                 if (result == null) {
@@ -423,6 +437,7 @@ namespace OpenUtau.Core.Editing {
                 int? lastX = null;
                 int? lastY = null;
                 // TODO: Optimize interpolation and command.
+                if (cancellationToken.IsCancellationRequested) break;
                 for (int i = 0; i < result.tones.Length; i++) {
                     if (result.tones[i] < 0) {
                         continue;
@@ -434,14 +449,21 @@ namespace OpenUtau.Core.Editing {
                     lastX ??= x;
                     lastY ??= y;
                     if (y > minPitD) {
-                        docManager.ExecuteCmd(new SetCurveCommand(
+                        commands.Add(new SetCurveCommand(
                             project, part, Format.Ustx.PITD, x, y, lastX.Value, lastY.Value));
                     }
                     lastX = x;
                     lastY = y;
                 }
+                finished += 1;
+                setProgressCallback(finished, phrases.Length);
             }
-            docManager.EndUndoGroup();
+
+            DocManager.Inst.PostOnUIThread(() => {
+                docManager.StartUndoGroup(true);
+                commands.ForEach(docManager.ExecuteCmd);
+                docManager.EndUndoGroup();
+            });
         }
     }
 

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -213,6 +213,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="phoneticassistant.copy">Copy</system:String>
 
   <system:String x:Key="pianoroll.menu.batch">Batch Edits</system:String>
+  <system:String x:Key="pianoroll.menu.batch.running">Running batch edit</system:String>
   <system:String x:Key="pianoroll.menu.lyrics">Lyrics</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">Replace "-" with "+"</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.edit">Edit Lyrics</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -210,6 +210,7 @@
   <system:String x:Key="phoneticassistant.copy">复制</system:String>
 
   <system:String x:Key="pianoroll.menu.batch">批量编辑</system:String>
+  <system:String x:Key="pianoroll.menu.batch.running">正在运行批处理</system:String>
   <system:String x:Key="pianoroll.menu.lyrics">歌词</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">将 "-" 替换为 "+"</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.edit">编辑歌词</system:String>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -33,7 +33,7 @@ namespace OpenUtau.App.Views {
 
         private bool splashDone = false;
 
-        private PianoRollWindow? pianoRollWindow;
+        public PianoRollWindow? pianoRollWindow;
         private bool openPianoRollWindow;
 
         private PartEditState? partEditState;

--- a/OpenUtau/Views/MessageBox.axaml.cs
+++ b/OpenUtau/Views/MessageBox.axaml.cs
@@ -141,17 +141,20 @@ namespace OpenUtau.App.Views {
                 action.Invoke(msgbox, tokenSource.Token);
                 return res;
             }, tokenSource.Token);
-
-            var btn = new Button { Content = ThemeManager.GetString("dialogs.messagebox.cancel") };
-            btn.Click += (_, __) => {
-                res = MessageBoxResult.Cancel;
-                tokenSource.Cancel();
-                msgbox.Close();
-            };
-            msgbox.Buttons.Children.Add(btn);
             task.ContinueWith(t => {
                 msgbox.Close();
             }, scheduler);
+
+            var btn = new Button { Content = ThemeManager.GetString("dialogs.messagebox.cancel") };
+            btn.Click += (_, __) => {
+                msgbox.Close();
+            };
+            msgbox.Buttons.Children.Add(btn);
+            msgbox.Closed += delegate {
+                if (task.IsCompleted) return;
+                res = MessageBoxResult.Cancel;
+                tokenSource.Cancel();
+            };
             msgbox.ShowDialog(parent);
 
             return task;


### PR DESCRIPTION
Some batch edits like DiffSinger autopitch may execute really slowly and block the UI. This PR supports running batch edits asynchronously, with a dialog showing progress of the running batch edit.

Major changes:

- Add a property `IsAsync` to `OpenUtau.Core.Editing.BatchEdit` to declare if the batch edit should be run asynchronously.
- Add a method `RunAsync()` to `OpenUtau.Core.Editing.BatchEdit` to run the batch edit asynchronously, with a callback to set the progress and a cancellation token to check if the process is cancelled by user. This method has the same behaviour like `Run()` if not overridden by its implementation classes.
- Adds a static method `ShowProcessing()` to `OpenUtau.App.Views.MessageBox` for running a task in the background and show a modal dialog for manipulating the progress.
- Make `OpenUtau.Core.Editing.NoteBatchEdit` to run asynchronously.

**Problem**

I did not figure out how to visit the instance of the pianoroll window. But I need that because the progress dialog should have it as the parent window, so I temporarily changed `OpenUtau.App.Views.MainWindow.pianoRollWindow` to public. I know this is not the proper way, but how can I do this without violating the rule of member visibility?