### PR TITLE
[ZH CVVC] Automatically add syllable ending if present (if next neighbor is null)

### DIFF
--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -63,6 +63,11 @@ namespace OpenUtau.Plugin.Builtin {
                     vcLen = MsToTick(cvOto.Preutter - cvOto.Overlap);
                 }
             }
+
+            if (singer.TryGetMappedOto(lyric, notes[0].tone + attr0.toneShift, attr0.voiceColor, out var cvOtoSimple)) {
+                lyric = cvOtoSimple.Alias;
+            }
+
             var vcPhoneme = $"{prevVowel} {consonant}";
             if (prevNeighbour != null) {
                 if (singer.TryGetMappedOto(vcPhoneme, prevNeighbour.Value.tone + attr0.toneShift, attr0.voiceColor, out oto)) {
@@ -104,7 +109,7 @@ namespace OpenUtau.Plugin.Builtin {
                         vcPhoneme = vcOto2.Alias;
                     }
                     // automatically add ending if present
-                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr2.toneShift, attr2.voiceColor, out var otoEnd) && singer.TryGetMappedOto(lyric, notes[0].tone + attr1.toneShift, attr1.voiceColor, out cvOto)) {
+                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr2.toneShift, attr2.voiceColor, out var otoEnd) && singer.TryGetMappedOto(lyric, notes[0].tone + attr1.toneShift, attr1.voiceColor, out var cvOto1)) {
                         return new Result {
                             phonemes = new Phoneme[] {
                                     new Phoneme() {
@@ -112,7 +117,7 @@ namespace OpenUtau.Plugin.Builtin {
                                         position = -vcLen,
                                 },
                                     new Phoneme() {
-                                        phoneme = cvOto?.Alias ?? lyric,
+                                        phoneme = cvOto1?.Alias ?? lyric,
                                 },
                                     new Phoneme() {
                                         phoneme = otoEnd.Alias,
@@ -125,7 +130,7 @@ namespace OpenUtau.Plugin.Builtin {
                         return new Result {
                             phonemes = new Phoneme[] {
                                 new Phoneme() {
-                                    phoneme = cvOto?.Alias ?? lyric,
+                                    phoneme = cvOtoSimple?.Alias ?? lyric,
                                 },
                                 new Phoneme() {
                                     phoneme = otoEnd1.Alias,
@@ -150,7 +155,7 @@ namespace OpenUtau.Plugin.Builtin {
                     },
                 };
             }
-            return MakeSimpleResult(cvOto?.Alias ?? lyric);
+            return MakeSimpleResult(cvOtoSimple?.Alias ?? lyric);
         }
 
         public override void SetSinger(USinger singer) {

--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -14,7 +14,6 @@ namespace OpenUtau.Plugin.Builtin {
         private Dictionary<string, string> vowels = new Dictionary<string, string>();
         private Dictionary<string, string> consonants = new Dictionary<string, string>();
         private USinger singer;
-
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             var lyric = notes[0].lyric;
             string consonant = consonants.TryGetValue(lyric, out consonant) ? consonant : lyric;
@@ -27,13 +26,31 @@ namespace OpenUtau.Plugin.Builtin {
             };
             var attr0 = notes[0].phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
             var attr1 = notes[0].phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
+            var attr2 = notes[0].phonemeAttributes?.FirstOrDefault(attr => attr.index == 2) ?? default;
             if (lyric == "-" || lyric.ToLowerInvariant() == "r") {
                 if (singer.TryGetMappedOto($"{prevVowel} R", notes[0].tone + attr0.toneShift, attr0.voiceColor, out var oto1)) {
                     return MakeSimpleResult(oto1.Alias);
                 }
                 return MakeSimpleResult($"{prevVowel} R");
             }
+            string currVowel = vowels.TryGetValue(lyric, out currVowel) ? currVowel : lyric;
+            int totalDuration = notes.Sum(n => n.duration); // totalDuration of current note
+
             if (singer.TryGetMappedOto($"{prevVowel} {lyric}", notes[0].tone + attr0.toneShift, attr0.voiceColor, out var oto)) {
+                if (nextNeighbour == null && singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr1.toneShift, attr1.voiceColor, out var oto1)) {
+                    // automatically add ending if present
+                    return new Result {
+                        phonemes = new Phoneme[] {
+                                new Phoneme() {
+                                    phoneme = oto.Alias,
+                                },
+                                new Phoneme() {
+                                    phoneme = oto1.Alias,
+                                    position = totalDuration - (totalDuration / 6),
+                                },
+                            },
+                    };
+                }
                 return MakeSimpleResult(oto.Alias);
             }
             int vcLen = 120;
@@ -51,16 +68,52 @@ namespace OpenUtau.Plugin.Builtin {
                 if (singer.TryGetMappedOto(vcPhoneme, prevNeighbour.Value.tone + attr0.toneShift, attr0.voiceColor, out oto)) {
                     vcPhoneme = oto.Alias;
                 }
-                // totalDuration calculated on basis of previous note length
-                int totalDuration = prevNeighbour.Value.duration;
+                // prevDuration calculated on basis of previous note length
+                int prevDuration = prevNeighbour.Value.duration;
                 // vcLength depends on the Vel of the current base note
-                vcLen = Convert.ToInt32(Math.Min(totalDuration / 1.5, Math.Max(30, vcLen * (attr1.consonantStretchRatio ?? 1))));
+                vcLen = Convert.ToInt32(Math.Min(prevDuration / 1.5, Math.Max(30, vcLen * (attr1.consonantStretchRatio ?? 1))));
             } else {
                 if (singer.TryGetMappedOto(vcPhoneme, notes[0].tone + attr0.toneShift, attr0.voiceColor, out oto)) {
                     vcPhoneme = oto.Alias;
                 }
                 // no previous note, so length can be minimum velocity regardless of oto
                 vcLen = Convert.ToInt32(Math.Min(vcLen * 2, Math.Max(30, vcLen * (attr1.consonantStretchRatio ?? 1))));
+            }
+
+            if (nextNeighbour == null) { // automatically add ending if present
+                if (!string.IsNullOrEmpty(vcPhoneme)) {
+                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr2.toneShift, attr2.voiceColor, out var oto1)) {
+                        return new Result {
+                            phonemes = new Phoneme[] {
+                                new Phoneme() {
+                                    phoneme = vcPhoneme,
+                                    position = -vcLen,
+                                },
+                                new Phoneme() {
+                                    phoneme = cvOto?.Alias ?? lyric,
+                                },
+                                new Phoneme() {
+                                    phoneme = oto1.Alias,
+                                    position = totalDuration - (totalDuration / 6),
+                                },
+                            },
+                        };
+                    }
+                } else {
+                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr1.toneShift, attr1.voiceColor, out var oto1)) {
+                        return new Result {
+                            phonemes = new Phoneme[] {
+                                new Phoneme() {
+                                    phoneme = cvOto?.Alias ?? lyric,
+                                },
+                                new Phoneme() {
+                                    phoneme = oto1.Alias,
+                                    position = totalDuration - (totalDuration / 6),
+                                },
+                            },
+                        };
+                    }
+                }
             }
 
             if (singer.TryGetMappedOto(vcPhoneme, notes[0].tone + attr0.toneShift, attr0.voiceColor, out oto)) {

--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -81,33 +81,54 @@ namespace OpenUtau.Plugin.Builtin {
             }
 
             if (nextNeighbour == null) { // automatically add ending if present
-                if (!string.IsNullOrEmpty(vcPhoneme)) {
-                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr2.toneShift, attr2.voiceColor, out var oto1)) {
+                if (singer.TryGetMappedOto($"{prevVowel} {lyric}", notes[0].tone + attr0.toneShift, attr0.voiceColor, out var oto0)) {
+                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr1.toneShift, attr1.voiceColor, out var otoEnd)) {
+                        // automatically add ending if present
                         return new Result {
                             phonemes = new Phoneme[] {
                                 new Phoneme() {
-                                    phoneme = vcPhoneme,
-                                    position = -vcLen,
+                                    phoneme = oto0.Alias,
                                 },
                                 new Phoneme() {
-                                    phoneme = cvOto?.Alias ?? lyric,
-                                },
-                                new Phoneme() {
-                                    phoneme = oto1.Alias,
+                                    phoneme = otoEnd.Alias,
                                     position = totalDuration - (totalDuration / 6),
                                 },
                             },
                         };
                     }
                 } else {
-                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr1.toneShift, attr1.voiceColor, out var oto1)) {
+                    // use vc if present
+                    if (prevNeighbour == null && singer.TryGetMappedOto(vcPhoneme, notes[0].tone + attr0.toneShift, attr0.voiceColor, out var vcOto1)) {
+                        vcPhoneme = vcOto1.Alias;
+                    } else if (prevNeighbour != null && singer.TryGetMappedOto(vcPhoneme, prevNeighbour.Value.tone + attr0.toneShift, attr0.voiceColor, out var vcOto2)) {
+                        vcPhoneme = vcOto2.Alias;
+                    }
+                    // automatically add ending if present
+                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr2.toneShift, attr2.voiceColor, out var otoEnd) && singer.TryGetMappedOto(lyric, notes[0].tone + attr1.toneShift, attr1.voiceColor, out cvOto)) {
+                        return new Result {
+                            phonemes = new Phoneme[] {
+                                    new Phoneme() {
+                                        phoneme = vcPhoneme,
+                                        position = -vcLen,
+                                },
+                                    new Phoneme() {
+                                        phoneme = cvOto?.Alias ?? lyric,
+                                },
+                                    new Phoneme() {
+                                        phoneme = otoEnd.Alias,
+                                        position = totalDuration - (totalDuration / 6),
+                                },
+                            },
+                        };
+                    } // just base note and ending
+                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr1.toneShift, attr1.voiceColor, out var otoEnd1)) {
                         return new Result {
                             phonemes = new Phoneme[] {
                                 new Phoneme() {
                                     phoneme = cvOto?.Alias ?? lyric,
                                 },
                                 new Phoneme() {
-                                    phoneme = oto1.Alias,
+                                    phoneme = otoEnd1.Alias,
                                     position = totalDuration - (totalDuration / 6),
                                 },
                             },

--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -105,26 +105,44 @@ namespace OpenUtau.Plugin.Builtin {
                     // use vc if present
                     if (prevNeighbour == null && singer.TryGetMappedOto(vcPhoneme, notes[0].tone + attr0.toneShift, attr0.voiceColor, out var vcOto1)) {
                         vcPhoneme = vcOto1.Alias;
-                    } else if (prevNeighbour != null && singer.TryGetMappedOto(vcPhoneme, prevNeighbour.Value.tone + attr0.toneShift, attr0.voiceColor, out var vcOto2)) {
-                        vcPhoneme = vcOto2.Alias;
-                    }
-                    // automatically add ending if present
-                    if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr2.toneShift, attr2.voiceColor, out var otoEnd) && singer.TryGetMappedOto(lyric, notes[0].tone + attr1.toneShift, attr1.voiceColor, out var cvOto1)) {
-                        return new Result {
-                            phonemes = new Phoneme[] {
+                        // automatically add ending if present
+                        if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr2.toneShift, attr2.voiceColor, out var otoEnd)) {
+                            return new Result {
+                                phonemes = new Phoneme[] {
                                     new Phoneme() {
                                         phoneme = vcPhoneme,
                                         position = -vcLen,
                                 },
                                     new Phoneme() {
-                                        phoneme = cvOto1?.Alias ?? lyric,
+                                        phoneme = cvOto?.Alias ?? lyric,
                                 },
                                     new Phoneme() {
                                         phoneme = otoEnd.Alias,
                                         position = totalDuration - (totalDuration / 6),
                                 },
                             },
-                        };
+                            };
+                        }
+                    } else if (prevNeighbour != null && singer.TryGetMappedOto(vcPhoneme, prevNeighbour.Value.tone + attr0.toneShift, attr0.voiceColor, out var vcOto2)) {
+                        vcPhoneme = vcOto2.Alias;
+                        // automatically add ending if present
+                        if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr2.toneShift, attr2.voiceColor, out var otoEnd)) {
+                            return new Result {
+                                phonemes = new Phoneme[] {
+                                    new Phoneme() {
+                                        phoneme = vcPhoneme,
+                                        position = -vcLen,
+                                },
+                                    new Phoneme() {
+                                        phoneme = cvOto?.Alias ?? lyric,
+                                },
+                                    new Phoneme() {
+                                        phoneme = otoEnd.Alias,
+                                        position = totalDuration - (totalDuration / 6),
+                                },
+                            },
+                            };
+                        }
                     } // just base note and ending
                     if (singer.TryGetMappedOto($"{currVowel} R", notes[0].tone + attr1.toneShift, attr1.voiceColor, out var otoEnd1)) {
                         return new Result {


### PR DESCRIPTION
This automatically adds a syllable ending to a note if the next neighbor is null (and if it exists in the oto). This function was added due to the existence of closed syllables and falling diphthongs in Chinese (unlike Japanese, where this can be optional). Currently, this has to be done manually on a separate note, which can be a relatively easy oversight.

Placing the ending on a separate note is still possible, if preferred. It also should not conflict with any end breaths etc.

Feedback is welcome.