### PR TITLE
[Japanese Presamp Phonemizer] Add option for MUSTVC

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -195,7 +195,7 @@ namespace OpenUtau.Plugin.Builtin {
             // Insert 2nd phoneme (when next doesn't have hint)
             if (nextNeighbour != null && string.IsNullOrEmpty(nextNeighbour.Value.phoneticHint)) {
                 int totalDuration = notes.Sum(n => n.duration);
-                if (TickToMs(totalDuration) < 100) {
+                if (TickToMs(totalDuration) < 100 && presamp.MustVC == false) {
                     return MakeSimpleResult(currentLyric);
                 }
 


### PR DESCRIPTION
This makes it so that when ``[MUSTVC]`` is set to ``1`` in the presamp.ini file, a VC phoneme will be inserted even on short notes. When set to ``0`` (which is the default), this will not happen.