### PR TITLE
Support using worldline resampler together with external wavtool

### DIFF
--- a/OpenUtau.Core/Classic/ExeWavtool.cs
+++ b/OpenUtau.Core/Classic/ExeWavtool.cs
@@ -26,6 +26,15 @@ namespace OpenUtau.Classic {
             if (cancellation.IsCancellationRequested) {
                 return null;
             }
+            //The builtin worldline resampler can't be called from bat script,
+            //so we need to call it directly from C#
+            foreach(var item in resamplerItems){
+                if(!(item.resampler is ExeResampler) && !cancellation.IsCancellationRequested && !File.Exists(item.outputFile)){
+                    lock (Renderers.GetCacheLock(item.outputFile)) {
+                        item.resampler.DoResamplerReturnsFile(item, Log.Logger);
+                    }
+                }
+            }
             PrepareHelper();
             string batPath = Path.Combine(PathManager.Inst.CachePath, "temp.bat");
             lock (tempBatLock) {

--- a/OpenUtau.Core/Render/Renderers.cs
+++ b/OpenUtau.Core/Render/Renderers.cs
@@ -105,13 +105,7 @@ namespace OpenUtau.Core.Render {
         }
 
         public static IReadOnlyList<IWavtool> GetSupportedWavtools(IResampler? resampler) {
-            if (resampler is WorldlineResampler) {
-                return ToolsManager.Inst.Wavtools
-                    .Where(r => r is SharpWavtool)
-                    .ToArray();
-            } else {
-                return ToolsManager.Inst.Wavtools;
-            }
+            return ToolsManager.Inst.Wavtools;
         }
     }
 }


### PR DESCRIPTION
After this change, worldline resampler can be used together with external wavtool. There will no longer be "no application set to open the document" error when switching to worldline mid-project with ENE expression. Worldline will also be listed as a resampler option when an external wavtool is used.