### PR TITLE
Improve Korean Translation, Add missing translation

### DIFF
--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -8,9 +8,9 @@
   <system:String x:Key="context.part.delete">파트 삭제</system:String>
   <system:String x:Key="context.part.gotofile">파일 위치 열기</system:String>
   <system:String x:Key="context.part.rename">파트 이름 변경</system:String>
-<system:String x:Key="context.part.replaceaudio">오디오 파일 교체</system:String>
-<system:String x:Key="context.part.transcribe">새 노트 파트로 오디오 전사</system:String>
-<system:String x:Key="context.part.transcribing">전사 중</system:String>
+  <system:String x:Key="context.part.replaceaudio">오디오 파일 교체</system:String>
+  <system:String x:Key="context.part.transcribe">새 노트 파트로 오디오 전사</system:String>
+  <system:String x:Key="context.part.transcribing">전사 중</system:String>
   <system:String x:Key="context.pitch.easein">Ease in</system:String>
   <system:String x:Key="context.pitch.easeinout">Ease in/out</system:String>
   <system:String x:Key="context.pitch.easeout">Ease out</system:String>
@@ -44,10 +44,10 @@
   <system:String x:Key="dialogs.messagebox.no">아니요</system:String>
   <system:String x:Key="dialogs.messagebox.ok">확인</system:String>
   <system:String x:Key="dialogs.messagebox.yes">네</system:String>
-  <system:String x:Key="dialogs.noresampler.caption">리샘플러 없음</system:String>
-  <system:String x:Key="dialogs.noresampler.message">리샘플러를 찾을 수 없습니다! 좋아하는 리샘플러의 exe나 dll을 'Resamplers' 폴더에 넣고, 환경 설정에서 원하는 리샘플러를 선택해 주세요!</system:String>
-  <system:String x:Key="dialogs.unsupportedfile.caption">지원하지 않는 파일 유형</system:String>
-  <system:String x:Key="dialogs.unsupportedfile.message">다음 파일 유형은 지원하지 않습니다. </system:String>
+  <system:String x:Key="dialogs.noresampler.caption">리샘플러가 없어요</system:String>
+  <system:String x:Key="dialogs.noresampler.message">리샘플러가 없어요! 'Resamplers' 폴더에 좋아하는 리샘플러의 exe나 dll을 넣고, 환경 설정에서 원하는 리샘플러를 골라 보세요!</system:String>
+  <system:String x:Key="dialogs.unsupportedfile.caption">이 파일 유형은 지원하지 않아요</system:String>
+  <system:String x:Key="dialogs.unsupportedfile.message">이 파일 유형은 지원하지 않아요: </system:String>
   <system:String x:Key="dialogs.timesig.caption">박자표</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">트랙 설정</system:String>
   <system:String x:Key="dialogs.tracksettings.location">위치 열기</system:String>
@@ -84,8 +84,8 @@
   <system:String x:Key="lyrics.selectnotes">먼저 원하는 노트를 선택해 주세요!</system:String>
   <system:String x:Key="lyrics.separators">구분 기준</system:String>
 
-  <system:String x:Key="lyricsreplace.after">수정 후:</system:String>
-  <system:String x:Key="lyricsreplace.before">수정 전:</system:String>
+  <system:String x:Key="lyricsreplace.after">찾을 내용</system:String>
+  <system:String x:Key="lyricsreplace.before">바꿀 내용</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvalphabet">알파벳 지우기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvnonhiragana">히라가나만 남기기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvphonetichint">발음 힌트 지우기</system:String>
@@ -109,7 +109,7 @@
   <system:String x:Key="menu.file.exportaudio">오디오 내보내기</system:String>
   <system:String x:Key="menu.file.exportds">다른 이름으로 DiffSinger 스크립트 내보내기</system:String>
   <system:String x:Key="menu.file.exportds.v2">다른 이름으로 DiffSinger 스크립트 내보내기 (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">다른 이름으로 DiffSinger 스크립트 내보내기 (v2, 피치 벤드 제외)</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">다른 이름으로 DiffSinger 스크립트 내보내기 (v2, 피치선 제외)</system:String>
   <system:String x:Key="menu.file.exportmidi">Midi로 내보내기</system:String>
   <system:String x:Key="menu.file.exportmixdown">Wav 파일로 믹스다운</system:String>
   <system:String x:Key="menu.file.exportproject">프로젝트 내보내기</system:String>
@@ -179,7 +179,7 @@
   <system:String x:Key="notedefaults.vibrato.length">길이</system:String>
   <system:String x:Key="notedefaults.vibrato.out">페이드 아웃</system:String>
   <system:String x:Key="notedefaults.vibrato.period">주기</system:String>
-  <system:String x:Key="notedefaults.vibrato.shift">위상</system:String>
+  <system:String x:Key="notedefaults.vibrato.shift">평행이동</system:String>
   <system:String x:Key="notedefaults.vibrato.vollink">볼륨 연동</system:String>
 
   <system:String x:Key="noteproperty">노트 속성</system:String>
@@ -188,7 +188,7 @@
   <system:String x:Key="noteproperty.cancel">취소</system:String>
   <system:String x:Key="noteproperty.set">모든 노트에 적용</system:String>
   <system:String x:Key="noteproperty.setlongnote">긴 노트에만 적용</system:String>
-  <system:String x:Key="noteproperty.tone">음높이</system:String>
+  <system:String x:Key="noteproperty.tone">음조</system:String>
   <system:String x:Key="noteproperty.vibratoenable">비브라토 활성화</system:String>
 
   <system:String x:Key="oto.alias">에일리어스</system:String>
@@ -226,25 +226,25 @@
   <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">로마자를 히라가나로</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">노트 기본값</system:String>
   <system:String x:Key="pianoroll.menu.notes">노트</system:String>
-  <system:String x:Key="pianoroll.menu.notes.addtaildash">끝에 '-' 노트 추가</system:String>
-  <system:String x:Key="pianoroll.menu.notes.addtailrest">끝에 'R' 노트 추가</system:String>
-  <system:String x:Key="pianoroll.menu.notes.autolegato">노트를 서로 자동 연결</system:String>
-  <system:String x:Key="pianoroll.menu.notes.bakepitch">PTTD(피치 표현)를 피치 벤드로 변환</system:String>
-  <system:String x:Key="pianoroll.menu.notes.clear.vibratos">비브라토 업생기</system:String>
-  <system:String x:Key="pianoroll.menu.notes.fixoverlap">겹친 노트 고치기</system:String>
-  <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">중국어 한자를 병음으로 변경</system:String>
+  <system:String x:Key="pianoroll.menu.notes.addtaildash">끝 노트로 '-' 추가</system:String>
+  <system:String x:Key="pianoroll.menu.notes.addtailrest">끝 노트로 'R' 추가</system:String>
+  <system:String x:Key="pianoroll.menu.notes.autolegato">선택한 노트들 자동 붙이기</system:String>
+  <system:String x:Key="pianoroll.menu.notes.bakepitch">PITD를 피치선으로</system:String>
+  <system:String x:Key="pianoroll.menu.notes.clear.vibratos">비브라토 제거</system:String>
+  <system:String x:Key="pianoroll.menu.notes.fixoverlap">노트 겹침 수정</system:String>
+  <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">중국어 한자를 병음으로</system:String>
   <system:String x:Key="pianoroll.menu.notes.lengthencrossfade">크로스페이드 길이 늘리기</system:String>
-  <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">렌더링된 피치 커브 불러오기</system:String>
+  <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">렌더링된 피치 불러오기</system:String>
   <system:String x:Key="pianoroll.menu.notes.octavedown">한 옥타브 아래로</system:String>
   <system:String x:Key="pianoroll.menu.notes.octaveup">한 옥타브 위로</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize15">1/128로 퀀타이즈</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize30">1/64로 퀀타이즈</system:String>
   <system:String x:Key="pianoroll.menu.notes.removetaildash">끝에 '-' 노트 지우기</system:String>
   <system:String x:Key="pianoroll.menu.notes.removetailrest">끝에 'R' 노트 지우기</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.aliases">음소 에일리어스 재설정</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.aliases">에일리어스 재설정</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.exps">모든 표현 재설정</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">음소 타이밍 재설정</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">피치 벤드 재설정</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">피치선 재설정</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.vibratos">비브라토 재설정</system:String>
   <system:String x:Key="pianoroll.menu.part">파트</system:String>
   <system:String x:Key="pianoroll.menu.part.legacypluginexp">레거시 플러그인(실험적)</system:String>
@@ -256,32 +256,32 @@
   <system:String x:Key="pianoroll.menu.searchnote.close">닫기</system:String>
   <system:String x:Key="pianoroll.menu.searchnote.next">다음</system:String>
   <system:String x:Key="pianoroll.menu.searchnote.prev">이전</system:String>
-  <system:String x:Key="pianoroll.toggle.finalpitch">최종 렌더링된 피치 커브 보기(R)</system:String>
-  <system:String x:Key="pianoroll.toggle.noteparams">노트 설정 열기(\)</system:String>
-  <system:String x:Key="pianoroll.toggle.phoneme">음소 표시(O)</system:String>
-  <system:String x:Key="pianoroll.toggle.pitch">피치 벤드 표시(I)</system:String>
-  <system:String x:Key="pianoroll.toggle.snap">토글 켜기·끄기(P)</system:String>
-  <system:String x:Key="pianoroll.toggle.snap.auto">자동 스냅</system:String>
-  <system:String x:Key="pianoroll.toggle.snap.autotriplet">자동 스냅(셋잇단)</system:String>
+  <system:String x:Key="pianoroll.toggle.finalpitch">렌더링된 피치 보기 (R)</system:String>
+  <system:String x:Key="pianoroll.toggle.noteparams">노트 설정 열기 (\)</system:String>
+  <system:String x:Key="pianoroll.toggle.phoneme">음소 표시 (O)</system:String>
+  <system:String x:Key="pianoroll.toggle.pitch">피치선 표시 (I)</system:String>
+  <system:String x:Key="pianoroll.toggle.snap">스냅 활성화 (P)</system:String>
+  <system:String x:Key="pianoroll.toggle.snap.auto">자동</system:String>
+  <system:String x:Key="pianoroll.toggle.snap.autotriplet">자동(3연음)</system:String>
   <system:String x:Key="pianoroll.toggle.tips">도움말 (T)</system:String>
-  <system:String x:Key="pianoroll.toggle.tone">노트 음높이 켜기(Y)</system:String>
+  <system:String x:Key="pianoroll.toggle.tone">노트음 활성 (Y)</system:String>
   <system:String x:Key="pianoroll.toggle.vibrato">비브라토 표시 (U)</system:String>
   <system:String x:Key="pianoroll.toggle.waveform">파형 표시 (W)</system:String>
-  <system:String x:Key="pianoroll.tool.drawpitch">피치 그리기 툴(4)
-    왼쪽 클릭으로 그리기
-    오른쪽 클릭으로 재설정
-    Ctrl 키를 누르며 클릭해 선택
-    Alt 키를 누르며 클릭해 다듬기</system:String>
-  <system:String x:Key="pianoroll.tool.eraser">지우기 툴(3)</system:String>
-  <system:String x:Key="pianoroll.tool.knife">자르기 툴(5)</system:String>
-  <system:String x:Key="pianoroll.tool.penplus">펜 플러스 툴(Ctrl + 2)
-    왼쪽 클릭으로 그리기
-    오른쪽 클릭으로 재설정
-    Ctrl 키를 누르며 클릭해 선택</system:String>
-  <system:String x:Key="pianoroll.tool.penv2">펜 툴(2)
-    왼쪽 클릭으로 그리기
-    Ctrl 키를 누르며 클릭해 선택</system:String>
-  <system:String x:Key="pianoroll.tool.selectionv2">선택 툴(1)</system:String>
+  <system:String x:Key="pianoroll.tool.drawpitch">피치 그리기 펜 (4)
+    피치 그리기: 왼쪽 클릭
+    피치 초기화: 오른쪽 클릭
+    노트 선택: Ctrl + 클릭
+    피치 다듬기: Alt + 클릭</system:String>
+  <system:String x:Key="pianoroll.tool.eraser">지우개 (3)</system:String>
+  <system:String x:Key="pianoroll.tool.knife">칼 (5)</system:String>
+  <system:String x:Key="pianoroll.tool.penplus">고급 펜 (Ctrl + 2)
+    노트 생성: 왼쪽 클릭
+    노트 삭제: 오른쪽 클릭
+    노트 선택: Ctrl + 클릭</system:String>
+  <system:String x:Key="pianoroll.tool.penv2">펜 (2)
+    노트 생성: 왼쪽 클릭
+    노트 선택: Ctrl + 클릭</system:String>
+  <system:String x:Key="pianoroll.tool.selectionv2">선택 도구 (1)</system:String>
 
   <system:String x:Key="prefs.advanced">고급</system:String>
   <system:String x:Key="prefs.advanced.beta">베타 버전 사용</system:String>
@@ -343,10 +343,10 @@
   <system:String x:Key="prefs.rendering.prerender">미리보기용 렌더</system:String>
   <system:String x:Key="prefs.rendering.resampler">리샘플러</system:String>
   <system:String x:Key="prefs.rendering.resampler.morewarn">
-    경고: moresampler는 완벽하게 지원되지 않습니다. 속도가 느릴 수 있고, 높은 CPU 점유율 유발할 수 있습니다. 그래도 사용하시려면 다음을 따라 주세요.
-    1. moreconfig.txt를 열어 resampler-compatibility 항목을 "on"으로 설정
-    2. 같은 파일에서 resampler-compatibility 항목을 "off"로 설정
-    3. moresampler가 누락된 llsm 파일을 다 생성할 때까지 대기
+    경고: 현재 moresampler의 지원은 아직 불완전합니다. 속도가 느릴 수 있고, CPU 점유율이 높아질 수 있습니다. 그래도 사용하시려면 다음을 따라 주세요.
+    1. moreconfig.txt를 열어 "resampler-compatibility"를 "on"으로 바꿉니다.
+    2. 같은 파일에서 "auto-update-llsm-mrq"을 "off"로 바꿉니다.
+    3. moresampler가 누락된 llsm 파일을 생성할 때까지 느긋하게 기다립니다.
   </system:String>
   <system:String x:Key="prefs.rendering.resampler.note">
     참고: 외부 리샘플러를 사용하려면, OpenUtau 설치 경로 속 Resamplers 폴더에 리샘플러의 DLL 또는 EXE 파일을 넣어 주세요. 그리고 환경 설정에서 리샘플러를 선택합시다.
@@ -362,10 +362,10 @@
   <system:String x:Key="progress.waitingrendering">렌더링을 기다리는 중</system:String>
 
   <system:String x:Key="singers.caption">가수 목록</system:String>
-  <system:String x:Key="singers.editoto.editinvlabeler">vLabeler로 편집</system:String>
+  <system:String x:Key="singers.editoto.editinvlabeler">vLabeler에서 편집</system:String>
   <system:String x:Key="singers.editoto.gotosource">원본 파일로 이동</system:String>
   <system:String x:Key="singers.editoto.regenfrq">FRQ 재생성</system:String>
-  <system:String x:Key="singers.editoto.regenfrq.regenerating">가수의 FRQ 파일 재생성 중...</system:String>
+  <system:String x:Key="singers.editoto.regenfrq.regenerating">FRQ 재생성 중</system:String>
   <system:String x:Key="singers.editoto.reset">원음 설정 초기화</system:String>
   <system:String x:Key="singers.editoto.save">원음 설정 저장</system:String>
   <system:String x:Key="singers.editoto.searchalias">에일리어스 검색</system:String>
@@ -401,8 +401,9 @@
   <system:String x:Key="singers.subbanks.save">저장</system:String>
   <system:String x:Key="singers.subbanks.selectall">모두 선택</system:String>
   <system:String x:Key="singers.subbanks.set">설정</system:String>
-  <system:String x:Key="singers.subbanks.tone">음계</system:String>
+  <system:String x:Key="singers.subbanks.tone">음조</system:String>
   <system:String x:Key="singers.subbanks.toneranges">음역대</system:String>
+  <system:String x:Key="singers.usefilename">파일명을 에일리어스로 사용</system:String>
   <system:String x:Key="singers.visitwebsite">웹사이트 방문</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">압축 파일의 인코딩</system:String>
@@ -465,7 +466,7 @@
   <system:String x:Key="updater.caption">업데이트 확인</system:String>
   <system:String x:Key="updater.description">오픈소스 음성 합성 플랫폼</system:String>
   <system:String x:Key="updater.github">GitHub</system:String>
-  <system:String x:Key="updater.status.available">v{0} 버전 업데이트가 있습니다!</system:String>
+  <system:String x:Key="updater.status.available">v{0} 버전 업데이트가 있어요!</system:String>
   <system:String x:Key="updater.status.checking">업데이트 확인 중...</system:String>
   <system:String x:Key="updater.status.notavailable">최신 버전</system:String>
   <system:String x:Key="updater.status.unknown">업데이트를 확인할 수 없어요</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -84,8 +84,8 @@
   <system:String x:Key="lyrics.selectnotes">먼저 원하는 노트를 선택해 주세요!</system:String>
   <system:String x:Key="lyrics.separators">구분 기준</system:String>
 
-  <system:String x:Key="lyricsreplace.after">찾을 내용</system:String>
-  <system:String x:Key="lyricsreplace.before">바꿀 내용</system:String>
+  <system:String x:Key="lyricsreplace.after">바꿀 내용</system:String>
+  <system:String x:Key="lyricsreplace.before">찾을 내용</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvalphabet">알파벳 지우기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvnonhiragana">히라가나만 남기기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvphonetichint">발음 힌트 지우기</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -369,8 +369,8 @@
   <system:String x:Key="singers.editoto.reset">원음 설정 초기화</system:String>
   <system:String x:Key="singers.editoto.save">원음 설정 저장</system:String>
   <system:String x:Key="singers.editoto.searchalias">에일리어스 검색</system:String>
-  <system:String x:Key="singers.editoto.setvlabelerpath">vLabeler 1.0.0-beta1 이상 버전이 필요합니다. https://github.com/sdercolin/vlabeler에서 vlabeler를 다운로드하고, 환경설정의 'vLabeler가 설치된 위치'에 등록해 주세요!</system:String>
-  <system:String x:Key="singers.errorreport">가수의 오류 보고서 생성</system:String>
+  <system:String x:Key="singers.editoto.setvlabelerpath">https://github.com/sdercolin/vlabeler 에서 vLabeler(1.0.0-beta1 이상)를 다운로드하고, 환경 설정에서 vLabeler 경로를 지정해 주세요!</system:String>
+  <system:String x:Key="singers.errorreport">가수 오류 보고서 생성</system:String>
   <system:String x:Key="singers.location">위치 열기</system:String>
   <system:String x:Key="singers.otoview.moveleft">왼쪽으로 이동</system:String>
   <system:String x:Key="singers.otoview.moveright">오른쪽으로 이동</system:String>
@@ -473,5 +473,5 @@
 
   <system:String x:Key="warning">경고</system:String>
   <system:String x:Key="warning.asciipath">OpenUtau 경로 "{0}"에 ASCII 인코딩에 없는 문자가 포함되어 있습니다. exe 리샘플러가 작동하지 않을 수 있습니다.</system:String>
-  <system:String x:Key="warning.renderer">이 렌더러를 위한 설정이 없습니다.</system:String>
+  <system:String x:Key="warning.renderer">이 렌더러에 대한 설정이 없습니다.</system:String>
 </ResourceDictionary>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -9,8 +9,8 @@
   <system:String x:Key="context.part.gotofile">파일 위치 열기</system:String>
   <system:String x:Key="context.part.rename">파트 이름 변경</system:String>
 <system:String x:Key="context.part.replaceaudio">오디오 파일 교체</system:String>
-  <system:String x:Key="context.part.transcribe">소리를 노트 파트로 변환</system:String>
-  <system:String x:Key="context.part.transcribing">변환 중</system:String>
+<system:String x:Key="context.part.transcribe">새 노트 파트로 오디오 전사</system:String>
+<system:String x:Key="context.part.transcribing">전사 중</system:String>
   <system:String x:Key="context.pitch.easein">Ease in</system:String>
   <system:String x:Key="context.pitch.easeinout">Ease in/out</system:String>
   <system:String x:Key="context.pitch.easeout">Ease out</system:String>
@@ -45,7 +45,7 @@
   <system:String x:Key="dialogs.messagebox.ok">확인</system:String>
   <system:String x:Key="dialogs.messagebox.yes">네</system:String>
   <system:String x:Key="dialogs.noresampler.caption">리샘플러 없음</system:String>
-  <system:String x:Key="dialogs.noresampler.message">리샘플러가 없습니다! 좋아하는 리샘플러의 exe나 dll을 'Resamplers' 폴더에 넣고, 환경 설정에서 원하는 리샘플러를 골라 보세요.</system:String>
+  <system:String x:Key="dialogs.noresampler.message">리샘플러를 찾을 수 없습니다! 좋아하는 리샘플러의 exe나 dll을 'Resamplers' 폴더에 넣고, 환경 설정에서 원하는 리샘플러를 선택해 주세요!</system:String>
   <system:String x:Key="dialogs.unsupportedfile.caption">지원하지 않는 파일 유형</system:String>
   <system:String x:Key="dialogs.unsupportedfile.message">다음 파일 유형은 지원하지 않습니다. </system:String>
   <system:String x:Key="dialogs.timesig.caption">박자표</system:String>
@@ -164,7 +164,7 @@
   <system:String x:Key="notedefaults.preset">프리셋</system:String>
   <system:String x:Key="notedefaults.preset.namenew">새 프리셋 이름</system:String>
   <system:String x:Key="notedefaults.preset.remove">삭제</system:String>
-  <system:String x:Key="notedefaults.preset.remove.tooltip">마지막 프리셋을 삭제합니다.</system:String>
+<system:String x:Key="notedefaults.preset.remove.tooltip">마지막으로 적용된 프리셋을 삭제합니다.</system:String>
   <system:String x:Key="notedefaults.preset.save">프리셋 저장</system:String>
   <system:String x:Key="notedefaults.preset.save.tooltip">현재 세팅으로 새 프리셋 추가</system:String>
   <system:String x:Key="notedefaults.reset">사용자 설정 초기화</system:String>
@@ -180,7 +180,7 @@
   <system:String x:Key="notedefaults.vibrato.out">페이드 아웃</system:String>
   <system:String x:Key="notedefaults.vibrato.period">주기</system:String>
   <system:String x:Key="notedefaults.vibrato.shift">위상</system:String>
-  <system:String x:Key="notedefaults.vibrato.vollink">볼륨 변화량</system:String>
+  <system:String x:Key="notedefaults.vibrato.vollink">볼륨 연동</system:String>
 
   <system:String x:Key="noteproperty">노트 속성</system:String>
   <system:String x:Key="noteproperty.apply">적용</system:String>
@@ -214,16 +214,16 @@
 
   <system:String x:Key="pianoroll.menu.batch">일괄 수정</system:String>
   <system:String x:Key="pianoroll.menu.lyrics">가사 설정</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">'-'를 '+'로 변경</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">'-'를 '+'로</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.edit">가사 편집</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.hiraganatoromaji">히라가나를 로마자로 변경</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.insertslur">이음줄 기호(+) 삽입</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.javcvtocv">일본어 VCV 가사를 일본어 CV 가사로 변경</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.movesuffixtovoicecolor">가사의 접미사를 음색으로 이동</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.hiraganatoromaji">히라가나를 로마자로</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.insertslur">이음줄 가사(+) 넣기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.javcvtocv">일본어 VCV를 일본어 CV로</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.movesuffixtovoicecolor">가사의 접미사를 음색으로</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.removelettersuffix">글자 접미사 제거</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.removephonetichint">발음 힌트 제거</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">음계 접미사 제거</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">로마자를 히라가나로 변경</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">로마자를 히라가나로</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">노트 기본값</system:String>
   <system:String x:Key="pianoroll.menu.notes">노트</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtaildash">끝에 '-' 노트 추가</system:String>
@@ -247,10 +247,10 @@
   <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">피치 벤드 재설정</system:String>
   <system:String x:Key="pianoroll.menu.notes.reset.vibratos">비브라토 재설정</system:String>
   <system:String x:Key="pianoroll.menu.part">파트</system:String>
-  <system:String x:Key="pianoroll.menu.part.legacypluginexp">레거시 플러그인(실험적 기능)</system:String>
+  <system:String x:Key="pianoroll.menu.part.legacypluginexp">레거시 플러그인(실험적)</system:String>
   <system:String x:Key="pianoroll.menu.part.singer">가수 및 원음 설정</system:String>
   <system:String x:Key="pianoroll.menu.plugin.openfolder">폴더 열기</system:String>
-  <system:String x:Key="pianoroll.menu.plugin.reload">새로 고침</system:String>
+  <system:String x:Key="pianoroll.menu.plugin.reload">새로고침</system:String>
   <system:String x:Key="pianoroll.menu.searchnote">노트 검색</system:String>
   <system:String x:Key="pianoroll.menu.searchnote.all">모두 선택</system:String>
   <system:String x:Key="pianoroll.menu.searchnote.close">닫기</system:String>
@@ -263,10 +263,10 @@
   <system:String x:Key="pianoroll.toggle.snap">토글 켜기·끄기(P)</system:String>
   <system:String x:Key="pianoroll.toggle.snap.auto">자동 스냅</system:String>
   <system:String x:Key="pianoroll.toggle.snap.autotriplet">자동 스냅(셋잇단)</system:String>
-  <system:String x:Key="pianoroll.toggle.tips">팁 표시(T)</system:String>
+  <system:String x:Key="pianoroll.toggle.tips">도움말 (T)</system:String>
   <system:String x:Key="pianoroll.toggle.tone">노트 음높이 켜기(Y)</system:String>
-  <system:String x:Key="pianoroll.toggle.vibrato">비브라토 표시(U)</system:String>
-  <system:String x:Key="pianoroll.toggle.waveform">파형 표시(W)</system:String>
+  <system:String x:Key="pianoroll.toggle.vibrato">비브라토 표시 (U)</system:String>
+  <system:String x:Key="pianoroll.toggle.waveform">파형 표시 (W)</system:String>
   <system:String x:Key="pianoroll.tool.drawpitch">피치 그리기 툴(4)
     왼쪽 클릭으로 그리기
     오른쪽 클릭으로 재설정
@@ -285,18 +285,18 @@
 
   <system:String x:Key="prefs.advanced">고급</system:String>
   <system:String x:Key="prefs.advanced.beta">베타 버전 사용</system:String>
-  <system:String x:Key="prefs.advanced.lyricshelper">가사 도우미</system:String>
-  <system:String x:Key="prefs.advanced.lyricshelper.brackets">가사 도우미의 발음 힌트에 대괄호 추가</system:String>
+  <system:String x:Key="prefs.advanced.lyricshelper">가사 입력 도우미</system:String>
+  <system:String x:Key="prefs.advanced.lyricshelper.brackets">가사 입력 도우미의 대괄호 자동 추가</system:String>
   <system:String x:Key="prefs.advanced.rememberfiletypes">'최근 파일'에 표시할 파일 유형</system:String>
   <system:String x:Key="prefs.advanced.resamplerlogging">리샘플러 로깅</system:String>
-  <system:String x:Key="prefs.advanced.resamplerlogging.warn">리샘플러의 결과물을 로그 파일에 저장합니다. 이 설정은 UI와 렌더링 성능을 낮출 수 있습니다.</system:String>
-  <system:String x:Key="prefs.advanced.stable">안정 버전</system:String>
-  <system:String x:Key="prefs.advanced.vlabelerpath">vLabeler가 설치된 위치</system:String>
+  <system:String x:Key="prefs.advanced.resamplerlogging.warn">리샘플러의 결과물을 로그 파일들로 저장합니다. UI와 렌더링의 속도가 느려질 수 있어요.</system:String>
+  <system:String x:Key="prefs.advanced.stable">안정화 버전</system:String>
+  <system:String x:Key="prefs.advanced.vlabelerpath">vLabeler 설치 경로</system:String>
   <system:String x:Key="prefs.appearance">외형</system:String>
   <system:String x:Key="prefs.appearance.degree">음계 표시</system:String>
-  <system:String x:Key="prefs.appearance.degree.numbered">순번(1 2 3 4 5 6 7)</system:String>
-  <system:String x:Key="prefs.appearance.degree.off">끄기</system:String>
-  <system:String x:Key="prefs.appearance.degree.solfege">계이름(도 레 미 파 솔 라 시)</system:String>
+  <system:String x:Key="prefs.appearance.degree.numbered">숫자매김 (1 2 3 4 5 6 7)</system:String>
+  <system:String x:Key="prefs.appearance.degree.off">미사용</system:String>
+  <system:String x:Key="prefs.appearance.degree.solfege">계이름 (do re mi fa sol la ti)</system:String>
   <system:String x:Key="prefs.appearance.lang">언어</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">피아노 롤에 다른 트랙의 노트 표시</system:String>
   <system:String x:Key="prefs.appearance.showicon">피아노 롤에 가수 아이콘 표시</system:String>
@@ -315,8 +315,8 @@
   <system:String x:Key="prefs.otoeditor">원음 설정 에디터</system:String>
   <system:String x:Key="prefs.otoeditor.select">기본 원음 설정 에디터</system:String>
   <system:String x:Key="prefs.paths">경로</system:String>
-  <system:String x:Key="prefs.paths.addlsinger">추가 가수 폴더</system:String>
-  <system:String x:Key="prefs.paths.addlsinger.install">가수 설치 시 '추가 가수 폴더'에 설치</system:String>
+  <system:String x:Key="prefs.paths.addlsinger">확장 가수 폴더</system:String>
+  <system:String x:Key="prefs.paths.addlsinger.install">가수 설치 시 '확장 가수 폴더'에 설치</system:String>
   <system:String x:Key="prefs.paths.reset">재설정</system:String>
   <system:String x:Key="prefs.paths.select">선택</system:String>
   <system:String x:Key="prefs.playback">재생</system:String>
@@ -329,18 +329,18 @@
   <system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>
   <system:String x:Key="prefs.playback.cursorposition">자동 스크롤 여백</system:String>
   <system:String x:Key="prefs.playback.device">오디오 재생 장치</system:String>
-  <system:String x:Key="prefs.playback.lockstarttime">일시 정지 동작</system:String>
-  <system:String x:Key="prefs.playback.lockstarttime.off">아무것도 하지 않음</system:String>
-  <system:String x:Key="prefs.playback.lockstarttime.on">재생을 시작한 위치로 커서 이동</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime">일시정지할 때</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime.off">아무것도 안 하기</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime.on">재생을 시작했던 위치로 커서 옮기기</system:String>
   <system:String x:Key="prefs.playback.test">출력 테스트</system:String>
   <system:String x:Key="prefs.rendering">렌더링</system:String>
-  <system:String x:Key="prefs.rendering.defaultrenderer">Classic 음원의 기본 렌더러</system:String>
+  <system:String x:Key="prefs.rendering.defaultrenderer">기본 렌더러 (Classic 음원용)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger 렌더링 깊이(Depth)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger 렌더링 가속</system:String>
   <system:String x:Key="prefs.rendering.onnxgpu">그래픽 카드(GPU)</system:String>
   <system:String x:Key="prefs.rendering.onnxrunner">머신러닝을 실행할 장치</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">위상 보정</system:String>
-  <system:String x:Key="prefs.rendering.prerender">미리 렌더링</system:String>
+  <system:String x:Key="prefs.rendering.prerender">미리보기용 렌더</system:String>
   <system:String x:Key="prefs.rendering.resampler">리샘플러</system:String>
   <system:String x:Key="prefs.rendering.resampler.morewarn">
     경고: moresampler는 완벽하게 지원되지 않습니다. 속도가 느릴 수 있고, 높은 CPU 점유율 유발할 수 있습니다. 그래도 사용하시려면 다음을 따라 주세요.
@@ -349,7 +349,7 @@
     3. moresampler가 누락된 llsm 파일을 다 생성할 때까지 대기
   </system:String>
   <system:String x:Key="prefs.rendering.resampler.note">
-    참고: 외부 리샘플러를 사용하시려면 OpenUtau 설치 폴더의 Resamplers 폴더 안에 리샘플러의 DLL 파일이나 EXE 파일을 넣어 주세요. 이후 환경 설정에서 리샘플러를 선택해 주세요.
+    참고: 외부 리샘플러를 사용하려면, OpenUtau 설치 경로 속 Resamplers 폴더에 리샘플러의 DLL 또는 EXE 파일을 넣어 주세요. 그리고 환경 설정에서 리샘플러를 선택합시다.
   </system:String>
   <system:String x:Key="prefs.rendering.threads.cpuwarn">
     경고: 렌더링 스레드가 너무 많으면 OpenUtau가 느리게 작동할 수 있습니다.
@@ -376,13 +376,13 @@
   <system:String x:Key="singers.otoview.moveright">오른쪽으로 이동</system:String>
   <system:String x:Key="singers.otoview.selectnext">다음 선택</system:String>
   <system:String x:Key="singers.otoview.selectprev">이전 선택</system:String>
-  <system:String x:Key="singers.otoview.showall">모두 보기</system:String>
+  <system:String x:Key="singers.otoview.showall">모두 보이기</system:String>
   <system:String x:Key="singers.otoview.zoomin">확대</system:String>
   <system:String x:Key="singers.otoview.zoomout">축소</system:String>
   <system:String x:Key="singers.playsample">샘플 재생</system:String>
-  <system:String x:Key="singers.readme">readme.txt 실행</system:String>
-  <system:String x:Key="singers.readme.notfound">readme.txt가 없습니다.</system:String>
-  <system:String x:Key="singers.refresh">새로 고침</system:String>
+  <system:String x:Key="singers.readme">readme.txt 열기</system:String>
+  <system:String x:Key="singers.readme.notfound">readme.txt를 찾지 못했어요.</system:String>
+  <system:String x:Key="singers.refresh">새로고침</system:String>
   <system:String x:Key="singers.setdefaultphonemizer">기본 음소화기 설정</system:String>
   <system:String x:Key="singers.setencoding">인코딩 설정</system:String>
   <system:String x:Key="singers.setimage">아이콘 지정</system:String>
@@ -392,12 +392,12 @@
   <system:String x:Key="singers.subbanks.clear">비우기</system:String>
   <system:String x:Key="singers.subbanks.color">음색</system:String>
   <system:String x:Key="singers.subbanks.color.add">음색 추가</system:String>
-  <system:String x:Key="singers.subbanks.color.remove">음색 지우기</system:String>
+  <system:String x:Key="singers.subbanks.color.remove">음색 삭제</system:String>
   <system:String x:Key="singers.subbanks.color.rename">음색 이름 변경</system:String>
   <system:String x:Key="singers.subbanks.edit">서브 뱅크 편집</system:String>
   <system:String x:Key="singers.subbanks.export">prefix.map 내보내기</system:String>
   <system:String x:Key="singers.subbanks.import">prefix.map 불러오기</system:String>
-  <system:String x:Key="singers.subbanks.reset">재설정</system:String>
+  <system:String x:Key="singers.subbanks.reset">초기화</system:String>
   <system:String x:Key="singers.subbanks.save">저장</system:String>
   <system:String x:Key="singers.subbanks.selectall">모두 선택</system:String>
   <system:String x:Key="singers.subbanks.set">설정</system:String>
@@ -406,39 +406,39 @@
   <system:String x:Key="singers.visitwebsite">웹사이트 방문</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">압축 파일의 인코딩</system:String>
-  <system:String x:Key="singersetup.archivefileencoding.prompt">파일 이름이 정상적으로 표시되는 인코딩 설정을 선택해 주세요.</system:String>
+  <system:String x:Key="singersetup.archivefileencoding.prompt">파일명이 정상적으로 보이는 인코딩을 골라 주세요.</system:String>
   <system:String x:Key="singersetup.back">이전</system:String>
   <system:String x:Key="singersetup.install">설치</system:String>
   <system:String x:Key="singersetup.missinginfo">음원의 character.yaml에 다음 설정이 없어, 정보 입력을 진행합니다.</system:String>
   <system:String x:Key="singersetup.next">다음</system:String>
   <system:String x:Key="singersetup.singertype">가수 유형</system:String>
   <system:String x:Key="singersetup.textfileencoding">텍스트 파일 인코딩</system:String>
-  <system:String x:Key="singersetup.textfileencoding.prompt">텍스트 파일 내용이 정상적으로 표시되는 인코딩 설정을 선택해 주세요.</system:String>
+  <system:String x:Key="singersetup.textfileencoding.prompt">텍스트가 정상적으로 보이는 인코딩을 골라 주세요.</system:String>
 
   <system:String x:Key="tip.aliasbox">에일리어스 덮어쓰기</system:String>
-  <system:String x:Key="tip.exps">왼쪽 클릭: 표현 설정
-오른쪽 클릭: 표현 재설정</system:String>
-  <system:String x:Key="tip.exps.notsupported">렌더러가 이 표현을 지원하지 않습니다</system:String>
-  <system:String x:Key="tip.lyricbox.next">Tab: 다음 노트</system:String>
-  <system:String x:Key="tip.lyricbox.prev">Shift + Tab: 이전 노트</system:String>
-  <system:String x:Key="tip.notes.basics">선택 툴
-    박스 선택: 노트 선택
-    Ctrl + 박스 선택: 여러 노트 선택
-    위/아래 화살표: 노트를 위로 이동
-    Ctrl + 위/아래 화살표: 한 옥타브씩 노트를 이동
-펜 툴
-    왼쪽 클릭한 채 이동: 노트 추가
-    오른쪽 클릭: 노트 삭제
-    오른쪽 클릭한 채 이동: 여러 노트 삭제
-일반
-    T: 팁 켜고 끄기
-    노트 드래그: 노트 이동
-    노트 끝 드래그: 노트 사이즈 변경
-    Alt + 노트 끝 드래그: 이웃한 노트 사이즈 수정
-    스페이스 키: 재생
+  <system:String x:Key="tip.exps">표현 설정: 왼쪽 마우스로 긋기
+표현 초기화: 오른쪽 마우스로 긋기</system:String>
+  <system:String x:Key="tip.exps.notsupported">렌더러가 이 표현을 지원하지 않아요</system:String>
+  <system:String x:Key="tip.lyricbox.next">다음 노트로: Tab</system:String>
+  <system:String x:Key="tip.lyricbox.prev">이전 노트로: Shift+Tab</system:String>
+  <system:String x:Key="tip.notes.basics">선택 도구
+    여러 노트 선택: Ctrl + 사각 범위 선택
+    추가로 노트 선택: Ctrl + 사각 범위 선택
+    선택된 노트들 음정 옮김: 위/아래 방향키  
+    선택된 노트들 옥타브 옮김: Ctrl + 위/아래 방향키
+펜
+    노트 생성: 왼쪽 마우스로 긋기
+    노트 삭제: 오른쪽 클릭
+    여러 노트 삭제: 오른쪽 마우스로 긋기
+기본
+    팁 켜고 끄기: T
+    노트 위치 이동: 노트 드래그
+    노트 길이 변경: 노트 끝 드래그
+    이웃한 노트 길이까지 변경: Alt + 노트 끝 드래그
+    재생: 스페이스 바
   </system:String>
-  <system:String x:Key="tip.notes.zoomx">◀ 수평으로 확대하려면 여기서 스크롤하세요 ▶</system:String>
-  <system:String x:Key="tip.notes.zoomy">수직으로 확대하려면 여기서 스크롤하세요 ▶</system:String>
+  <system:String x:Key="tip.notes.zoomx">◀ 수평으로 확대하려면 여기서 스크롤 ▶</system:String>
+  <system:String x:Key="tip.notes.zoomy">수직으로 확대하려면 여기서 스크롤 ▶</system:String>
 
   <system:String x:Key="tracks.duplicate">트랙 복제</system:String>
   <system:String x:Key="tracks.duplicatesettings">트랙 설정 복제</system:String>
@@ -446,7 +446,7 @@
   <system:String x:Key="tracks.movedown">아래로 이동</system:String>
   <system:String x:Key="tracks.moveup">위로 이동</system:String>
   <system:String x:Key="tracks.mute">음소거</system:String>
-  <system:String x:Key="tracks.mute.allothers">다른 모든 트랙 음소거</system:String>
+  <system:String x:Key="tracks.mute.allothers">모든 다른 트랙 음소거</system:String>
   <system:String x:Key="tracks.mute.only">이 트랙만 음소거</system:String>
   <system:String x:Key="tracks.mute.unmuteall">모든 트랙 음소거 해제</system:String>
   <system:String x:Key="tracks.remove">트랙 제거</system:String>
@@ -464,14 +464,14 @@
 
   <system:String x:Key="updater.caption">업데이트 확인</system:String>
   <system:String x:Key="updater.description">오픈소스 음성 합성 플랫폼</system:String>
-  <system:String x:Key="updater.github">GitHub 방문</system:String>
+  <system:String x:Key="updater.github">GitHub</system:String>
   <system:String x:Key="updater.status.available">v{0} 버전 업데이트가 있습니다!</system:String>
-  <system:String x:Key="updater.status.checking">업데이트를 확인 중입니다...</system:String>
-  <system:String x:Key="updater.status.notavailable">이미 최신 버전입니다</system:String>
-  <system:String x:Key="updater.status.unknown">업데이트를 확인할 수 없습니다</system:String>
+  <system:String x:Key="updater.status.checking">업데이트 확인 중...</system:String>
+  <system:String x:Key="updater.status.notavailable">최신 버전</system:String>
+  <system:String x:Key="updater.status.unknown">업데이트를 확인할 수 없어요</system:String>
   <system:String x:Key="updater.update">업데이트</system:String>
 
   <system:String x:Key="warning">경고</system:String>
-  <system:String x:Key="warning.asciipath">OpenUtau 경로 "{0}"에 ASCII 인코딩에 없는 문자가 포함되어 있습니다. exe 리샘플러가 작동하지 않을 수 있습니다.</system:String>
+  <system:String x:Key="warning.asciipath">OpenUtau 설치 경로 "{0}"에 비 ASCII 문자가 있어요. Exe 리샘플러가 작동하지 않을 수 있습니다. </system:String>
   <system:String x:Key="warning.renderer">이 렌더러에 대한 설정이 없습니다.</system:String>
 </ResourceDictionary>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -3,25 +3,25 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <system:String x:Key="context.note.copy">노트 복사</system:String>
-  <system:String x:Key="context.note.delete">노트 지우기</system:String>
+  <system:String x:Key="context.note.delete">노트 삭제</system:String>
   <system:String x:Key="context.note.pasteparameters">선택하고 파라미터 붙여넣기</system:String>
-  <system:String x:Key="context.part.delete">파트 지우기</system:String>
+  <system:String x:Key="context.part.delete">파트 삭제</system:String>
   <system:String x:Key="context.part.gotofile">파일 위치 열기</system:String>
   <system:String x:Key="context.part.rename">파트 이름 변경</system:String>
-  <system:String x:Key="context.part.replaceaudio">오디오 파일 변경</system:String>
+<system:String x:Key="context.part.replaceaudio">오디오 파일 교체</system:String>
   <system:String x:Key="context.part.transcribe">소리를 노트 파트로 변환</system:String>
   <system:String x:Key="context.part.transcribing">변환 중</system:String>
-  <system:String x:Key="context.pitch.easein">Ease in 곡선</system:String>
-  <system:String x:Key="context.pitch.easeinout">Ease in/out 곡선</system:String>
-  <system:String x:Key="context.pitch.easeout">Ease out 곡선</system:String>
-  <system:String x:Key="context.pitch.linear">선형</system:String>
+  <system:String x:Key="context.pitch.easein">Ease in</system:String>
+  <system:String x:Key="context.pitch.easeinout">Ease in/out</system:String>
+  <system:String x:Key="context.pitch.easeout">Ease out</system:String>
+  <system:String x:Key="context.pitch.linear">Linear</system:String>
   <system:String x:Key="context.pitch.pointadd">피치 점 추가</system:String>
   <system:String x:Key="context.pitch.pointdel">피치 점 삭제</system:String>
   <system:String x:Key="context.pitch.pointsnapprev">이전 노트에 물리기</system:String>
   <system:String x:Key="context.timeline.addtempo">{0}에서 템포 변경</system:String>
   <system:String x:Key="context.timeline.addtimesig">박자표 변경</system:String>
-  <system:String x:Key="context.timeline.deltempo">{0}에서 바뀐 템포 지우기</system:String>
-  <system:String x:Key="context.timeline.deltimesig">바뀐 박자표 지우기</system:String>
+  <system:String x:Key="context.timeline.deltempo">{0}에서 변경된 템포 삭제</system:String>
+  <system:String x:Key="context.timeline.deltimesig">변경된 박자표 삭제</system:String>
 
   <system:String x:Key="debug.clear">비우기</system:String>
   <system:String x:Key="debug.copylog">로그 복사</system:String>
@@ -29,16 +29,16 @@
 
   <system:String x:Key="dialogs.about.caption">OpenUTAU란?</system:String>
   <system:String x:Key="dialogs.about.message">
-    OpenUtau(오픈 우타우)는 UTAU(우타우) 커뮤니티를 위한 오픈 소스 에디팅 환경으로, 세련된 사용자 경험과 폭넓은 음운 지원을 제공합니다. 지금 GitHub에서 OpenUtau 레포지토리를 방문해 보세요.
+    OpenUtau(오픈우타우)는 세련된 사용자 경험과 유연한 음운 지원을 통해, UTAU 커뮤니티를 위한 오픈 소스 편집 환경이 되고자 합니다. 지금 GitHub의 OpenUtau 레포지토리를 방문해 보세요.
   </system:String>
   <system:String x:Key="dialogs.exitsave.caption">프로젝트 닫기</system:String>
-  <system:String x:Key="dialogs.exitsave.message">프로젝트 파일이 저장되지 않았습니다. 저장할까요?</system:String>
+  <system:String x:Key="dialogs.exitsave.message">프로젝트가 저장되지 않았습니다. 저장할까요?</system:String>
   <system:String x:Key="dialogs.export.caption">내보내기</system:String>
-  <system:String x:Key="dialogs.export.savefirst">먼저 프로젝트 파일을 저장해야 합니다</system:String>
-  <system:String x:Key="dialogs.installdependency.caption">의존 요소 설치 중…</system:String>
-  <system:String x:Key="dialogs.installdependency.message">설치 중…</system:String>
-  <system:String x:Key="dialogs.installdll.caption">음소화기 설치 중…</system:String>
-  <system:String x:Key="dialogs.installdll.message">설치 중…</system:String>
+  <system:String x:Key="dialogs.export.savefirst">먼저 프로젝트 파일을 저장해 주세요</system:String>
+  <system:String x:Key="dialogs.installdependency.caption">의존 요소 설치 중</system:String>
+  <system:String x:Key="dialogs.installdependency.message">설치 중</system:String>
+  <system:String x:Key="dialogs.installdll.caption">음소화기 설치 중</system:String>
+  <system:String x:Key="dialogs.installdll.message">설치 중</system:String>
   <system:String x:Key="dialogs.messagebox.cancel">취소</system:String>
   <system:String x:Key="dialogs.messagebox.copy">클립보드에 오류 복사</system:String>
   <system:String x:Key="dialogs.messagebox.no">아니요</system:String>
@@ -69,7 +69,7 @@
   <system:String x:Key="exps.minvalue">최솟값</system:String>
   <system:String x:Key="exps.name">이름</system:String>
   <system:String x:Key="exps.optionvalues">선택형 값</system:String>
-  <system:String x:Key="exps.sepbycomma">쉼표(,)로 값을 구분할 수 있습니다</system:String>
+  <system:String x:Key="exps.sepbycomma">값은 쉼표(,)로 구분합니다</system:String>
   <system:String x:Key="exps.type">유형</system:String>
   <system:String x:Key="exps.type.curve">커브형</system:String>
   <system:String x:Key="exps.type.numerical">숫자형</system:String>
@@ -80,7 +80,7 @@
   <system:String x:Key="lyrics.caption">가사 편집하기</system:String>
   <system:String x:Key="lyrics.livepreview">실시간 노트 미리보기</system:String>
   <system:String x:Key="lyrics.max">최대</system:String>
-  <system:String x:Key="lyrics.reset">재설정</system:String>
+  <system:String x:Key="lyrics.reset">초기화</system:String>
   <system:String x:Key="lyrics.selectnotes">먼저 원하는 노트를 선택해 주세요!</system:String>
   <system:String x:Key="lyrics.separators">구분 기준</system:String>
 
@@ -93,13 +93,13 @@
   <system:String x:Key="lyricsreplace.preset.rmvtone">음계 접미사 지우기</system:String>
   <system:String x:Key="lyricsreplace.presets">프리셋</system:String>
   <system:String x:Key="lyricsreplace.preview">미리보기</system:String>
-  <system:String x:Key="lyricsreplace.regex">정규표현식 사용</system:String>
+  <system:String x:Key="lyricsreplace.regex">정규식 사용 가능</system:String>
   <system:String x:Key="lyricsreplace.replace">가사 일괄 수정</system:String>
 
   <system:String x:Key="menu.edit">편집</system:String>
   <system:String x:Key="menu.edit.copy">복사</system:String>
   <system:String x:Key="menu.edit.cut">잘라내기</system:String>
-  <system:String x:Key="menu.edit.delete">지우기</system:String>
+  <system:String x:Key="menu.edit.delete">삭제</system:String>
   <system:String x:Key="menu.edit.paste">붙여넣기</system:String>
   <system:String x:Key="menu.edit.redo">다시 실행</system:String>
   <system:String x:Key="menu.edit.selectall">모두 선택</system:String>
@@ -113,17 +113,17 @@
   <system:String x:Key="menu.file.exportmidi">Midi로 내보내기</system:String>
   <system:String x:Key="menu.file.exportmixdown">Wav 파일로 믹스다운</system:String>
   <system:String x:Key="menu.file.exportproject">프로젝트 내보내기</system:String>
-  <system:String x:Key="menu.file.exportust">Ust 파일 여러 개로 내보내기</system:String>
-  <system:String x:Key="menu.file.exportustto">Ust 파일 여러 개를 다른 이름으로 내보내기...</system:String>
-  <system:String x:Key="menu.file.exportwav">Wav 파일 여러 개로 내보내기</system:String>
-  <system:String x:Key="menu.file.exportwavto">Wav 파일 여러 개를 다른 이름으로 내보내기...</system:String>
+  <system:String x:Key="menu.file.exportust">개별 트랙 Ust로 내보내기</system:String>
+  <system:String x:Key="menu.file.exportustto">다른 이름으로 개별 트랙 Ust로 내보내기...</system:String>
+  <system:String x:Key="menu.file.exportwav">개별 트랙 Wav로 내보내기</system:String>
+  <system:String x:Key="menu.file.exportwavto">다른 이름으로 개별 트랙 Wav로 내보내기...</system:String>
   <system:String x:Key="menu.file.importaudio">오디오 가져오기...</system:String>
   <system:String x:Key="menu.file.importmidi">Midi 가져오기...</system:String>
   <system:String x:Key="menu.file.importmidi.drywetmidi">DryWetMidi로 가져오기</system:String>
   <system:String x:Key="menu.file.importmidi.naudio">Naudio로 가져오기</system:String>
   <system:String x:Key="menu.file.importtracks">여러 트랙 가져오기...</system:String>
   <system:String x:Key="menu.file.new">새로 만들기</system:String>
-  <system:String x:Key="menu.file.newfromtemplate">템플릿 파일로 새로 만들기</system:String>
+  <system:String x:Key="menu.file.newfromtemplate">템플릿 파일에서 새로 만들기</system:String>
   <system:String x:Key="menu.file.open">열기...</system:String>
   <system:String x:Key="menu.file.openas">다른 이름으로 열기...</system:String>
   <system:String x:Key="menu.file.openexportlocation">내보내기 위치 열기</system:String>
@@ -167,14 +167,14 @@
   <system:String x:Key="notedefaults.preset.remove.tooltip">마지막 프리셋을 삭제합니다.</system:String>
   <system:String x:Key="notedefaults.preset.save">프리셋 저장</system:String>
   <system:String x:Key="notedefaults.preset.save.tooltip">현재 세팅으로 새 프리셋 추가</system:String>
-  <system:String x:Key="notedefaults.reset">모든 설정 초기화</system:String>
-  <system:String x:Key="notedefaults.reset.tooltip">모든 설정을 기본값으로 설정합니다.
-주의: 사용자가 만들어 둔 프리셋이 전부 사라집니다.</system:String>
+  <system:String x:Key="notedefaults.reset">사용자 설정 초기화</system:String>
+  <system:String x:Key="notedefaults.reset.tooltip">모든 설정 항목을 기본값으로 복구합니다.
+경고: 내 커스텀 프리셋이 전부 사라져요. </system:String>
   <system:String x:Key="notedefaults.vibrato">비브라토</system:String>
   <system:String x:Key="notedefaults.vibrato.autominlength">최소 노트 길이</system:String>
   <system:String x:Key="notedefaults.vibrato.autotoggle">길이에 따라 비브라토 자동 적용</system:String>
   <system:String x:Key="notedefaults.vibrato.depth">깊이</system:String>
-  <system:String x:Key="notedefaults.vibrato.drift">드리프트(상하 이동)</system:String>
+  <system:String x:Key="notedefaults.vibrato.drift">음정 드리프트</system:String>
   <system:String x:Key="notedefaults.vibrato.in">페이드 인</system:String>
   <system:String x:Key="notedefaults.vibrato.length">길이</system:String>
   <system:String x:Key="notedefaults.vibrato.out">페이드 아웃</system:String>
@@ -203,7 +203,7 @@
   <system:String x:Key="oto.file">파일</system:String>
   <system:String x:Key="oto.offset">오프셋</system:String>
   <system:String x:Key="oto.overlap">오버랩(OVL)</system:String>
-  <system:String x:Key="oto.phonetic">음성 기호</system:String>
+  <system:String x:Key="oto.phonetic">음성기호</system:String>
   <system:String x:Key="oto.prefix">접두사</system:String>
   <system:String x:Key="oto.preutter">선행 발성(PRE)</system:String>
   <system:String x:Key="oto.set">폴더</system:String>
@@ -237,7 +237,7 @@
   <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">렌더링된 피치 커브 불러오기</system:String>
   <system:String x:Key="pianoroll.menu.notes.octavedown">한 옥타브 아래로</system:String>
   <system:String x:Key="pianoroll.menu.notes.octaveup">한 옥타브 위로</system:String>
-  <system:String x:Key="pianoroll.menu.notes.quantize15">1/128 퀀타이즈</system:String>
+  <system:String x:Key="pianoroll.menu.notes.quantize15">1/128로 퀀타이즈</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize30">1/64로 퀀타이즈</system:String>
   <system:String x:Key="pianoroll.menu.notes.removetaildash">끝에 '-' 노트 지우기</system:String>
   <system:String x:Key="pianoroll.menu.notes.removetailrest">끝에 'R' 노트 지우기</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -111,7 +111,7 @@
   <system:String x:Key="menu.file.exportds.v2">다른 이름으로 DiffSinger 스크립트 내보내기 (v2)</system:String>
   <system:String x:Key="menu.file.exportds.v2withoutpitch">다른 이름으로 DiffSinger 스크립트 내보내기 (v2, 피치 벤드 제외)</system:String>
   <system:String x:Key="menu.file.exportmidi">Midi로 내보내기</system:String>
-  <system:String x:Key="menu.file.exportmixdown">모두 합쳐 Wav로 내보내기</system:String>
+  <system:String x:Key="menu.file.exportmixdown">Wav 파일로 믹스다운</system:String>
   <system:String x:Key="menu.file.exportproject">프로젝트 내보내기</system:String>
   <system:String x:Key="menu.file.exportust">Ust 파일 여러 개로 내보내기</system:String>
   <system:String x:Key="menu.file.exportustto">Ust 파일 여러 개를 다른 이름으로 내보내기...</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -84,8 +84,8 @@
   <system:String x:Key="lyrics.selectnotes">먼저 원하는 노트를 선택해 주세요!</system:String>
   <system:String x:Key="lyrics.separators">구분 기준</system:String>
 
-  <system:String x:Key="lyricsreplace.after">수정 전</system:String>
-  <system:String x:Key="lyricsreplace.before">수정 후</system:String>
+  <system:String x:Key="lyricsreplace.after">수정 후:</system:String>
+  <system:String x:Key="lyricsreplace.before">수정 전:</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvalphabet">알파벳 지우기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvnonhiragana">히라가나만 남기기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvphonetichint">발음 힌트 지우기</system:String>
@@ -179,7 +179,7 @@
   <system:String x:Key="notedefaults.vibrato.length">길이</system:String>
   <system:String x:Key="notedefaults.vibrato.out">페이드 아웃</system:String>
   <system:String x:Key="notedefaults.vibrato.period">주기</system:String>
-  <system:String x:Key="notedefaults.vibrato.shift">시프트(좌우 이동)</system:String>
+  <system:String x:Key="notedefaults.vibrato.shift">위상</system:String>
   <system:String x:Key="notedefaults.vibrato.vollink">볼륨 변화량</system:String>
 
   <system:String x:Key="noteproperty">노트 속성</system:String>
@@ -293,7 +293,7 @@
   <system:String x:Key="prefs.advanced.stable">안정 버전</system:String>
   <system:String x:Key="prefs.advanced.vlabelerpath">vLabeler가 설치된 위치</system:String>
   <system:String x:Key="prefs.appearance">외형</system:String>
-  <system:String x:Key="prefs.appearance.degree">음 이름 표시 설정</system:String>
+  <system:String x:Key="prefs.appearance.degree">음계 표시</system:String>
   <system:String x:Key="prefs.appearance.degree.numbered">순번(1 2 3 4 5 6 7)</system:String>
   <system:String x:Key="prefs.appearance.degree.off">끄기</system:String>
   <system:String x:Key="prefs.appearance.degree.solfege">계이름(도 레 미 파 솔 라 시)</system:String>
@@ -322,8 +322,8 @@
   <system:String x:Key="prefs.playback">재생</system:String>
   <system:String x:Key="prefs.playback.autoscroll">자동 스크롤</system:String>
   <system:String x:Key="prefs.playback.autoscrollmode">자동 스크롤 모드</system:String>
-  <system:String x:Key="prefs.playback.autoscrollmode.pagescroll">페이지 넘기듯 스크롤</system:String>
-  <system:String x:Key="prefs.playback.autoscrollmode.stationarycursor">두루마리 읽듯 스크롤</system:String>
+  <system:String x:Key="prefs.playback.autoscrollmode.pagescroll">페이지 스크롤</system:String>
+  <system:String x:Key="prefs.playback.autoscrollmode.stationarycursor">커서 스크롤</system:String>
   <system:String x:Key="prefs.playback.backend">오디오 백엔드</system:String>
   <system:String x:Key="prefs.playback.backend.auto">자동</system:String>
   <system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>
@@ -343,10 +343,10 @@
   <system:String x:Key="prefs.rendering.prerender">미리 렌더링</system:String>
   <system:String x:Key="prefs.rendering.resampler">리샘플러</system:String>
   <system:String x:Key="prefs.rendering.resampler.morewarn">
-    경고: 아직 moresampler는 완벽하게 지원되는 상태가 아닙니다. 속도가 느릴 수 있고, 높은 CPU 점유율 유발할 수 있습니다. 그래도 사용하시려면 다음을 따라 주세요.
-    1. moreconfig.txt를 열어 resampler-compatibility 항목을 "on"으로 설정합니다.
-    2. 같은 파일에서 resampler-compatibility 항목을 "off"로 설정합니다.
-    3. moresampler가 누락된 llsm 파일을 다 생성할 때까지 느긋하게 기다립니다.
+    경고: moresampler는 완벽하게 지원되지 않습니다. 속도가 느릴 수 있고, 높은 CPU 점유율 유발할 수 있습니다. 그래도 사용하시려면 다음을 따라 주세요.
+    1. moreconfig.txt를 열어 resampler-compatibility 항목을 "on"으로 설정
+    2. 같은 파일에서 resampler-compatibility 항목을 "off"로 설정
+    3. moresampler가 누락된 llsm 파일을 다 생성할 때까지 대기
   </system:String>
   <system:String x:Key="prefs.rendering.resampler.note">
     참고: 외부 리샘플러를 사용하시려면 OpenUtau 설치 폴더의 Resamplers 폴더 안에 리샘플러의 DLL 파일이나 EXE 파일을 넣어 주세요. 이후 환경 설정에서 리샘플러를 선택해 주세요.
@@ -362,7 +362,7 @@
   <system:String x:Key="progress.waitingrendering">렌더링을 기다리는 중</system:String>
 
   <system:String x:Key="singers.caption">가수 목록</system:String>
-  <system:String x:Key="singers.editoto.editinvlabeler">vLabeler에서 원음 설정</system:String>
+  <system:String x:Key="singers.editoto.editinvlabeler">vLabeler로 편집</system:String>
   <system:String x:Key="singers.editoto.gotosource">원본 파일로 이동</system:String>
   <system:String x:Key="singers.editoto.regenfrq">FRQ 재생성</system:String>
   <system:String x:Key="singers.editoto.regenfrq.regenerating">가수의 FRQ 파일 재생성 중...</system:String>
@@ -454,8 +454,8 @@
   <system:String x:Key="tracks.selectrenderer">렌더러 선택</system:String>
   <system:String x:Key="tracks.selectsinger">가수 선택</system:String>
   <system:String x:Key="tracks.solo">솔로</system:String>
-  <system:String x:Key="tracks.solo.add">함께 솔로(다른 트랙의 솔로는 끄지 않음)</system:String>
-  <system:String x:Key="tracks.solo.only">이 트랙만 솔로(다른 트랙의 솔로는 끔)</system:String>
+  <system:String x:Key="tracks.solo.add">솔로 추가 (다른 트랙의 솔로는 해제하지 않음)</system:String>
+  <system:String x:Key="tracks.solo.only">솔로 (다른 트랙의 솔로 해제)</system:String>
   <system:String x:Key="tracks.solo.unsoloall">모든 트랙의 솔로를 해제</system:String>
   <system:String x:Key="tracks.trackcolor">트랙 색상 변경</system:String>
   <system:String x:Key="tracks.tracksettings">트랙 설정</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -11,16 +11,16 @@
   <system:String x:Key="context.part.replaceaudio">오디오 파일 바꾸기</system:String>
   <!--<system:String x:Key="context.part.transcribe">Transcribe audio to create a note part</system:String>-->
   <!--<system:String x:Key="context.part.transcribing">Transcribing</system:String>-->
-  <system:String x:Key="context.pitch.easein">피치선 다듬기(ease in)</system:String>
-  <system:String x:Key="context.pitch.easeinout">피치선 다듬기(ease in and out)</system:String>
-  <system:String x:Key="context.pitch.easeout">피치선 다듬기(ease out)</system:String>
-  <system:String x:Key="context.pitch.linear">피치선 다듬기(linear)</system:String>
+  <system:String x:Key="context.pitch.easein">피치선 다듬기(Ease in)</system:String>
+  <system:String x:Key="context.pitch.easeinout">피치선 다듬기(Ease in and out)</system:String>
+  <system:String x:Key="context.pitch.easeout">피치선 다듬기(Ease out)</system:String>
+  <system:String x:Key="context.pitch.linear">피치선 다듬기(Linear)</system:String>
   <system:String x:Key="context.pitch.pointadd">피치 점 추가</system:String>
   <system:String x:Key="context.pitch.pointdel">피치 점 삭제</system:String>
   <system:String x:Key="context.pitch.pointsnapprev">이전 노트에 물리기</system:String>
-  <system:String x:Key="context.timeline.addtempo">{0} 에서 템포 바꾸기</system:String>
+  <system:String x:Key="context.timeline.addtempo">{0}에서 템포 바꾸기</system:String>
   <system:String x:Key="context.timeline.addtimesig">박자표 바꾸기</system:String>
-  <system:String x:Key="context.timeline.deltempo">{0} 에서 바뀐 템포 지우기</system:String>
+  <system:String x:Key="context.timeline.deltempo">{0}에서 바뀐 템포 지우기</system:String>
   <system:String x:Key="context.timeline.deltimesig">바뀐 박자표 지우기</system:String>
 
   <system:String x:Key="debug.clear">비우기</system:String>
@@ -29,99 +29,99 @@
 
   <system:String x:Key="dialogs.about.caption">OpenUTAU란?</system:String>
   <system:String x:Key="dialogs.about.message">
-    OpenUtau(오픈우타우)는 UTAU(우타우) 커뮤니티를 위한 오픈 소스 에디팅 환경으로, 세련된 UX와 폭넓은 음운 지원 제공을 표방합니다. 지금 깃헙에서 OpenUtau 레포지토리를 방문해 보세요.
+    OpenUtau(오픈 우타우)는 UTAU(우타우) 커뮤니티를 위한 오픈 소스 에디팅 환경으로, 세련된 사용자 경험과 폭넓은 음운 지원을 제공합니다. 지금 GitHub에서 OpenUtau 레포지토리를 방문해 보세요.
   </system:String>
   <system:String x:Key="dialogs.exitsave.caption">프로젝트 닫기</system:String>
-  <system:String x:Key="dialogs.exitsave.message">프로젝트 파일이 저장되지 않았어요. 저장할까요?</system:String>
+  <system:String x:Key="dialogs.exitsave.message">프로젝트 파일이 저장되지 않았습니다. 저장할까요?</system:String>
   <system:String x:Key="dialogs.export.caption">내보내기</system:String>
-  <system:String x:Key="dialogs.export.savefirst">먼저 프로젝트 파일을 저장해야 해요!</system:String>
-  <system:String x:Key="dialogs.installdependency.caption">의존요소 설치 중이에요…</system:String>
-  <system:String x:Key="dialogs.installdependency.message">설치 중이에요…</system:String>
-  <system:String x:Key="dialogs.installdll.caption">음소화기 설치 중이에요…</system:String>
-  <system:String x:Key="dialogs.installdll.message">설치 중이에요…</system:String>
+  <system:String x:Key="dialogs.export.savefirst">먼저 프로젝트 파일을 저장해야 합니다!</system:String>
+  <system:String x:Key="dialogs.installdependency.caption">의존 요소 설치 중…</system:String>
+  <system:String x:Key="dialogs.installdependency.message">설치 중…</system:String>
+  <system:String x:Key="dialogs.installdll.caption">음소화기 설치 중…</system:String>
+  <system:String x:Key="dialogs.installdll.message">설치 중…</system:String>
   <system:String x:Key="dialogs.messagebox.cancel">취소</system:String>
   <!--<system:String x:Key="dialogs.messagebox.copy">Copy error to clipboard</system:String>-->
   <system:String x:Key="dialogs.messagebox.no">아니요</system:String>
   <system:String x:Key="dialogs.messagebox.ok">확인</system:String>
   <system:String x:Key="dialogs.messagebox.yes">네</system:String>
-  <system:String x:Key="dialogs.noresampler.caption">리샘플러가 없어요.</system:String>
-  <system:String x:Key="dialogs.noresampler.message">폴더에 리샘플러가 없어요! 좋아하는 리샘플러의 exe나 dll을 "Resamplers"폴더에 넣고, "환경 설정"을 켜서 원하는 리샘플러를 골라 봅시다.</system:String>
+  <system:String x:Key="dialogs.noresampler.caption">리샘플러가 없습니다.</system:String>
+  <system:String x:Key="dialogs.noresampler.message">리샘플러가 없습니다! 좋아하는 리샘플러의 exe나 dll을 'Resamplers' 폴더에 넣고, 환경 설정에서 원하는 리샘플러를 골라 보세요.</system:String>
   <system:String x:Key="dialogs.timesig.caption">박자표</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">트랙 설정</system:String>
   <system:String x:Key="dialogs.tracksettings.location">위치 열기</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">렌더러</system:String>
-  <system:String x:Key="dialogs.tracksettings.setasdefault">기본값으로 사용</system:String>
+  <system:String x:Key="dialogs.tracksettings.setasdefault">기본값으로 설정</system:String>
   <system:String x:Key="dialogs.voicecolorremapping">보이스 컬러 재맵핑</system:String>
-  <system:String x:Key="dialogs.voicecolorremapping.caption">▼ 재맵핑된 컬러가 이 트랙의 모든 노트에 적용되요 </system:String>
+  <system:String x:Key="dialogs.voicecolorremapping.caption">재맵핑된 컬러가 다음 트랙의 모든 노트에 적용됩니다.</system:String>
 
-  <system:String x:Key="errors.caption">오류가 발생했어요!</system:String>
+  <system:String x:Key="errors.caption">오류가 발생했습니다!</system:String>
 
   <system:String x:Key="exps.abbr">줄임말</system:String>
   <system:String x:Key="exps.apply">적용</system:String>
   <system:String x:Key="exps.caption">표현 설정</system:String>
   <system:String x:Key="exps.defaultvalue">기본값</system:String>
   <system:String x:Key="exps.flag">리샘플러 플래그</system:String>
-  <system:String x:Key="exps.getsuggestions">렌더러가 제안하는 모든 표현들을 추가할래요</system:String>
-  <system:String x:Key="exps.isflag">리샘플러의 플래그에요</system:String>
+  <system:String x:Key="exps.getsuggestions">렌더러가 제안하는 모든 표현 추가</system:String>
+  <system:String x:Key="exps.isflag">리샘플러 플래그 여부</system:String>
   <system:String x:Key="exps.maxvalue">최댓값</system:String>
   <system:String x:Key="exps.minvalue">최솟값</system:String>
   <system:String x:Key="exps.name">표현 이름</system:String>
   <system:String x:Key="exps.optionvalues">선택형 값</system:String>
-  <system:String x:Key="exps.sepbycomma">','(쉼표)로 값을 구분해요</system:String>
+  <system:String x:Key="exps.sepbycomma">쉼표(,)로 값을 구분해요</system:String>
   <system:String x:Key="exps.type">표현 종류</system:String>
   <system:String x:Key="exps.type.curve">커브형 표현</system:String>
   <system:String x:Key="exps.type.numerical">숫자형 표현</system:String>
   <system:String x:Key="exps.type.options">선택지형 표현</system:String>
 
-  <system:String x:Key="lyrics.apply">적용하기</system:String>
+  <system:String x:Key="lyrics.apply">적용</system:String>
   <system:String x:Key="lyrics.cancel">취소</system:String>
   <system:String x:Key="lyrics.caption">가사 편집하기</system:String>
   <system:String x:Key="lyrics.livepreview">실시간 노트 미리보기</system:String>
   <system:String x:Key="lyrics.max">최대</system:String>
   <system:String x:Key="lyrics.reset">리셋</system:String>
-  <system:String x:Key="lyrics.selectnotes">먼저 원하는 노트를 "선택"해 주세요!</system:String>
+  <system:String x:Key="lyrics.selectnotes">먼저 원하는 노트를 선택해 주세요!</system:String>
   <system:String x:Key="lyrics.separators">이 값 기준으로 가사 나누기</system:String>
 
-  <system:String x:Key="lyricsreplace.after">글자 앞에서:</system:String>
-  <system:String x:Key="lyricsreplace.before">글자 뒤에서:</system:String>
+  <system:String x:Key="lyricsreplace.after">수정 전</system:String>
+  <system:String x:Key="lyricsreplace.before">수정 후</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvalphabet">알파벳 없애기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvnonhiragana">히라가나만 남기기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvphonetichint">발음 힌트 지우기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvspace">스페이스 공백 없애기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvtone">음계 접미사 없애기</system:String>
-  <system:String x:Key="lyricsreplace.presets">프리셋 ▼</system:String>
+  <system:String x:Key="lyricsreplace.presets">프리셋</system:String>
   <system:String x:Key="lyricsreplace.preview">미리보기</system:String>
-  <system:String x:Key="lyricsreplace.regex">"정규표현식" 사용</system:String>
-  <system:String x:Key="lyricsreplace.replace">가사 대체 도우미</system:String>
+  <system:String x:Key="lyricsreplace.regex">정규표현식 사용</system:String>
+  <system:String x:Key="lyricsreplace.replace">가사 일괄 수정</system:String>
 
   <system:String x:Key="menu.edit">편집</system:String>
-  <system:String x:Key="menu.edit.copy">복사하기</system:String>
+  <system:String x:Key="menu.edit.copy">복사</system:String>
   <system:String x:Key="menu.edit.cut">잘라내기</system:String>
   <system:String x:Key="menu.edit.delete">지우기</system:String>
   <system:String x:Key="menu.edit.paste">붙여넣기</system:String>
-  <system:String x:Key="menu.edit.redo">되돌리기</system:String>
+  <system:String x:Key="menu.edit.redo">다시 실행</system:String>
   <system:String x:Key="menu.edit.selectall">모두 선택</system:String>
-  <system:String x:Key="menu.edit.undo">뒤로가기</system:String>
+  <system:String x:Key="menu.edit.undo">실행 취소</system:String>
   <system:String x:Key="menu.file">파일</system:String>
   <system:String x:Key="menu.file.exit">나가기</system:String>
   <system:String x:Key="menu.file.exportaudio">오디오 내보내기</system:String>
-  <system:String x:Key="menu.file.exportds">다른 이름으로 디프싱어 스크립트 내보내기</system:String>
-  <system:String x:Key="menu.file.exportds.v2">다른 이름으로 디프싱어 스크립트 내보내기 V2</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">다른 이름으로 디프싱어 스크립트 내보내기 V2(피치선 없이!)</system:String>
-  <system:String x:Key="menu.file.exportmidi">Midi 내보내기</system:String>
-  <system:String x:Key="menu.file.exportmixdown">믹싱해서 내보내기(Wav)</system:String>
+  <system:String x:Key="menu.file.exportds">다른 이름으로 DiffSinger 스크립트 내보내기</system:String>
+  <system:String x:Key="menu.file.exportds.v2">다른 이름으로 DiffSinger 스크립트 내보내기 (v2)</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">다른 이름으로 DiffSinger 스크립트 내보내기 (v2, 피치선 제외)</system:String>
+  <system:String x:Key="menu.file.exportmidi">Midi로 내보내기</system:String>
+  <system:String x:Key="menu.file.exportmixdown">모두 합쳐 Wav로 내보내기</system:String>
   <system:String x:Key="menu.file.exportproject">프로젝트 내보내기</system:String>
-  <system:String x:Key="menu.file.exportust">Ust로 내보내기</system:String>
-  <system:String x:Key="menu.file.exportustto">다른 이름으로 Ust 내보내기...</system:String>
+  <system:String x:Key="menu.file.exportust">Ust 파일로 내보내기</system:String>
+  <system:String x:Key="menu.file.exportustto">다른 이름으로 Ust로 내보내기...</system:String>
   <system:String x:Key="menu.file.exportwav">개별 트랙을 Wav로 내보내기</system:String>
-  <system:String x:Key="menu.file.exportwavto">다른 이름으로 개별 트랙 Wav 내보내기...</system:String>
+  <system:String x:Key="menu.file.exportwavto">다른 이름으로 개별 트랙을 Wav로 내보내기...</system:String>
   <system:String x:Key="menu.file.importaudio">오디오 불러오기...</system:String>
   <system:String x:Key="menu.file.importmidi">Midi 불러오기...</system:String>
   <system:String x:Key="menu.file.importmidi.drywetmidi">DryWetMidi로 불러오기</system:String>
   <system:String x:Key="menu.file.importmidi.naudio">Naudio로 불러오기</system:String>
-  <system:String x:Key="menu.file.importtracks">트랙들 불러오기...</system:String>
+  <system:String x:Key="menu.file.importtracks">여러 트랙 불러오기...</system:String>
   <system:String x:Key="menu.file.new">새로 만들기</system:String>
-  <system:String x:Key="menu.file.newfromtemplate">템플릿 파일에서 새로 만들기</system:String>
+  <system:String x:Key="menu.file.newfromtemplate">템플릿 파일로 새로 만들기</system:String>
   <system:String x:Key="menu.file.open">열기...</system:String>
   <system:String x:Key="menu.file.openas">다른 이름으로 열기...</system:String>
   <system:String x:Key="menu.file.openexportlocation">내보낸 파일 위치 열기</system:String>
@@ -139,6 +139,7 @@
   <system:String x:Key="menu.tools">도구</system:String>
   <system:String x:Key="menu.tools.clearcache">캐시 비우기</system:String>
   <system:String x:Key="menu.tools.debugwindow">디버그 창</system:String>
+  <system:String x:Key="menu.tools.dependency.install">의존 요소 설치(.oudep)...</system:String>
   <system:String x:Key="menu.tools.layout">레이아웃</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">1:1 수평 배치</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">1:2 수평 배치</system:String>
@@ -146,48 +147,46 @@
   <system:String x:Key="menu.tools.layout.vsplit11">1:1 수직 배치</system:String>
   <system:String x:Key="menu.tools.layout.vsplit12">1:2 수직 배치</system:String>
   <system:String x:Key="menu.tools.layout.vsplit13">1:3 수직 배치</system:String>
-  <system:String x:Key="menu.tools.prefs">환경 설정</system:String>
-  <system:String x:Key="menu.tools.project.expressions">표현 설정</system:String>
-  <system:String x:Key="menu.tools.singer.install">가수 설치</system:String>
-  <system:String x:Key="menu.tools.singer.installadv">가수 설치(고급)</system:String>
-  <system:String x:Key="menu.tools.singers">가수 목록</system:String>
-  <!--<system:String x:Key="menu.view">View</system:String>-->
+  <system:String x:Key="menu.tools.prefs">환경 설정...</system:String>
+  <system:String x:Key="menu.tools.project.expressions">표현 설정...</system:String>
+  <system:String x:Key="menu.tools.singer.install">가수 설치...</system:String>
+  <system:String x:Key="menu.tools.singer.installadv">가수 설치(고급)...</system:String>
+  <system:String x:Key="menu.tools.singers">가수 목록...</system:String>
+  <system:String x:Key="menu.view">보기</system:String>
 
-  <system:String x:Key="notedefaults.lyric">노트 가사 조정</system:String>
+  <system:String x:Key="notedefaults.lyric">가사</system:String>
   <system:String x:Key="notedefaults.lyric.defaultlyric">가사 기본값</system:String>
-  <system:String x:Key="notedefaults.portamento">노트 포르타멘토 조정</system:String>
+  <system:String x:Key="notedefaults.portamento">포르타멘토</system:String>
   <system:String x:Key="notedefaults.portamento.length">길이</system:String>
   <system:String x:Key="notedefaults.portamento.start">시작</system:String>
-  <system:String x:Key="notedefaults.preset">내 프리셋</system:String>
+  <system:String x:Key="notedefaults.preset">프리셋</system:String>
   <system:String x:Key="notedefaults.preset.namenew">새 프리셋 이름 지정</system:String>
   <system:String x:Key="notedefaults.preset.remove">프리셋 제거</system:String>
   <system:String x:Key="notedefaults.preset.remove.tooltip">이 프리셋 제거</system:String>
   <system:String x:Key="notedefaults.preset.save">프리셋 저장</system:String>
   <system:String x:Key="notedefaults.preset.save.tooltip">현재 세팅으로 새 프리셋 추가</system:String>
-  <system:String x:Key="notedefaults.reset">모두 초기화(경고!)</system:String>
-  <system:String x:Key="notedefaults.reset.tooltip">
-    경고!!! 내가 만들어 둔 프리셋이 전부 사라져요!!!
-    사용자 지정 프리셋을 전부 지우고, 모든 프리셋을 기본값으로 초기화합니다.
-  </system:String>
-  <system:String x:Key="notedefaults.vibrato">노트 비브라토 조정</system:String>
-  <system:String x:Key="notedefaults.vibrato.autominlength">비브라토를 적용할 최소 길이</system:String>
-  <system:String x:Key="notedefaults.vibrato.autotoggle">긴 노트에만 비브라토 적용</system:String>
-  <system:String x:Key="notedefaults.vibrato.depth">비브라토 깊이</system:String>
-  <system:String x:Key="notedefaults.vibrato.drift">음정을 드리프트</system:String>
+  <system:String x:Key="notedefaults.reset">설정 모두 초기화</system:String>
+  <system:String x:Key="notedefaults.reset.tooltip">모든 설정을 기본값으로 설정합니다.
+    주의: 사용자가 만들어 둔 프리셋이 전부 사라집니다.</system:String>
+  <system:String x:Key="notedefaults.vibrato">비브라토</system:String>
+  <system:String x:Key="notedefaults.vibrato.autominlength">최소 노트 길이</system:String>
+  <system:String x:Key="notedefaults.vibrato.autotoggle">길이에 따라 비브라토 자동 적용</system:String>
+  <system:String x:Key="notedefaults.vibrato.depth">깊이</system:String>
+  <system:String x:Key="notedefaults.vibrato.drift">드리프트(상하 이동)</system:String>
   <system:String x:Key="notedefaults.vibrato.in">페이드 인</system:String>
-  <system:String x:Key="notedefaults.vibrato.length">비브라토 길이</system:String>
+  <system:String x:Key="notedefaults.vibrato.length">길이</system:String>
   <system:String x:Key="notedefaults.vibrato.out">페이드 아웃</system:String>
-  <system:String x:Key="notedefaults.vibrato.period">비브라토 주기</system:String>
-  <system:String x:Key="notedefaults.vibrato.shift">앞뒤 위치 이동</system:String>
-  <system:String x:Key="notedefaults.vibrato.vollink">볼륨도 함께 움직이기</system:String>
+  <system:String x:Key="notedefaults.vibrato.period">주기</system:String>
+  <system:String x:Key="notedefaults.vibrato.shift">시프트(좌우 이동)</system:String>
+  <system:String x:Key="notedefaults.vibrato.vollink">볼륨 변화량</system:String>
 
   <system:String x:Key="noteproperty">노트 속성</system:String>
   <system:String x:Key="noteproperty.apply">적용</system:String>
-  <!--<system:String x:Key="noteproperty.basic">Basic</system:String>-->
+  <system:String x:Key="noteproperty.basic">기본</system:String>
   <system:String x:Key="noteproperty.cancel">취소</system:String>
   <system:String x:Key="noteproperty.set">모든 노트에 적용</system:String>
   <system:String x:Key="noteproperty.setlongnote">긴 노트에만 적용</system:String>
-  <!--<system:String x:Key="noteproperty.tone">Tone</system:String>-->
+  <system:String x:Key="noteproperty.tone">음높이</system:String>
   <system:String x:Key="noteproperty.vibratoenable">비브라토 활성화</system:String>
 
   <system:String x:Key="oto.alias">에일리어스</system:String>
@@ -198,219 +197,201 @@
   <system:String x:Key="oto.edit.cutoff">컷오프 편집</system:String>
   <system:String x:Key="oto.edit.offset">오프셋 편집</system:String>
   <system:String x:Key="oto.edit.overlap">오버랩(OVL) 편집</system:String>
-  <system:String x:Key="oto.edit.preutter">선행발성(PRE) 편집</system:String>
+  <system:String x:Key="oto.edit.preutter">선행 발성(PRE) 편집</system:String>
   <system:String x:Key="oto.file">파일</system:String>
   <system:String x:Key="oto.offset">오프셋</system:String>
   <system:String x:Key="oto.overlap">오버랩(OVL)</system:String>
-  <system:String x:Key="oto.phonetic">음성기호</system:String>
+  <system:String x:Key="oto.phonetic">음성 기호</system:String>
   <system:String x:Key="oto.prefix">접두사</system:String>
-  <system:String x:Key="oto.preutter">선행발성(PRE)</system:String>
+  <system:String x:Key="oto.preutter">선행 발성(PRE)</system:String>
   <system:String x:Key="oto.set">폴더</system:String>
   <system:String x:Key="oto.suffix">접미사</system:String>
 
   <system:String x:Key="phoneticassistant.caption">음소 작성 도우미</system:String>
   <system:String x:Key="phoneticassistant.copy">복사</system:String>
 
-  <system:String x:Key="pianoroll.menu.batch">일괄 제어</system:String>
+  <system:String x:Key="pianoroll.menu.batch">일괄 수정</system:String>
   <system:String x:Key="pianoroll.menu.lyrics">가사 설정</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">"-"를 "+"로 바꾸기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.edit">가사 편집...</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.hiraganatoromaji">"히라가나"를 "로마자"로 바꾸기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.insertslur">"이음 기호"(+) 삽입</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.javcvtocv">"일본어 VCV 가사"를 "일본어 CV 가사"로 바꾸기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.movesuffixtovoicecolor">"가사의 접미사"를 "컬러"로 이동시키기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.removelettersuffix">"글자 접미사" 없애기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.removephonetichint">"발음 힌트" 없애기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">"음계 접미사" 없애기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">"로마자"를 "히라가나"로 바꾸기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">'-'를 '+'로 바꾸기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.edit">가사 편집</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.hiraganatoromaji">히라가나를 로마자로 바꾸기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.insertslur">이음줄 기호(+) 삽입</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.javcvtocv">일본어 VCV 가사를 일본어 CV 가사로 바꾸기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.movesuffixtovoicecolor">가사의 접미사를 컬러로 이동시키기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.removelettersuffix">글자 접미사 없애기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.removephonetichint">발음 힌트 없애기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">음계 접미사 없애기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">로마자를 히라가나로 바꾸기</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">노트 기본값</system:String>
-  <system:String x:Key="pianoroll.menu.notes">노트...</system:String>
-  <system:String x:Key="pianoroll.menu.notes.addtaildash">끝 기호 추가: "-"</system:String>
-  <system:String x:Key="pianoroll.menu.notes.addtailrest">끝 기호 추가: "R"</system:String>
-  <system:String x:Key="pianoroll.menu.notes.autolegato">선택한 노트들 자동 붙이기</system:String>
-  <system:String x:Key="pianoroll.menu.notes.bakepitch">"피치 커브"를 "피치 점을 사용하는 피치선"으로 변환</system:String>
-  <system:String x:Key="pianoroll.menu.notes.clear.vibratos">"비브라토" 아예 없애기</system:String>
-  <!--<system:String x:Key="pianoroll.menu.notes.fixoverlap">Fix overlapping notes</system:String>-->
-  <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">"중국어 한자"를 "중국어 병음"으로</system:String>
-  <system:String x:Key="pianoroll.menu.notes.lengthencrossfade">"크로스페이드 길이" 늘리기(더 부드럽게)</system:String>
-  <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">"렌더링된 피치 커브" 불러오기</system:String>
+  <system:String x:Key="pianoroll.menu.notes">노트</system:String>
+  <system:String x:Key="pianoroll.menu.notes.addtaildash">끝에 '-' 노트 추가</system:String>
+  <system:String x:Key="pianoroll.menu.notes.addtailrest">끝에 'R' 노트 추가</system:String>
+  <system:String x:Key="pianoroll.menu.notes.autolegato">노트를 서로 자동 연결</system:String>
+  <system:String x:Key="pianoroll.menu.notes.bakepitch">PTTD(피치 커브)를 피치선으로 변환</system:String>
+  <system:String x:Key="pianoroll.menu.notes.clear.vibratos">비브라토 업생기</system:String>
+  <system:String x:Key="pianoroll.menu.notes.fixoverlap">겹친 노트 고치기</system:String>
+  <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">중국어 한자를 병음으로</system:String>
+  <system:String x:Key="pianoroll.menu.notes.lengthencrossfade">크로스페이드 길이 늘리기</system:String>
+  <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">렌더링된 피치 커브 불러오기</system:String>
   <system:String x:Key="pianoroll.menu.notes.octavedown">한 옥타브 아래로</system:String>
   <system:String x:Key="pianoroll.menu.notes.octaveup">한 옥타브 위로</system:String>
-  <system:String x:Key="pianoroll.menu.notes.quantize15">1/128로 퀀타이즈</system:String>
+  <system:String x:Key="pianoroll.menu.notes.quantize15">1/128 퀀타이즈</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize30">1/64로 퀀타이즈</system:String>
-  <system:String x:Key="pianoroll.menu.notes.removetaildash">끝 기호 지우기: "-"</system:String>
-  <system:String x:Key="pianoroll.menu.notes.removetailrest">끝 기호 지우기: "R"</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.aliases">"에일리어스" 리셋</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.exps">모든 "표현" 리셋</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">"음소 타이밍" 리셋</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">"피치선" 리셋</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.vibratos">"비브라토" 리셋</system:String>
+  <system:String x:Key="pianoroll.menu.notes.removetaildash">끝에 '-' 노트 지우기</system:String>
+  <system:String x:Key="pianoroll.menu.notes.removetailrest">끝에 'R' 노트 지우기</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.aliases">음소 에일리어스 리셋</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.exps">모든 표현 리셋</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">음소 타이밍 리셋</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">피치선 리셋</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.vibratos">비브라토 리셋</system:String>
   <system:String x:Key="pianoroll.menu.part">파트</system:String>
-  <system:String x:Key="pianoroll.menu.part.legacypluginexp">레거시 플러그인 실험실</system:String>
-  <system:String x:Key="pianoroll.menu.part.singer">가수 및 원음설정</system:String>
-  <system:String x:Key="pianoroll.menu.plugin.openfolder">플러그인 폴더 열기</system:String>
-  <system:String x:Key="pianoroll.menu.plugin.reload">플러그인 새로고침</system:String>
+  <system:String x:Key="pianoroll.menu.part.legacypluginexp">레거시 플러그인(실험적 기능)</system:String>
+  <system:String x:Key="pianoroll.menu.part.singer">가수 및 원음 설정</system:String>
+  <system:String x:Key="pianoroll.menu.plugin.openfolder">폴더 열기</system:String>
+  <system:String x:Key="pianoroll.menu.plugin.reload">새로 고침</system:String>
   <system:String x:Key="pianoroll.menu.searchnote">노트 검색</system:String>
-  <system:String x:Key="pianoroll.menu.searchnote.all">검색된 노트 모두 선택</system:String>
+  <system:String x:Key="pianoroll.menu.searchnote.all">모두 선택</system:String>
   <system:String x:Key="pianoroll.menu.searchnote.close">닫기</system:String>
-  <system:String x:Key="pianoroll.menu.searchnote.next">다음으로 이동</system:String>
-  <system:String x:Key="pianoroll.menu.searchnote.prev">이전으로 이동</system:String>
-  <system:String x:Key="pianoroll.toggle.finalpitch">최종 렌더링된 피치 커브 보기 (R)</system:String>
-  <system:String x:Key="pianoroll.toggle.noteparams">노트 설정 열기 (\)</system:String>
-  <system:String x:Key="pianoroll.toggle.phoneme">음소 표시 (O)</system:String>
-  <system:String x:Key="pianoroll.toggle.pitch">피치선 표시 (I)</system:String>
-  <system:String x:Key="pianoroll.toggle.snap">물리기 활성화 (P)</system:String>
-  <system:String x:Key="pianoroll.toggle.snap.auto">자동 물리기</system:String>
-  <system:String x:Key="pianoroll.toggle.snap.autotriplet">자동 물리기 (3연음)</system:String>
-  <system:String x:Key="pianoroll.toggle.tips">팁 표시 (T)</system:String>
-  <system:String x:Key="pianoroll.toggle.tone">노트음 켜기 (Y)</system:String>
-  <system:String x:Key="pianoroll.toggle.vibrato">비브라토 표시 (U)</system:String>
-  <system:String x:Key="pianoroll.toggle.waveform">파형 표시 (W)</system:String>
-  <system:String x:Key="pianoroll.tool.drawpitch">
-    피치 펜 (4)
-    마우스 왼쪽 버튼으로 그려요.
-    마우스 오른쪽 버튼으로 리셋해요.
-    노트를 선택하려면: 
-     - Ctrl(컨트롤)키를 누른 채로 노트를 선택하세요.
-    피치선을 매끄럽게 다듬으려면: 
-     - Alt(알트)키를 누른 채로 다듬고 싶은 피치선 위를 드래그하세요.
-  </system:String>
-  <system:String x:Key="pianoroll.tool.eraser">노트 지우개 (3)</system:String>
-  <system:String x:Key="pianoroll.tool.knife">자르기 칼 (5)</system:String>
-  <system:String x:Key="pianoroll.tool.penplus">
-    고급 펜 (Ctrl + 2)
-    마우스 왼쪽 버튼으로 노트를 추가해요.
-    마우스 오른쪽 버튼으로 노트를 지워요.
-    노트를 선택하려면: 
-     - Ctrl(컨트롤)키를 누른 채로 노트를 선택하세요.
-  </system:String>
-  <system:String x:Key="pianoroll.tool.penv2">
-    펜 (2)
-    마우스 왼쪽 버튼으로 노트를 추가해요.
-    노트를 선택하려면: 
-     - Ctrl(컨트롤)키를 누른 채로 노트를 선택하세요.
-  </system:String>
-  <system:String x:Key="pianoroll.tool.selectionv2">
-  선택 도구 (1)
-  노트를 선택하려면: 
-   - 범위 드래그로 노트를 선택하세요.
-   - Ctrl(컨트롤)키를 누른 채로 드래그하면, 선택된 노트를 유지하며 노트를 선택할 수 있어요.
-  </system:String>
+  <system:String x:Key="pianoroll.menu.searchnote.next">다음</system:String>
+  <system:String x:Key="pianoroll.menu.searchnote.prev">이전</system:String>
+  <system:String x:Key="pianoroll.toggle.finalpitch">최종 렌더링된 피치 커브 보기(R)</system:String>
+  <system:String x:Key="pianoroll.toggle.noteparams">노트 설정 열기(\)</system:String>
+  <system:String x:Key="pianoroll.toggle.phoneme">음소 표시(O)</system:String>
+  <system:String x:Key="pianoroll.toggle.pitch">피치선 표시(I)</system:String>
+  <system:String x:Key="pianoroll.toggle.snap">토글 켜기·끄기(P)</system:String>
+  <system:String x:Key="pianoroll.toggle.snap.auto">자동 스냅</system:String>
+  <system:String x:Key="pianoroll.toggle.snap.autotriplet">자동 스냅(셋잇단)</system:String>
+  <system:String x:Key="pianoroll.toggle.tips">팁 표시(T)</system:String>
+  <system:String x:Key="pianoroll.toggle.tone">노트 음높이 켜기(Y)</system:String>
+  <system:String x:Key="pianoroll.toggle.vibrato">비브라토 표시(U)</system:String>
+  <system:String x:Key="pianoroll.toggle.waveform">파형 표시(W)</system:String>
+  <system:String x:Key="pianoroll.tool.drawpitch">피치 그리기 툴(4)
+    왼쪽 클릭으로 그리기
+    오른쪽 클릭으로 리셋
+    Ctrl 키를 누르며 클릭해 선택
+    Alt 키를 누르며 클릭해 다듬기</system:String>
+  <system:String x:Key="pianoroll.tool.eraser">지우기 툴(3)</system:String>
+  <system:String x:Key="pianoroll.tool.knife">자르기 툴(5)</system:String>
+  <system:String x:Key="pianoroll.tool.penplus">펜 플러스 툴(Ctrl + 2)
+    왼쪽 클릭으로 그리기
+    오른쪽 클릭으로 리셋
+    Ctrl 키를 누르며 클릭해 선택</system:String>
+  <system:String x:Key="pianoroll.tool.penv2">펜 툴(2)
+    왼쪽 클릭으로 그리기
+    Ctrl 키를 누르며 클릭해 선택</system:String>
+  <system:String x:Key="pianoroll.tool.selectionv2">선택 툴(1)</system:String>
 
-  <system:String x:Key="prefs.advanced">고급 설정</system:String>
-  <system:String x:Key="prefs.advanced.beta">베타 버전을 사용할래요</system:String>
-  <system:String x:Key="prefs.advanced.lyricshelper">이 가사 입력 도우미를 사용할래요</system:String>
-  <system:String x:Key="prefs.advanced.lyricshelper.brackets">가사 도우미가 자동으로 발음 힌트에 대괄호([])를 붙여 줍니다.</system:String>
-  <system:String x:Key="prefs.advanced.rememberfiletypes">이런 확장자의 파일도 "최근 파일"에 저장해 주세요▼</system:String>
-  <system:String x:Key="prefs.advanced.resamplerlogging">리샘플러 로깅을 사용할래요</system:String>
-  <system:String x:Key="prefs.advanced.resamplerlogging.warn">주의! 이 옵션은 UI를 느리게 만들고, 렌더링 속도를 늦출 수 있어요! 리샘플러의 결과물을 로그 파일 내에 저장합니다.</system:String>
-  <system:String x:Key="prefs.advanced.stable">스테이블</system:String>
-  <system:String x:Key="prefs.advanced.vlabelerpath">브이라벨러(vLabeler)가 설치된 위치</system:String>
-  <system:String x:Key="prefs.appearance">외형 설정</system:String>
-  <system:String x:Key="prefs.appearance.degree">피아노롤 도우미 설정</system:String>
-  <system:String x:Key="prefs.appearance.degree.numbered">숫자매김형 도우미 (1 2 3 4 5 6 7)</system:String>
-  <system:String x:Key="prefs.appearance.degree.off">도우미 미사용</system:String>
-  <system:String x:Key="prefs.appearance.degree.solfege">계이름 도우미 (도 레 미 파 솔 라 시)</system:String>
-  <system:String x:Key="prefs.appearance.lang">인터페이스 언어</system:String>
-  <system:String x:Key="prefs.appearance.showghostnotes">피아노 롤에 다른 트랙의 노트 표시(유령 노트)</system:String>
-  <system:String x:Key="prefs.appearance.showportrait">피아노 롤에 가수의 스탠딩 표시</system:String>
+  <system:String x:Key="prefs.advanced">고급</system:String>
+  <system:String x:Key="prefs.advanced.beta">베타 버전 사용</system:String>
+  <system:String x:Key="prefs.advanced.lyricshelper">가사 도우미</system:String>
+  <system:String x:Key="prefs.advanced.lyricshelper.brackets">가사 도우미의 발음 힌트에 대괄호 추가</system:String>
+  <system:String x:Key="prefs.advanced.rememberfiletypes">'최근 파일'에 표시할 파일 유형</system:String>
+  <system:String x:Key="prefs.advanced.resamplerlogging">리샘플러 로깅</system:String>
+  <system:String x:Key="prefs.advanced.resamplerlogging.warn">리샘플러의 결과물을 로그 파일에 저장합니다. 이 설정은 UI와 렌더링 성능을 낮출 수 있습니다.</system:String>
+  <system:String x:Key="prefs.advanced.stable">안정 버전</system:String>
+  <system:String x:Key="prefs.advanced.vlabelerpath">vLabeler가 설치된 위치</system:String>
+  <system:String x:Key="prefs.appearance">외형</system:String>
+  <system:String x:Key="prefs.appearance.degree">음 이름 표시 설정</system:String>
+  <system:String x:Key="prefs.appearance.degree.numbered">순번(1 2 3 4 5 6 7)</system:String>
+  <system:String x:Key="prefs.appearance.degree.off">끄기</system:String>
+  <system:String x:Key="prefs.appearance.degree.solfege">계이름(도 레 미 파 솔 라 시)</system:String>
+  <system:String x:Key="prefs.appearance.lang">언어</system:String>
+  <system:String x:Key="prefs.appearance.showghostnotes">피아노 롤에 다른 트랙의 노트 표시</system:String>
+  <system:String x:Key="prefs.appearance.showicon">피아노 롤에 가수 아이콘 표시</system:String>
+  <system:String x:Key="prefs.appearance.showportrait">피아노 롤에 가수 스탠딩 표시</system:String>
   <system:String x:Key="prefs.appearance.sortorder">가수 이름 표시 언어</system:String>
-  <system:String x:Key="prefs.appearance.theme">테마 설정</system:String>
-  <system:String x:Key="prefs.appearance.theme.dark">다크 테마</system:String>
-  <system:String x:Key="prefs.appearance.theme.light">라이트 테마</system:String>
-  <system:String x:Key="prefs.appearance.trackcolor">트랙 색상 UI 사용하기</system:String>
+  <system:String x:Key="prefs.appearance.theme">테마</system:String>
+  <system:String x:Key="prefs.appearance.theme.dark">다크</system:String>
+  <system:String x:Key="prefs.appearance.theme.light">라이트</system:String>
+  <system:String x:Key="prefs.appearance.trackcolor">UI에 트랙 색상 사용</system:String>
   <system:String x:Key="prefs.cache">캐시</system:String>
-  <system:String x:Key="prefs.cache.clearonquit">프로그램을 나가면 캐시 비우기</system:String>
+  <system:String x:Key="prefs.cache.clearonquit">프로그램을 나갈 때 캐시 비우기</system:String>
   <system:String x:Key="prefs.caption">환경 설정</system:String>
-  <system:String x:Key="prefs.note.restart">참고: 이 설정은 오픈우타우를 재부팅해야 적용됩니다!</system:String>
+  <system:String x:Key="prefs.note.restart">참고: 이 설정은 OpenUtau를 재시작해야 적용됩니다.</system:String>
   <system:String x:Key="prefs.off">꺼짐</system:String>
   <system:String x:Key="prefs.on">켜짐</system:String>
-  <system:String x:Key="prefs.otoeditor">원음설정 에디터</system:String>
-  <system:String x:Key="prefs.otoeditor.select">기본 원음설정 에디터</system:String>
+  <system:String x:Key="prefs.otoeditor">원음 설정 에디터</system:String>
+  <system:String x:Key="prefs.otoeditor.select">기본 원음 설정 에디터</system:String>
   <system:String x:Key="prefs.paths">경로</system:String>
-  <system:String x:Key="prefs.paths.addlsinger">"추가 가수 폴더" 확장하기</system:String>
-  <system:String x:Key="prefs.paths.addlsinger.install">앞으로 설치하는 모든 가수들은 "추가 가수 폴더"에 설치할래요.</system:String>
+  <system:String x:Key="prefs.paths.addlsinger">추가 가수 폴더</system:String>
+  <system:String x:Key="prefs.paths.addlsinger.install">가수 설치 시 '추가 가수 폴더'에 설치</system:String>
   <system:String x:Key="prefs.paths.reset">리셋</system:String>
   <system:String x:Key="prefs.paths.select">선택</system:String>
   <system:String x:Key="prefs.playback">재생</system:String>
-  <system:String x:Key="prefs.playback.autoscroll">피아노롤의 자동 스크롤 설정</system:String>
-  <system:String x:Key="prefs.playback.autoscrollmode">자동 스크롤을 어떻게 할까요?▼</system:String>
-  <system:String x:Key="prefs.playback.autoscrollmode.pagescroll">순간이동 스크롤</system:String>
-  <system:String x:Key="prefs.playback.autoscrollmode.stationarycursor">부드러운 스크롤(Stationary cursor)</system:String>
-  <system:String x:Key="prefs.playback.backend">오디오 백엔드 설정</system:String>
-  <system:String x:Key="prefs.playback.backend.auto">자동 선택</system:String>
+  <system:String x:Key="prefs.playback.autoscroll">자동 스크롤</system:String>
+  <system:String x:Key="prefs.playback.autoscrollmode">자동 스크롤 모드</system:String>
+  <system:String x:Key="prefs.playback.autoscrollmode.pagescroll">페이지 넘기듯 스크롤</system:String>
+  <system:String x:Key="prefs.playback.autoscrollmode.stationarycursor">두루마리 읽듯 스크롤</system:String>
+  <system:String x:Key="prefs.playback.backend">오디오 백엔드</system:String>
+  <system:String x:Key="prefs.playback.backend.auto">자동</system:String>
   <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
-  <system:String x:Key="prefs.playback.cursorposition">자동 스크롤 범위 설정</system:String>
+  <system:String x:Key="prefs.playback.cursorposition">자동 스크롤 여백</system:String>
   <system:String x:Key="prefs.playback.device">오디오 재생 장치</system:String>
-  <system:String x:Key="prefs.playback.lockstarttime">일시정지할 때</system:String>
-  <system:String x:Key="prefs.playback.lockstarttime.off">아무것도 안 하기</system:String>
-  <system:String x:Key="prefs.playback.lockstarttime.on">커서를 이동시키기 - 재생을 시작한 위치로</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime">일시 정지 동작</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime.off">아무것도 하지 않음</system:String>
+  <system:String x:Key="prefs.playback.lockstarttime.on">재생을 시작한 위치로 커서 이동</system:String>
   <system:String x:Key="prefs.playback.test">출력 테스트</system:String>
-  <system:String x:Key="prefs.rendering">렌더링 설정</system:String>
-  <system:String x:Key="prefs.rendering.defaultrenderer">클래식 가수들을 위한 기본 렌더러 설정</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerdepth">디프싱어 렌더링 깊이(depth)</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerspeedup">디프싱어 렌더링 가속</system:String>
+  <system:String x:Key="prefs.rendering">렌더링</system:String>
+  <system:String x:Key="prefs.rendering.defaultrenderer">Classic 음원의 기본 렌더러</system:String>
+  <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger 렌더링 깊이(Depth)</system:String>
+  <system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger 렌더링 가속</system:String>
   <system:String x:Key="prefs.rendering.onnxgpu">그래픽 카드(GPU)</system:String>
   <system:String x:Key="prefs.rendering.onnxrunner">머신러닝을 실행할 장치</system:String>
-  <system:String x:Key="prefs.rendering.phasecomp">주파수 위상 보상(Phase Compensation)</system:String>
-  <system:String x:Key="prefs.rendering.prerender">미리보기용 렌더링</system:String>
-  <system:String x:Key="prefs.rendering.resampler">리샘플러 선택</system:String>
-  <system:String x:Key="prefs.rendering.resampler.morewarn">
-    경고! 오픈우타우에서 moresampler 지원은 아직 완벽하지 않아요. 속도가 느려질 수도 있고, CPU 점유율이 높아질 수도 있어요. 그래도 쓰고 싶으시다면... 다음을 따라합시다!:
-    1. moreconfig.txt를 여세요. 
-    moreconfig.txt는 moresampler.exe와 함께 "Resamplers" 폴더 내에 들어 있어야 합니다!
-    2. "resampler-compatibility" 항목을 "on"으로 수정합니다.
-    3. "auto-update-llsm-mrq" 항목을 "off"로 수정합니다.
-    4. 끝입니다! 
-    참고로, moresampler가 누락된 llsm 파일들을 생성할 때마다 버벅일 수 있습니다. 차분히 인내하며 기다리세요.
+  <system:String x:Key="prefs.rendering.phasecomp">위상 보정</system:String>
+  <system:String x:Key="prefs.rendering.prerender">미리 렌더링</system:String>
+  <system:String x:Key="prefs.rendering.resampler">리샘플러</system:String>
+  <system:String x:Key="prefs.rendering.resampler.morewarn">경고: 아직 moresampler는 완벽하게 지원되는 상태가 아닙니다. 속도가 느릴 수 있고, 높은 CPU 점유율 유발할 수 있습니다. 그래도 사용하시려면 다음을 따라 주세요.
+    1. moreconfig.txt를 열어 resampler-compatibility 항목을 "on"으로 설정합니다.
+    2. 같은 파일에서 resampler-compatibility 항목을 "off"로 설정합니다.
+    3. moresampler가 누락된 llsm 파일을 다 생성할 때까지 느긋하게 기다립니다.
   </system:String>
   <system:String x:Key="prefs.rendering.resampler.note">
-    외부 리샘플러를 사용하고 싶다면, 리샘플러의 DLL 혹은 exe 파일을 OpenUtau 설치 폴더의 "Resamplers"에 넣고, 환경 설정에서 리샘플러를 고르면 사용 가능해져요.
+    참고: 외부 리샘플러를 사용하시려면 OpenUtau 설치 폴더의 Resamplers 폴더 안에 리샘플러의 DLL 파일이나 EXE 파일을 넣어 주세요. 이후 환경 설정에서 리샘플러를 선택해 주세요.
   </system:String>
   <system:String x:Key="prefs.rendering.threads.cpuwarn">
-    경고! 설정된 렌더링 스레드가 너무 많아요. 기기에 따라서는 오픈우타우가 무거워지고, 속도가 느려지는 원인이 될 수 있답니다. 
+    경고: 렌더링 스레드가 너무 많으면 OpenUtau가 느리게 작동할 수 있습니다.
   </system:String>
-  <system:String x:Key="prefs.rendering.threads.numthreads">렌더링에 쓰는 최대 스레드 수</system:String>
-  <system:String x:Key="prefs.rendering.wavtool">웨이브툴</system:String>
+  <system:String x:Key="prefs.rendering.threads.numthreads">최대 렌더링 스레드 수</system:String>
+  <system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>
 
-  <system:String x:Key="progress.loadingsingers">가수를 불러오고 있어요...</system:String>
-  <system:String x:Key="progress.saved">프로젝트를 저장했어요: {0}</system:String>
-  <system:String x:Key="progress.waitingrendering">렌더링을 기다리는 중...</system:String>
+  <system:String x:Key="progress.loadingsingers">가수를 불러오는 중...</system:String>
+  <system:String x:Key="progress.saved">{0} 프로젝트를 저장했습니다.</system:String>
+  <system:String x:Key="progress.waitingrendering">렌더링을 기다리는 중<system:String>
 
   <system:String x:Key="singers.caption">가수 목록</system:String>
-  <system:String x:Key="singers.editoto.editinvlabeler">브이라벨러에서 원음설정</system:String>
-  <system:String x:Key="singers.editoto.gotosource">소스 파일로 이동</system:String>
+  <system:String x:Key="singers.editoto.editinvlabeler">vLabeler에서 원음 설정</system:String>
+  <system:String x:Key="singers.editoto.gotosource">원본 파일로 이동</system:String>
   <system:String x:Key="singers.editoto.regenfrq">FRQ 재생성</system:String>
-  <system:String x:Key="singers.editoto.regenfrq.regenerating">가수의 FRQ 파일을 재생성하고 있어요...</system:String>
-  <system:String x:Key="singers.editoto.reset">원래 oto.ini로 되돌리기</system:String>
-  <system:String x:Key="singers.editoto.save">원음설정 저장</system:String>
+  <system:String x:Key="singers.editoto.regenfrq.regenerating">가수의 FRQ 파일 재생성 중...</system:String>
+  <system:String x:Key="singers.editoto.reset">원음 설정 초기화</system:String>
+  <system:String x:Key="singers.editoto.save">원음 설정 저장</system:String>
   <system:String x:Key="singers.editoto.searchalias">에일리어스 검색</system:String>
-  <system:String x:Key="singers.editoto.setvlabelerpath">브이라벨러(vLabeler) 1.0.0-beta1 이상 버전이 필요해요. https://github.com/sdercolin/vlabeler 에서 브이라벨러를 다운로드하고, 환경설정의 "브이라벨러(vLabeler)가 설치된 위치"에 등록해 주세요!</system:String>
-  <system:String x:Key="singers.errorreport">가수의 오류 보고서 생성하기</system:String>
+  <system:String x:Key="singers.editoto.setvlabelerpath">vLabeler 1.0.0-beta1 이상 버전이 필요해요. https://github.com/sdercolin/vlabeler 에서 브이라벨러를 다운로드하고, 환경설정의 "브이라벨러(vLabeler)가 설치된 위치"에 등록해 주세요!</system:String>
+  <system:String x:Key="singers.errorreport">가수의 오류 보고서 생성</system:String>
   <system:String x:Key="singers.location">위치 열기</system:String>
   <system:String x:Key="singers.otoview.moveleft">왼쪽으로 이동</system:String>
   <system:String x:Key="singers.otoview.moveright">오른쪽으로 이동</system:String>
-  <system:String x:Key="singers.otoview.selectnext">다음 음소 선택</system:String>
-  <system:String x:Key="singers.otoview.selectprev">이전 음소 선택</system:String>
-  <system:String x:Key="singers.otoview.showall">모두 보이기</system:String>
+  <system:String x:Key="singers.otoview.selectnext">다음 선택</system:String>
+  <system:String x:Key="singers.otoview.selectprev">이전 선택</system:String>
+  <system:String x:Key="singers.otoview.showall">모두 보기</system:String>
   <system:String x:Key="singers.otoview.zoomin">확대</system:String>
   <system:String x:Key="singers.otoview.zoomout">축소</system:String>
-  <system:String x:Key="singers.playsample">샘플 음성</system:String>
-  <system:String x:Key="singers.readme">이용약관(readme)</system:String>
-  <system:String x:Key="singers.readme.notfound">가수가 있는 폴더에 readme.txt 가 존재하지 않아요.</system:String>
-  <system:String x:Key="singers.refresh">새로고침</system:String>
-  <system:String x:Key="singers.setdefaultphonemizer">가수의 기본 음소화기 설정</system:String>
+  <system:String x:Key="singers.playsample">샘플 재생</system:String>
+  <system:String x:Key="singers.readme">readme.txt 실행</system:String>
+  <system:String x:Key="singers.readme.notfound">readme.txt가 없습니다.</system:String>
+  <system:String x:Key="singers.refresh">새로 고침</system:String>
+  <system:String x:Key="singers.setdefaultphonemizer">기본 음소화기 설정</system:String>
   <system:String x:Key="singers.setencoding">인코딩 설정</system:String>
-  <system:String x:Key="singers.setimage">가수의 아이콘 지정</system:String>
-  <system:String x:Key="singers.setportrait">가수의 스탠딩 지정</system:String>
-  <!--<system:String x:Key="singers.setsingertype">Set Singer Type</system:String>-->
+  <system:String x:Key="singers.setimage">아이콘 지정</system:String>
+  <system:String x:Key="singers.setportrait">스탠딩 지정</system:String>
+  <system:String x:Key="singers.setsingertype">가수 유형 설정</system:String>
   <system:String x:Key="singers.subbanks.cancel">취소</system:String>
-  <system:String x:Key="singers.subbanks.clear">전부 지우기</system:String>
+  <system:String x:Key="singers.subbanks.clear">비우기</system:String>
   <system:String x:Key="singers.subbanks.color">컬러</system:String>
   <system:String x:Key="singers.subbanks.color.add">컬러 추가</system:String>
   <system:String x:Key="singers.subbanks.color.remove">컬러 지우기</system:String>
   <system:String x:Key="singers.subbanks.color.rename">컬러 이름 바꾸기</system:String>
-  <system:String x:Key="singers.subbanks.edit">서브뱅크 편집</system:String>
+  <system:String x:Key="singers.subbanks.edit">서브 뱅크 편집</system:String>
   <system:String x:Key="singers.subbanks.export">prefix.map 내보내기</system:String>
   <system:String x:Key="singers.subbanks.import">prefix.map 불러오기</system:String>
   <system:String x:Key="singers.subbanks.reset">리셋</system:String>
@@ -419,78 +400,75 @@
   <system:String x:Key="singers.subbanks.set">설정</system:String>
   <system:String x:Key="singers.subbanks.tone">음계</system:String>
   <system:String x:Key="singers.subbanks.toneranges">음역대</system:String>
-  <system:String x:Key="singers.visitwebsite">가수 공식 사이트 방문</system:String>
+  <system:String x:Key="singers.visitwebsite">웹사이트 방문</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">압축 파일의 인코딩</system:String>
-  <system:String x:Key="singersetup.archivefileencoding.prompt">파일명이 정상적으로 보일 때까지 "인코딩"을 조정하세요.</system:String>
-  <system:String x:Key="singersetup.back">이전으로</system:String>
-  <system:String x:Key="singersetup.install">가수 설치</system:String>
-  <system:String x:Key="singersetup.missinginfo">가수의 character.yaml에 다음의 설정이 없어, 정보 입력을 진행합니다.</system:String>
-  <system:String x:Key="singersetup.next">다음으로</system:String>
-  <system:String x:Key="singersetup.singertype">이 가수의 타입</system:String>
-  <system:String x:Key="singersetup.textfileencoding">텍스트 인코딩</system:String>
-  <system:String x:Key="singersetup.textfileencoding.prompt">텍스트 파일 내용이 정상적으로 보일 때까지 "인코딩"을 조정하세요.</system:String>
+  <system:String x:Key="singersetup.archivefileencoding.prompt">파일 이름이 정상적으로 표시되는 인코딩 설정을 선택해 주세요.</system:String>
+  <system:String x:Key="singersetup.back">이전</system:String>
+  <system:String x:Key="singersetup.install">설치</system:String>
+  <system:String x:Key="singersetup.missinginfo">음원의 character.yaml에 다음 설정이 없어, 정보 입력을 진행합니다.</system:String>
+  <system:String x:Key="singersetup.next">다음</system:String>
+  <system:String x:Key="singersetup.singertype">가수 유형</system:String>
+  <system:String x:Key="singersetup.textfileencoding">텍스트 파일 인코딩</system:String>
+  <system:String x:Key="singersetup.textfileencoding.prompt">텍스트 파일 내용이 정상적으로 표시되는 인코딩 설정을 선택해 주세요.</system:String>
 
-  <system:String x:Key="tip.aliasbox">에일리어스 재설정(override)</system:String>
-  <system:String x:Key="tip.exps">
-    마우스 왼쪽 버튼으로 "표현"을 조교하고,
-    마우스 오른쪽 버튼으로 "표현"을 리셋하세요.
+  <system:String x:Key="tip.aliasbox">에일리어스 덮어쓰기</system:String>
+  <system:String x:Key="tip.exps">왼쪽 클릭: 표현 설정
+오른쪽 클릭: 표현 재설정</system:String>
+  <system:String x:Key="tip.exps.notsupported">렌더러가 이 표현을 지원하지 않습니다</system:String>
+  <system:String x:Key="tip.lyricbox.next">Tab: 다음 노트</system:String>
+  <system:String x:Key="tip.lyricbox.prev">Shift + Tab: 이전 노트</system:String>
+  <system:String x:Key="tip.notes.basics"선택 툴
+    박스 선택: 노트 선택
+    Ctrl + 박스 선택: 여러 노트 선택
+    위/아래 화살표: 노트를 위로 이동
+    Ctrl + 위/아래 화살표: 한 옥타브씩 노트를 이동
+펜 툴
+    왼쪽 클릭한 채 이동: 노트 추가
+    오른쪽 클릭: 노트 삭제
+    오른쪽 클릭한 채 이동: 여러 노트 삭제
+일반
+    T: 팁 켜고 끄기
+    노트 드래그: 노트 이동
+    노트 끝 드래그: 노트 사이즈 변경
+    Alt + 노트 끝 드래그: 이웃한 노트 사이즈 수정
+    스페이스 키: 재생
   </system:String>
-  <system:String x:Key="tip.exps.notsupported">이 렌더러는 이 표현을 지원하지 않아요.</system:String>
-  <system:String x:Key="tip.lyricbox.next">[Tab] (다음 노트로) →</system:String>
-  <system:String x:Key="tip.lyricbox.prev">← [Shift + Tab] (이전 노트로) </system:String>
-  <system:String x:Key="tip.notes.basics">
-    
-    ▼ 팁 ▼
-
-    T 키를 눌러 이 도움말을 켜거나 끌 수 있어요!
-
-    1. 스페이스를 눌러 재생해요.
-
-    2. 화살표 위/아래 키를 누르면, 선택된 노트들을 "음 단위로" 올리거나 내려요. 
-    3. Ctrl(컨트롤)키를 누른 채로 화살표 위/아래 키를 누르면, 선택된 노트들을 "옥타브 단위로" 올리거나 내려요.
-    
-    4. 노트의 "몸통"을 드래그해 노트 위치를 옮겨요.
-    5. 노트의 "끝"을 드래그해 노트 길이를 조정해요.
-    6. Alt(알트)키를 누른 채로 노트의 "끝"을 드래그하면, 이웃 노트들의 길이가 함께 바뀐답니다! 
-    
-  </system:String>
-  <system:String x:Key="tip.notes.zoomx">◀ 옆으로 길게 확대하려면 여기서 드래그하세요 ▶</system:String>
-  <system:String x:Key="tip.notes.zoomy">위아래로 길게 확대하려면 이 옆에서 드래그하세요 ▶</system:String>
+  <system:String x:Key="tip.notes.zoomx">◀ 수평으로 확대하려면 여기서 스크롤하세요 ▶</system:String>
+  <system:String x:Key="tip.notes.zoomy">수직으로 확대하려면 여기서 스크롤하세요 ▶</system:String>
 
   <system:String x:Key="tracks.duplicate">트랙 복제</system:String>
   <system:String x:Key="tracks.duplicatesettings">트랙 설정 복제</system:String>
-  <system:String x:Key="tracks.more">더보기</system:String>
+  <system:String x:Key="tracks.more">더 보기</system:String>
   <system:String x:Key="tracks.movedown">아래로 이동</system:String>
   <system:String x:Key="tracks.moveup">위로 이동</system:String>
   <system:String x:Key="tracks.mute">음소거</system:String>
-  <system:String x:Key="tracks.mute.allothers">모든 트랙을 음소거</system:String>
+  <system:String x:Key="tracks.mute.allothers">다른 모든 트랙 음소거</system:String>
   <system:String x:Key="tracks.mute.only">이 트랙만 음소거</system:String>
-  <system:String x:Key="tracks.mute.unmuteall">모든 트랙의 음소거 해제</system:String>
+  <system:String x:Key="tracks.mute.unmuteall">모든 트랙 음소거 해제</system:String>
   <system:String x:Key="tracks.remove">트랙 제거</system:String>
   <system:String x:Key="tracks.rename">트랙 이름 바꾸기</system:String>
-  <system:String x:Key="tracks.selectrenderer">렌더러를 지정하세요</system:String>
-  <system:String x:Key="tracks.selectsinger">가수를 지정하세요</system:String>
-  <!--<system:String x:Key="tracks.solo">Solo</system:String>-->
-  <system:String x:Key="tracks.solo.add">트랙 솔로 </system:String>
-  <system:String x:Key="tracks.solo.only">트랙 독주 </system:String>
+  <system:String x:Key="tracks.selectrenderer">렌더러 선택</system:String>
+  <system:String x:Key="tracks.selectsinger">가수 선택</system:String>
+  <system:String x:Key="tracks.solo">솔로</system:String>
+  <system:String x:Key="tracks.solo.add">함께 솔로(다른 트랙의 솔로는 끄지 않음)</system:String>
+  <system:String x:Key="tracks.solo.only">이 트랙만 솔로(다른 트랙의 솔로는 끔)</system:String>
   <system:String x:Key="tracks.solo.unsoloall">모든 트랙의 솔로를 해제</system:String>
   <system:String x:Key="tracks.trackcolor">트랙 색상 변경</system:String>
-  <!--<system:String x:Key="tracks.tracksettings">Track Settings</system:String>-->
+  <system:String x:Key="tracks.tracksettings">트랙 설정</system:String>
 
   <!--<FontFamily x:Key="ui.fontfamily">Segoe UI,San Francisco,Helvetica Neue</FontFamily>-->
 
-  <system:String x:Key="updater.caption">버전 체크</system:String>
-  <system:String x:Key="updater.description">오픈소스 가성 합성 플랫폼</system:String>
-  <system:String x:Key="updater.github">깃헙 방문</system:String>
-  <system:String x:Key="updater.status.available">오픈우타우 v{0} 을 쓸 수 있어요!</system:String>
-  <system:String x:Key="updater.status.checking">업데이트 사항을 확인하고 있어요.</system:String>
-  <system:String x:Key="updater.status.notavailable">최신 버전이라 업데이트할 필요가 없어요.</system:String>
-  <system:String x:Key="updater.status.unknown">업데이트 체크에 실패했어요.</system:String>
+  <system:String x:Key="updater.caption">업데이트 확인</system:String>
+  <system:String x:Key="updater.description">오픈소스 음성 합성 플랫폼</system:String>
+  <system:String x:Key="updater.github">GitHub 방문</system:String>
+  <system:String x:Key="updater.status.available">v{0} 버전 업데이트가 있습니다!</system:String>
+  <system:String x:Key="updater.status.checking">업데이트를 확인 중입니다...</system:String>
+  <system:String x:Key="updater.status.notavailable">이미 최신 버전입니다</system:String>
+  <system:String x:Key="updater.status.unknown">업데이트를 확인할 수 없습니다</system:String>
   <system:String x:Key="updater.update">업데이트</system:String>
 
-  <system:String x:Key="warning">경고!</system:String>
-  <system:String x:Key="warning.asciipath">
-  오픈우타우가 설치된 경로인 "{0}"에 ASCII 인코딩이 아닌 문자가 존재해요. Exe 리샘플러가 작동하지 않을 수 있어요! 오픈우타우 설치 경로에 한글이 들어가 있다면, 한글을 없애 봅시다.</system:String>
-  <system:String x:Key="warning.renderer">이 렌더러를 위한 설정이 존재하지 않아요.</system:String>
+  <system:String x:Key="warning">경고</system:String>
+  <system:String x:Key="warning.asciipath">OpenUtau 경로 "{0}"에 ASCII 인코딩에 없는 문자(예컨대 한글, 일본어 등)가 포함되어 있습니다. Exe 리샘플러가 작동하지 않을 수 있습니다.</system:String>
+  <system:String x:Key="warning.renderer">이 렌더러를 위한 설정이 없습니다.</system:String>
 </ResourceDictionary>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -6,20 +6,20 @@
   <system:String x:Key="context.note.delete">노트 지우기</system:String>
   <system:String x:Key="context.note.pasteparameters">선택하고 파라미터 붙여넣기</system:String>
   <system:String x:Key="context.part.delete">파트 지우기</system:String>
-  <!--<system:String x:Key="context.part.gotofile">View file location</system:String>-->
-  <system:String x:Key="context.part.rename">파트 이름 바꾸기</system:String>
-  <system:String x:Key="context.part.replaceaudio">오디오 파일 바꾸기</system:String>
-  <!--<system:String x:Key="context.part.transcribe">Transcribe audio to create a note part</system:String>-->
-  <!--<system:String x:Key="context.part.transcribing">Transcribing</system:String>-->
-  <system:String x:Key="context.pitch.easein">피치선 다듬기(Ease in)</system:String>
-  <system:String x:Key="context.pitch.easeinout">피치선 다듬기(Ease in and out)</system:String>
-  <system:String x:Key="context.pitch.easeout">피치선 다듬기(Ease out)</system:String>
-  <system:String x:Key="context.pitch.linear">피치선 다듬기(Linear)</system:String>
+  <system:String x:Key="context.part.gotofile">파일 위치 열기</system:String>
+  <system:String x:Key="context.part.rename">파트 이름 변경</system:String>
+  <system:String x:Key="context.part.replaceaudio">오디오 파일 변경</system:String>
+  <system:String x:Key="context.part.transcribe">소리를 노트 파트로 변환</system:String>
+  <system:String x:Key="context.part.transcribing">변환 중</system:String>
+  <system:String x:Key="context.pitch.easein">Ease in 곡선</system:String>
+  <system:String x:Key="context.pitch.easeinout">Ease in/out 곡선</system:String>
+  <system:String x:Key="context.pitch.easeout">Ease out 곡선</system:String>
+  <system:String x:Key="context.pitch.linear">선형</system:String>
   <system:String x:Key="context.pitch.pointadd">피치 점 추가</system:String>
   <system:String x:Key="context.pitch.pointdel">피치 점 삭제</system:String>
   <system:String x:Key="context.pitch.pointsnapprev">이전 노트에 물리기</system:String>
-  <system:String x:Key="context.timeline.addtempo">{0}에서 템포 바꾸기</system:String>
-  <system:String x:Key="context.timeline.addtimesig">박자표 바꾸기</system:String>
+  <system:String x:Key="context.timeline.addtempo">{0}에서 템포 변경</system:String>
+  <system:String x:Key="context.timeline.addtimesig">박자표 변경</system:String>
   <system:String x:Key="context.timeline.deltempo">{0}에서 바뀐 템포 지우기</system:String>
   <system:String x:Key="context.timeline.deltimesig">바뀐 박자표 지우기</system:String>
 
@@ -34,27 +34,29 @@
   <system:String x:Key="dialogs.exitsave.caption">프로젝트 닫기</system:String>
   <system:String x:Key="dialogs.exitsave.message">프로젝트 파일이 저장되지 않았습니다. 저장할까요?</system:String>
   <system:String x:Key="dialogs.export.caption">내보내기</system:String>
-  <system:String x:Key="dialogs.export.savefirst">먼저 프로젝트 파일을 저장해야 합니다!</system:String>
+  <system:String x:Key="dialogs.export.savefirst">먼저 프로젝트 파일을 저장해야 합니다</system:String>
   <system:String x:Key="dialogs.installdependency.caption">의존 요소 설치 중…</system:String>
   <system:String x:Key="dialogs.installdependency.message">설치 중…</system:String>
   <system:String x:Key="dialogs.installdll.caption">음소화기 설치 중…</system:String>
   <system:String x:Key="dialogs.installdll.message">설치 중…</system:String>
   <system:String x:Key="dialogs.messagebox.cancel">취소</system:String>
-  <!--<system:String x:Key="dialogs.messagebox.copy">Copy error to clipboard</system:String>-->
+  <system:String x:Key="dialogs.messagebox.copy">클립보드에 오류 복사</system:String>
   <system:String x:Key="dialogs.messagebox.no">아니요</system:String>
   <system:String x:Key="dialogs.messagebox.ok">확인</system:String>
   <system:String x:Key="dialogs.messagebox.yes">네</system:String>
-  <system:String x:Key="dialogs.noresampler.caption">리샘플러가 없습니다.</system:String>
+  <system:String x:Key="dialogs.noresampler.caption">리샘플러 없음</system:String>
   <system:String x:Key="dialogs.noresampler.message">리샘플러가 없습니다! 좋아하는 리샘플러의 exe나 dll을 'Resamplers' 폴더에 넣고, 환경 설정에서 원하는 리샘플러를 골라 보세요.</system:String>
+  <system:String x:Key="dialogs.unsupportedfile.caption">지원하지 않는 파일 유형</system:String>
+  <system:String x:Key="dialogs.unsupportedfile.message">다음 파일 유형은 지원하지 않습니다. </system:String>
   <system:String x:Key="dialogs.timesig.caption">박자표</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">트랙 설정</system:String>
   <system:String x:Key="dialogs.tracksettings.location">위치 열기</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">렌더러</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">기본값으로 설정</system:String>
-  <system:String x:Key="dialogs.voicecolorremapping">보이스 컬러 재맵핑</system:String>
-  <system:String x:Key="dialogs.voicecolorremapping.caption">재맵핑된 컬러가 다음 트랙의 모든 노트에 적용됩니다.</system:String>
+  <system:String x:Key="dialogs.voicecolorremapping">음색 재배치</system:String>
+  <system:String x:Key="dialogs.voicecolorremapping.caption">다음 트랙의 모든 노트에 적용됩니다.</system:String>
 
-  <system:String x:Key="errors.caption">오류가 발생했습니다!</system:String>
+  <system:String x:Key="errors.caption">오류</system:String>
 
   <system:String x:Key="exps.abbr">줄임말</system:String>
   <system:String x:Key="exps.apply">적용</system:String>
@@ -65,30 +67,30 @@
   <system:String x:Key="exps.isflag">리샘플러 플래그 여부</system:String>
   <system:String x:Key="exps.maxvalue">최댓값</system:String>
   <system:String x:Key="exps.minvalue">최솟값</system:String>
-  <system:String x:Key="exps.name">표현 이름</system:String>
+  <system:String x:Key="exps.name">이름</system:String>
   <system:String x:Key="exps.optionvalues">선택형 값</system:String>
-  <system:String x:Key="exps.sepbycomma">쉼표(,)로 값을 구분해요</system:String>
-  <system:String x:Key="exps.type">표현 종류</system:String>
-  <system:String x:Key="exps.type.curve">커브형 표현</system:String>
-  <system:String x:Key="exps.type.numerical">숫자형 표현</system:String>
-  <system:String x:Key="exps.type.options">선택지형 표현</system:String>
+  <system:String x:Key="exps.sepbycomma">쉼표(,)로 값을 구분할 수 있습니다</system:String>
+  <system:String x:Key="exps.type">유형</system:String>
+  <system:String x:Key="exps.type.curve">커브형</system:String>
+  <system:String x:Key="exps.type.numerical">숫자형</system:String>
+  <system:String x:Key="exps.type.options">선택지형</system:String>
 
   <system:String x:Key="lyrics.apply">적용</system:String>
   <system:String x:Key="lyrics.cancel">취소</system:String>
   <system:String x:Key="lyrics.caption">가사 편집하기</system:String>
   <system:String x:Key="lyrics.livepreview">실시간 노트 미리보기</system:String>
   <system:String x:Key="lyrics.max">최대</system:String>
-  <system:String x:Key="lyrics.reset">리셋</system:String>
+  <system:String x:Key="lyrics.reset">재설정</system:String>
   <system:String x:Key="lyrics.selectnotes">먼저 원하는 노트를 선택해 주세요!</system:String>
-  <system:String x:Key="lyrics.separators">이 값 기준으로 가사 나누기</system:String>
+  <system:String x:Key="lyrics.separators">구분 기준</system:String>
 
   <system:String x:Key="lyricsreplace.after">수정 전</system:String>
   <system:String x:Key="lyricsreplace.before">수정 후</system:String>
-  <system:String x:Key="lyricsreplace.preset.rmvalphabet">알파벳 없애기</system:String>
+  <system:String x:Key="lyricsreplace.preset.rmvalphabet">알파벳 지우기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvnonhiragana">히라가나만 남기기</system:String>
   <system:String x:Key="lyricsreplace.preset.rmvphonetichint">발음 힌트 지우기</system:String>
-  <system:String x:Key="lyricsreplace.preset.rmvspace">스페이스 공백 없애기</system:String>
-  <system:String x:Key="lyricsreplace.preset.rmvtone">음계 접미사 없애기</system:String>
+  <system:String x:Key="lyricsreplace.preset.rmvspace">스페이스 공백 지우기</system:String>
+  <system:String x:Key="lyricsreplace.preset.rmvtone">음계 접미사 지우기</system:String>
   <system:String x:Key="lyricsreplace.presets">프리셋</system:String>
   <system:String x:Key="lyricsreplace.preview">미리보기</system:String>
   <system:String x:Key="lyricsreplace.regex">정규표현식 사용</system:String>
@@ -107,24 +109,24 @@
   <system:String x:Key="menu.file.exportaudio">오디오 내보내기</system:String>
   <system:String x:Key="menu.file.exportds">다른 이름으로 DiffSinger 스크립트 내보내기</system:String>
   <system:String x:Key="menu.file.exportds.v2">다른 이름으로 DiffSinger 스크립트 내보내기 (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">다른 이름으로 DiffSinger 스크립트 내보내기 (v2, 피치선 제외)</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">다른 이름으로 DiffSinger 스크립트 내보내기 (v2, 피치 벤드 제외)</system:String>
   <system:String x:Key="menu.file.exportmidi">Midi로 내보내기</system:String>
   <system:String x:Key="menu.file.exportmixdown">모두 합쳐 Wav로 내보내기</system:String>
   <system:String x:Key="menu.file.exportproject">프로젝트 내보내기</system:String>
-  <system:String x:Key="menu.file.exportust">Ust 파일로 내보내기</system:String>
-  <system:String x:Key="menu.file.exportustto">다른 이름으로 Ust로 내보내기...</system:String>
-  <system:String x:Key="menu.file.exportwav">개별 트랙을 Wav로 내보내기</system:String>
-  <system:String x:Key="menu.file.exportwavto">다른 이름으로 개별 트랙을 Wav로 내보내기...</system:String>
-  <system:String x:Key="menu.file.importaudio">오디오 불러오기...</system:String>
-  <system:String x:Key="menu.file.importmidi">Midi 불러오기...</system:String>
-  <system:String x:Key="menu.file.importmidi.drywetmidi">DryWetMidi로 불러오기</system:String>
-  <system:String x:Key="menu.file.importmidi.naudio">Naudio로 불러오기</system:String>
-  <system:String x:Key="menu.file.importtracks">여러 트랙 불러오기...</system:String>
+  <system:String x:Key="menu.file.exportust">Ust 파일 여러 개로 내보내기</system:String>
+  <system:String x:Key="menu.file.exportustto">Ust 파일 여러 개를 다른 이름으로 내보내기...</system:String>
+  <system:String x:Key="menu.file.exportwav">Wav 파일 여러 개로 내보내기</system:String>
+  <system:String x:Key="menu.file.exportwavto">Wav 파일 여러 개를 다른 이름으로 내보내기...</system:String>
+  <system:String x:Key="menu.file.importaudio">오디오 가져오기...</system:String>
+  <system:String x:Key="menu.file.importmidi">Midi 가져오기...</system:String>
+  <system:String x:Key="menu.file.importmidi.drywetmidi">DryWetMidi로 가져오기</system:String>
+  <system:String x:Key="menu.file.importmidi.naudio">Naudio로 가져오기</system:String>
+  <system:String x:Key="menu.file.importtracks">여러 트랙 가져오기...</system:String>
   <system:String x:Key="menu.file.new">새로 만들기</system:String>
   <system:String x:Key="menu.file.newfromtemplate">템플릿 파일로 새로 만들기</system:String>
   <system:String x:Key="menu.file.open">열기...</system:String>
   <system:String x:Key="menu.file.openas">다른 이름으로 열기...</system:String>
-  <system:String x:Key="menu.file.openexportlocation">내보낸 파일 위치 열기</system:String>
+  <system:String x:Key="menu.file.openexportlocation">내보내기 위치 열기</system:String>
   <system:String x:Key="menu.file.openprojectlocation">프로젝트 위치 열기</system:String>
   <system:String x:Key="menu.file.openrecent">최근 파일</system:String>
   <system:String x:Key="menu.file.save">저장</system:String>
@@ -160,14 +162,14 @@
   <system:String x:Key="notedefaults.portamento.length">길이</system:String>
   <system:String x:Key="notedefaults.portamento.start">시작</system:String>
   <system:String x:Key="notedefaults.preset">프리셋</system:String>
-  <system:String x:Key="notedefaults.preset.namenew">새 프리셋 이름 지정</system:String>
-  <system:String x:Key="notedefaults.preset.remove">프리셋 제거</system:String>
-  <system:String x:Key="notedefaults.preset.remove.tooltip">이 프리셋 제거</system:String>
+  <system:String x:Key="notedefaults.preset.namenew">새 프리셋 이름</system:String>
+  <system:String x:Key="notedefaults.preset.remove">삭제</system:String>
+  <system:String x:Key="notedefaults.preset.remove.tooltip">마지막 프리셋을 삭제합니다.</system:String>
   <system:String x:Key="notedefaults.preset.save">프리셋 저장</system:String>
   <system:String x:Key="notedefaults.preset.save.tooltip">현재 세팅으로 새 프리셋 추가</system:String>
-  <system:String x:Key="notedefaults.reset">설정 모두 초기화</system:String>
+  <system:String x:Key="notedefaults.reset">모든 설정 초기화</system:String>
   <system:String x:Key="notedefaults.reset.tooltip">모든 설정을 기본값으로 설정합니다.
-    주의: 사용자가 만들어 둔 프리셋이 전부 사라집니다.</system:String>
+주의: 사용자가 만들어 둔 프리셋이 전부 사라집니다.</system:String>
   <system:String x:Key="notedefaults.vibrato">비브라토</system:String>
   <system:String x:Key="notedefaults.vibrato.autominlength">최소 노트 길이</system:String>
   <system:String x:Key="notedefaults.vibrato.autotoggle">길이에 따라 비브라토 자동 적용</system:String>
@@ -190,10 +192,10 @@
   <system:String x:Key="noteproperty.vibratoenable">비브라토 활성화</system:String>
 
   <system:String x:Key="oto.alias">에일리어스</system:String>
-  <system:String x:Key="oto.color">컬러</system:String>
-  <system:String x:Key="oto.consonant">고정자음부</system:String>
+  <system:String x:Key="oto.color">음색</system:String>
+  <system:String x:Key="oto.consonant">고정 자음부</system:String>
   <system:String x:Key="oto.cutoff">컷오프</system:String>
-  <system:String x:Key="oto.edit.consonant">고정자음부 편집</system:String>
+  <system:String x:Key="oto.edit.consonant">고정 자음부 편집</system:String>
   <system:String x:Key="oto.edit.cutoff">컷오프 편집</system:String>
   <system:String x:Key="oto.edit.offset">오프셋 편집</system:String>
   <system:String x:Key="oto.edit.overlap">오버랩(OVL) 편집</system:String>
@@ -212,25 +214,25 @@
 
   <system:String x:Key="pianoroll.menu.batch">일괄 수정</system:String>
   <system:String x:Key="pianoroll.menu.lyrics">가사 설정</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">'-'를 '+'로 바꾸기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.dashtoplus">'-'를 '+'로 변경</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.edit">가사 편집</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.hiraganatoromaji">히라가나를 로마자로 바꾸기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.hiraganatoromaji">히라가나를 로마자로 변경</system:String>
   <system:String x:Key="pianoroll.menu.lyrics.insertslur">이음줄 기호(+) 삽입</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.javcvtocv">일본어 VCV 가사를 일본어 CV 가사로 바꾸기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.movesuffixtovoicecolor">가사의 접미사를 컬러로 이동시키기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.removelettersuffix">글자 접미사 없애기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.removephonetichint">발음 힌트 없애기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">음계 접미사 없애기</system:String>
-  <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">로마자를 히라가나로 바꾸기</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.javcvtocv">일본어 VCV 가사를 일본어 CV 가사로 변경</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.movesuffixtovoicecolor">가사의 접미사를 음색으로 이동</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.removelettersuffix">글자 접미사 제거</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.removephonetichint">발음 힌트 제거</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.removetonesuffix">음계 접미사 제거</system:String>
+  <system:String x:Key="pianoroll.menu.lyrics.romajitohiragana">로마자를 히라가나로 변경</system:String>
   <system:String x:Key="pianoroll.menu.notedefaults">노트 기본값</system:String>
   <system:String x:Key="pianoroll.menu.notes">노트</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtaildash">끝에 '-' 노트 추가</system:String>
   <system:String x:Key="pianoroll.menu.notes.addtailrest">끝에 'R' 노트 추가</system:String>
   <system:String x:Key="pianoroll.menu.notes.autolegato">노트를 서로 자동 연결</system:String>
-  <system:String x:Key="pianoroll.menu.notes.bakepitch">PTTD(피치 커브)를 피치선으로 변환</system:String>
+  <system:String x:Key="pianoroll.menu.notes.bakepitch">PTTD(피치 표현)를 피치 벤드로 변환</system:String>
   <system:String x:Key="pianoroll.menu.notes.clear.vibratos">비브라토 업생기</system:String>
   <system:String x:Key="pianoroll.menu.notes.fixoverlap">겹친 노트 고치기</system:String>
-  <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">중국어 한자를 병음으로</system:String>
+  <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">중국어 한자를 병음으로 변경</system:String>
   <system:String x:Key="pianoroll.menu.notes.lengthencrossfade">크로스페이드 길이 늘리기</system:String>
   <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">렌더링된 피치 커브 불러오기</system:String>
   <system:String x:Key="pianoroll.menu.notes.octavedown">한 옥타브 아래로</system:String>
@@ -239,11 +241,11 @@
   <system:String x:Key="pianoroll.menu.notes.quantize30">1/64로 퀀타이즈</system:String>
   <system:String x:Key="pianoroll.menu.notes.removetaildash">끝에 '-' 노트 지우기</system:String>
   <system:String x:Key="pianoroll.menu.notes.removetailrest">끝에 'R' 노트 지우기</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.aliases">음소 에일리어스 리셋</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.exps">모든 표현 리셋</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">음소 타이밍 리셋</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">피치선 리셋</system:String>
-  <system:String x:Key="pianoroll.menu.notes.reset.vibratos">비브라토 리셋</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.aliases">음소 에일리어스 재설정</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.exps">모든 표현 재설정</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.phonemetimings">음소 타이밍 재설정</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.pitchbends">피치 벤드 재설정</system:String>
+  <system:String x:Key="pianoroll.menu.notes.reset.vibratos">비브라토 재설정</system:String>
   <system:String x:Key="pianoroll.menu.part">파트</system:String>
   <system:String x:Key="pianoroll.menu.part.legacypluginexp">레거시 플러그인(실험적 기능)</system:String>
   <system:String x:Key="pianoroll.menu.part.singer">가수 및 원음 설정</system:String>
@@ -257,7 +259,7 @@
   <system:String x:Key="pianoroll.toggle.finalpitch">최종 렌더링된 피치 커브 보기(R)</system:String>
   <system:String x:Key="pianoroll.toggle.noteparams">노트 설정 열기(\)</system:String>
   <system:String x:Key="pianoroll.toggle.phoneme">음소 표시(O)</system:String>
-  <system:String x:Key="pianoroll.toggle.pitch">피치선 표시(I)</system:String>
+  <system:String x:Key="pianoroll.toggle.pitch">피치 벤드 표시(I)</system:String>
   <system:String x:Key="pianoroll.toggle.snap">토글 켜기·끄기(P)</system:String>
   <system:String x:Key="pianoroll.toggle.snap.auto">자동 스냅</system:String>
   <system:String x:Key="pianoroll.toggle.snap.autotriplet">자동 스냅(셋잇단)</system:String>
@@ -267,14 +269,14 @@
   <system:String x:Key="pianoroll.toggle.waveform">파형 표시(W)</system:String>
   <system:String x:Key="pianoroll.tool.drawpitch">피치 그리기 툴(4)
     왼쪽 클릭으로 그리기
-    오른쪽 클릭으로 리셋
+    오른쪽 클릭으로 재설정
     Ctrl 키를 누르며 클릭해 선택
     Alt 키를 누르며 클릭해 다듬기</system:String>
   <system:String x:Key="pianoroll.tool.eraser">지우기 툴(3)</system:String>
   <system:String x:Key="pianoroll.tool.knife">자르기 툴(5)</system:String>
   <system:String x:Key="pianoroll.tool.penplus">펜 플러스 툴(Ctrl + 2)
     왼쪽 클릭으로 그리기
-    오른쪽 클릭으로 리셋
+    오른쪽 클릭으로 재설정
     Ctrl 키를 누르며 클릭해 선택</system:String>
   <system:String x:Key="pianoroll.tool.penv2">펜 툴(2)
     왼쪽 클릭으로 그리기
@@ -315,7 +317,7 @@
   <system:String x:Key="prefs.paths">경로</system:String>
   <system:String x:Key="prefs.paths.addlsinger">추가 가수 폴더</system:String>
   <system:String x:Key="prefs.paths.addlsinger.install">가수 설치 시 '추가 가수 폴더'에 설치</system:String>
-  <system:String x:Key="prefs.paths.reset">리셋</system:String>
+  <system:String x:Key="prefs.paths.reset">재설정</system:String>
   <system:String x:Key="prefs.paths.select">선택</system:String>
   <system:String x:Key="prefs.playback">재생</system:String>
   <system:String x:Key="prefs.playback.autoscroll">자동 스크롤</system:String>
@@ -324,7 +326,7 @@
   <system:String x:Key="prefs.playback.autoscrollmode.stationarycursor">두루마리 읽듯 스크롤</system:String>
   <system:String x:Key="prefs.playback.backend">오디오 백엔드</system:String>
   <system:String x:Key="prefs.playback.backend.auto">자동</system:String>
-  <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
+  <system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>
   <system:String x:Key="prefs.playback.cursorposition">자동 스크롤 여백</system:String>
   <system:String x:Key="prefs.playback.device">오디오 재생 장치</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">일시 정지 동작</system:String>
@@ -340,7 +342,8 @@
   <system:String x:Key="prefs.rendering.phasecomp">위상 보정</system:String>
   <system:String x:Key="prefs.rendering.prerender">미리 렌더링</system:String>
   <system:String x:Key="prefs.rendering.resampler">리샘플러</system:String>
-  <system:String x:Key="prefs.rendering.resampler.morewarn">경고: 아직 moresampler는 완벽하게 지원되는 상태가 아닙니다. 속도가 느릴 수 있고, 높은 CPU 점유율 유발할 수 있습니다. 그래도 사용하시려면 다음을 따라 주세요.
+  <system:String x:Key="prefs.rendering.resampler.morewarn">
+    경고: 아직 moresampler는 완벽하게 지원되는 상태가 아닙니다. 속도가 느릴 수 있고, 높은 CPU 점유율 유발할 수 있습니다. 그래도 사용하시려면 다음을 따라 주세요.
     1. moreconfig.txt를 열어 resampler-compatibility 항목을 "on"으로 설정합니다.
     2. 같은 파일에서 resampler-compatibility 항목을 "off"로 설정합니다.
     3. moresampler가 누락된 llsm 파일을 다 생성할 때까지 느긋하게 기다립니다.
@@ -356,7 +359,7 @@
 
   <system:String x:Key="progress.loadingsingers">가수를 불러오는 중...</system:String>
   <system:String x:Key="progress.saved">{0} 프로젝트를 저장했습니다.</system:String>
-  <system:String x:Key="progress.waitingrendering">렌더링을 기다리는 중<system:String>
+  <system:String x:Key="progress.waitingrendering">렌더링을 기다리는 중</system:String>
 
   <system:String x:Key="singers.caption">가수 목록</system:String>
   <system:String x:Key="singers.editoto.editinvlabeler">vLabeler에서 원음 설정</system:String>
@@ -366,7 +369,7 @@
   <system:String x:Key="singers.editoto.reset">원음 설정 초기화</system:String>
   <system:String x:Key="singers.editoto.save">원음 설정 저장</system:String>
   <system:String x:Key="singers.editoto.searchalias">에일리어스 검색</system:String>
-  <system:String x:Key="singers.editoto.setvlabelerpath">vLabeler 1.0.0-beta1 이상 버전이 필요해요. https://github.com/sdercolin/vlabeler 에서 브이라벨러를 다운로드하고, 환경설정의 "브이라벨러(vLabeler)가 설치된 위치"에 등록해 주세요!</system:String>
+  <system:String x:Key="singers.editoto.setvlabelerpath">vLabeler 1.0.0-beta1 이상 버전이 필요합니다. https://github.com/sdercolin/vlabeler에서 vlabeler를 다운로드하고, 환경설정의 'vLabeler가 설치된 위치'에 등록해 주세요!</system:String>
   <system:String x:Key="singers.errorreport">가수의 오류 보고서 생성</system:String>
   <system:String x:Key="singers.location">위치 열기</system:String>
   <system:String x:Key="singers.otoview.moveleft">왼쪽으로 이동</system:String>
@@ -387,14 +390,14 @@
   <system:String x:Key="singers.setsingertype">가수 유형 설정</system:String>
   <system:String x:Key="singers.subbanks.cancel">취소</system:String>
   <system:String x:Key="singers.subbanks.clear">비우기</system:String>
-  <system:String x:Key="singers.subbanks.color">컬러</system:String>
-  <system:String x:Key="singers.subbanks.color.add">컬러 추가</system:String>
-  <system:String x:Key="singers.subbanks.color.remove">컬러 지우기</system:String>
-  <system:String x:Key="singers.subbanks.color.rename">컬러 이름 바꾸기</system:String>
+  <system:String x:Key="singers.subbanks.color">음색</system:String>
+  <system:String x:Key="singers.subbanks.color.add">음색 추가</system:String>
+  <system:String x:Key="singers.subbanks.color.remove">음색 지우기</system:String>
+  <system:String x:Key="singers.subbanks.color.rename">음색 이름 변경</system:String>
   <system:String x:Key="singers.subbanks.edit">서브 뱅크 편집</system:String>
   <system:String x:Key="singers.subbanks.export">prefix.map 내보내기</system:String>
   <system:String x:Key="singers.subbanks.import">prefix.map 불러오기</system:String>
-  <system:String x:Key="singers.subbanks.reset">리셋</system:String>
+  <system:String x:Key="singers.subbanks.reset">재설정</system:String>
   <system:String x:Key="singers.subbanks.save">저장</system:String>
   <system:String x:Key="singers.subbanks.selectall">모두 선택</system:String>
   <system:String x:Key="singers.subbanks.set">설정</system:String>
@@ -418,7 +421,7 @@
   <system:String x:Key="tip.exps.notsupported">렌더러가 이 표현을 지원하지 않습니다</system:String>
   <system:String x:Key="tip.lyricbox.next">Tab: 다음 노트</system:String>
   <system:String x:Key="tip.lyricbox.prev">Shift + Tab: 이전 노트</system:String>
-  <system:String x:Key="tip.notes.basics"선택 툴
+  <system:String x:Key="tip.notes.basics">선택 툴
     박스 선택: 노트 선택
     Ctrl + 박스 선택: 여러 노트 선택
     위/아래 화살표: 노트를 위로 이동
@@ -447,7 +450,7 @@
   <system:String x:Key="tracks.mute.only">이 트랙만 음소거</system:String>
   <system:String x:Key="tracks.mute.unmuteall">모든 트랙 음소거 해제</system:String>
   <system:String x:Key="tracks.remove">트랙 제거</system:String>
-  <system:String x:Key="tracks.rename">트랙 이름 바꾸기</system:String>
+  <system:String x:Key="tracks.rename">트랙 이름 변경</system:String>
   <system:String x:Key="tracks.selectrenderer">렌더러 선택</system:String>
   <system:String x:Key="tracks.selectsinger">가수 선택</system:String>
   <system:String x:Key="tracks.solo">솔로</system:String>
@@ -469,6 +472,6 @@
   <system:String x:Key="updater.update">업데이트</system:String>
 
   <system:String x:Key="warning">경고</system:String>
-  <system:String x:Key="warning.asciipath">OpenUtau 경로 "{0}"에 ASCII 인코딩에 없는 문자(예컨대 한글, 일본어 등)가 포함되어 있습니다. Exe 리샘플러가 작동하지 않을 수 있습니다.</system:String>
+  <system:String x:Key="warning.asciipath">OpenUtau 경로 "{0}"에 ASCII 인코딩에 없는 문자가 포함되어 있습니다. exe 리샘플러가 작동하지 않을 수 있습니다.</system:String>
   <system:String x:Key="warning.renderer">이 렌더러를 위한 설정이 없습니다.</system:String>
 </ResourceDictionary>


### PR DESCRIPTION
## Overview 개요
This is a PR with the following fixes for the Korean translation. It still needs to be reviewed several times.
- Fix mistranslations
- Add missing translations
- Edit terms for consistency
- Proofread sentences

한국어 번역에 대해 다음 수정 사항을 담은 PR입니다. 아직 여러 번 검토가 필요합니다.
- 오역 수정
- 누락된 번역 추가
- 단어 난립 교정
- 문장 다듬기

## Changes 변경 사항
Here's a summary of the changes. My English isn't exactly great, so I won't be able to translate everything into English, but I've added subheadings for English-speaking contributors.
세부 변경 내용은 다음과 같습니다. 영어 실력이 딱히 뛰어난 정도는 아니어서 모든 내용을 영어로 전해 드리진 못하겠습니다. 다만 영어권 기여자분들을 위해 소제목을 추가했으니 참고해 주세요.

- **과도한 '해요체' 교정 / Correct sentences that are unnaturally forced into a single grammatical style.**  
 보통 한국어 화자는 적당히 격식을 갖추는 자리에서 하십시오체와 해요체를 적절히 섞어서 사용합니다. "오류가 발생했습니다. 다음을 확인해 주세요."라든지, "오늘까지는 어려울 것 같습니다. 내일이라면 가능할 것 같은데, 어떠신가요?"처럼요. 반면 현재 적용된 한국어 번역에서는 거의 모든 문장이 해요체로만 적혀 있습니다. 딱히 그럴 필요가 없는 곳에서까지 해요체를 사용하니, 격식이 떨어지는 인상이 들 수 있고, 전체적으로 많이 비전문적인 느낌이 듭니다. 이에 관해 쓰인 책의 몇 단락을 발췌해 보여 드리겠습니다.  

  > '우리 서비스는 힙하니까 단일 문체 해요체로 일치시켜 버리고 모든 상황에서 우리는 해요체만 쓰겠어요!'처럼 다른 문체를 완전히 배제해 버리면, 우리 서비스의 보이스는 유아적이고 지나치게 친한 척하는 비전문적인 목소리가 될 수밖에 없다. 반대로 '본 서비스는 다루는 주제가 무겁고 어려우므로 전중하고 공적이며 전문적인 것처럼 보이도록 하십시오체만 쓰도록 하겠습니다'와 같은 생각도 역시 잘못됐다.
  > 모든 UI 텍스트의 문장의 어미를 '-요'나 '-ㅂ니다'로 맞추겠다고 생각하는 것은 애초에 불가능한 어미 순결주의에 대한 강박이다. 그건 텍스트 가이드를 지키는 것이 아닌 유아적인 어미 짝맞추기에 불과하다. 이렇게 어미 짝맞추기만 고집한다면 어떤 일이 벌어질까? 서비스 화면의 모든 문장에 '-해요, -예요, -해요'와 같은 어미가 중복되면서 어린 아이를 흉내내는 기계가 글을 찍어 낸 것 같은 어색함만이 남게 된다. 근래 들어 해요체만 고집하는 서비스에 내가 느끼는 인상이 바로 그것이다.  
  > -- 전주경, 《그렇게 쓰면 아무도 안 읽습니다》, (주)윌북, 140쪽  

   마냥 해요체를 폄하하고자 하는 게 아닙니다. 이는 책의 저자도 인용 부분 이후에 언급하는 내용입니다. 해요체가 힘을 발휘하는 부분도 분명히 있습니다. 하지만 모든 문장에 해요체를 적용하는 것은 하십시오체의 성질과 힘을 전혀 고려하지 않은 결정입니다. 결정적으로 해요체만을 쓰면서 말하는 한국어 화자는 없다시피 할 정도입니다. 그래서 이 PR에서는 해요체만을 쓰는 번역본 전반을 하십시오체와 해요체 병용으로 수정했습니다.

   특히, '할래요'처럼 '-ㄹ래요' 종결 어미가 쓰인 문장들은 전부 사용 위치에 맞게 어미를 수정했습니다. 다른 문체에 비해 길이가 비약적으로 길어지고, 사용자에게 의지를 너무 강요하는 느낌이 드는 문체기 때문입니다. 다음 문서를 확인해 이에 관해 더 알아보실 수 있습니다. https://brunch.co.kr/@joojun/117

   추가로, 수정 전 "··· 중이에요..." 꼴로 쓰인 문장들이 "··· 중..."으로 바뀐 것도 무분별한 해요체 남용 방지의 일환입니다. 물론 간결함이라는 다른 목적도 가지고 있습니다.


- **맞춤법 교정, 문맥상 부자연스러운 단어 수정 / Correct spelling, remove unnatural words from context**  
 말 그대로입니다. 맞춤법에 맞지 않는 내용을 교정하고, 문맥상 자연스럽지 않은 단어를 수정했습니다. 예를 들어서 다음과 같습니다.
 
  > 폭넓은 음운 지원 제공을 표방합니다.   
 
  [수정 전 32번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L32)에 있던 구절입니다. 여기서 '표방하다'는 고려대한국어대사전에 따르면 "(사람이 자기의 주의나 주장, 처지 따위를) 어떤 명목을 붙여 앞에 내세우다."라는 의미를 지닙니다. 즉 부정적인 느낌이 강합니다. 하지만 원문을 보면 결코 부정적인 느낌을 주기 위해 쓰인 글이 아니므로 수정하거나 삭제하는 게 의미 전달에 더 도움이 됩니다. 이 PR에서는 저 구절을 "···지원을 제공합니다."로 수정했습니다.


- **한글로 음차된 고유명사를 공식 용어로 수정 / Correct Korean transliterated proper names to official terms**  
 [수정 전 108~109번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L108-L109) 등에서 보인 '디프싱어', [308](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L308C7-L308C7), [381번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L381) 등에서 보인 '브이라벨러', [325번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L325C5-L325C5) 등에서 보인 '오픈우타우' 등등... 각각 DiffSinger, vLabeler, OpenUtau 등 한글로 표기할 이유가 없는 고유 명사들입니다. 딱히 그럴 필요가 없는 상황에서 고유 명사를 한글로 표기하면 사용자에게 오히려 혼란을 안길 수 있고, 프로그램 이름이 임의로 음역되는 것이기에 추후 생길 수 있는 한글 공식 표기와 상충할 수도 있습니다. 이 PR에서는 고유 명사를 전부 공식 용어로 수정했습니다.


- **심하게 남용된 문장 부호 교정 / Correct overused punctuation**  
 [수정 전 216~247번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L216-L247) 등에서 특히 도드라지게 보이는데, 큰따옴표를 전혀 쓰지 않아도 되는 상황인데도 삽입되어 도리어 난잡해 보입니다. 원문에 문장 부호가 없어서 문장 부호를 쓰지 않아도 되는 상황인데도 사용한 경우, 일관성을 위해 꽤 너저분해 보여도 넣은 경우가 주를 이룹니다. 필요하지 않은 문장 부호는 전부 삭제했고, 잘못 사용된 문장 부호는 규범에 맞게 수정했습니다. 대부분의 큰따옴표가 작은따옴표로 바뀐 이유도 이것입니다.


- **문자열 사용 위치에 따라 문체 수정 / Modify style based on where the string is used**  
   > 리샘플러의 플래그에요

   [수정 전 65번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L65C7-L65C7)의 문자열입니다. 처음의 문자열만 보고 단순히 "리샘플러의 플래그입니다"로 교정했었는데, OpenUtau 안에서 확인해 보니 리샘플러 플래그인지 아닌지를 설정하는 체크박스의 라벨이었습니다. 문장형 문자열은 엔간해서는 체크박스 라벨에 어울리지 않으므로 "리샘플러 플래그 여부"로 다시 수정했습니다.

   > 적용하기

   [수정 전 76번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L76)의 문자열입니다. 버튼에 들어가는 문자열인데, 이 아래로도 일관성 없이 단순 명사와 명사절이 뒤섞여 쓰이고 있었습니다. '-하기' 꼴은 사용자에게 무의식적으로 의지를 요구할 수 있는 문체이기도 하고, 길이가 길어서 전부 명사로 수정했습니다. 고작 두 글자가 길다고 느껴지냐고 하실 수도 있습니다만, OpenUtau에서 보통 버튼을 가로로 나열하기 때문에 버튼 안 
텍스트가 몇 글자만 커져도 줄 바꿈이 되거나 가용 범위를 넘어서거나, 창 크기가 늘어나는 참사가 일어날 수도 있습니다.


- **문자열 윤문 / Polish strings**  
 원문과 다르게 번역된 내용 중에서, 프로그램에서 사용할 때 글 문맥이나 사용 흐름상 필요하지 않은 내용(예컨대 환경 설정 창 안에서 그룹 라벨에 '설정'이 쓰인 경우)을 다듬었고, 딱히 없어도 의미가 통하는 부분은 원문에 맞추어 삭제했습니다. 잘 통용되지 않거나, 어려운 용어는 풀어서 썼습니다. 이외에도 기타 자잘한 내용이 다듬어졌습니다.


- **원문에 없는 내용이 멋대로 추가된 번역 대거 수정 / Fix a bunch of translations that added content that wasn't in the original**  
  수정 전 번역본, 그러니까 현재 번역본에는 번역자가 원문에 없는 내용을 추가하거나, 삭제하거나, 수정한 내용이 심각할 정도로 많습니다. 단순히 한국어 화자가 영어 기준으로 쓰인 글을 이해하는 데 은근한 도움을 줄 목적을 넘어서서, 다시 말해 의역의 정도를 넘어선 내용이 다수 포함되어 있습니다.  

  이 파일의 문자열들은 영어 원문의 번역본이기 때문에 번역자가 임의로 내용을 추가하면 안 됩니다. 추가되거나 수정되면 이해하는 데 도움이 될 법한 내용은 이슈나 PR로 원문을 수정한 다음 번역을 적용하거나, 원문과 번역본을 둘 다 수정해 PR을 넣어야 합니다. 특별한 상의 없이 임의로 내용을 추가하는 것은 역주도, 의역도 아닌 원문 왜곡이기 때문입니다. 

  ```xml
  <system:String x:Key="notedefaults.reset">모두 초기화(경고!)</system:String>
  <system:String x:Key="notedefaults.reset.tooltip">
    경고!!! 내가 만들어 둔 프리셋이 전부 사라져요!!!
    사용자 지정 프리셋을 전부 지우고, 모든 프리셋을 기본값으로 초기화합니다.
  </system:String>
  ```
 
   [수정 전 167~171번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L167C38-L171C9) 문자열입니다. 

  ```xml
    <system:String x:Key="notedefaults.reset">Reset All Settings</system:String>
    <system:String x:Key="notedefaults.reset.tooltip">Reset every setting to default values.
  Warning: this option removes custom presets.</system:String>
  ```
   그리고 이건 [원문의 같은 문자열 부분입니다](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.axaml#L170C1-L172C61). 무슨 느낌인지 와닿으실 거라 생각합니다. 원문에는 없는 "(경고!)"가 추가됐고, 문장 순서를 바꾸며 "내가 만들어 둔 프리셋이 전부 사라져요!!!" 같은 문장이 새롭게 생겨났습니다.

  ```xml
    <system:String x:Key="prefs.rendering.resampler.morewarn">
      경고! 오픈우타우에서 moresampler 지원은 아직 완벽하지 않아요. 속도가 느려질 수도 있고, CPU 점유율이 높아질 수도 있어요. 그래도 쓰고 싶으시다면... 다음을 따라합시다!:
      1. moreconfig.txt를 여세요. 
      moreconfig.txt는 moresampler.exe와 함께 "Resamplers" 폴더 내에 들어 있어야 합니다!
      2. "resampler-compatibility" 항목을 "on"으로 수정합니다.
      3. "auto-update-llsm-mrq" 항목을 "off"로 수정합니다.
      4. 끝입니다! 
      참고로, moresampler가 누락된 llsm 파일들을 생성할 때마다 버벅일 수 있습니다. 차분히 인내하며 기다리세요.
    </system:String>
  ```
   다른 예시입니다. [수정 전 358~366번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L358-L366)에 해당하는 문자열인데, [원문](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.axaml#L345-L350)에 비해서 이상할 정도로 분량이 많아진 것을 확인할 수 있습니다. 번역자가 추가해 둔 `"moreconfig.txt는 moresampler.exe와 함께 "Resamplers" 폴더 내에 들어 있어야 합니다!"`도 눈에 돋보입니다.

   이외에도 이런 내용은 수도 없이 많습니다. 원문에 미세하게 번역자의 의지가 스며든 것도 예를 하나하나 들 수 없을 정도로 많고([수정 전 95번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L95C11-L95C11) 등), 내용을 통째로 바꿔 버리는 일도 있을 뿐더러([수정 전 442~457번째 줄](https://github.com/stakira/OpenUtau/blob/f23b17163eb1b2f02a201e7cdb3df66a60bc6837/OpenUtau/Strings/Strings.ko-KR.axaml#L442-L457)), 통용되지 않는 용어를 번역본에 추가하는 일도 있습니다. 물론 하나같이 번역이라는 작업 안에서는 이루어지면 안 되는 일입니다.

   이 PR에서는 이런 내용을 중점적으로 대거 수정했습니다.

## 끝맺음 Conclusion
이 PR에 과잉 교정이 있을 수 있습니다. 한국어를 할 줄 아신다면 부디 검토해 주시면 감사하겠습니다.
This PR may contain overcorrections, mistakes, or inconsistencies. I would appreciate it if you could review it.