### PR TITLE
Move DIFFS ZH-YUE and VOGEN ZH-YUE to ZH-YUE category

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerJyutpingPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerJyutpingPhonemizer.cs
@@ -4,7 +4,7 @@ using OpenUtau.Core.G2p;
 using System.Linq;
 
 namespace OpenUtau.Core.DiffSinger {
-    [Phonemizer("DiffSinger Jyutping Phonemizer", "DIFFS ZH-YUE", language: "ZH")]
+    [Phonemizer("DiffSinger Jyutping Phonemizer", "DIFFS ZH-YUE", language: "ZH-YUE")]
     public class DiffSingerJyutpingPhonemizer : DiffSingerBasePhonemizer {
         protected override string[] Romanize(IEnumerable<string> lyrics) {
             return ZhG2p.CantoneseInstance.Convert(lyrics.ToList(), false, true).Split(" ");

--- a/OpenUtau.Core/Vogen/VogenYuePhonemizer.cs
+++ b/OpenUtau.Core/Vogen/VogenYuePhonemizer.cs
@@ -3,7 +3,7 @@ using OpenUtau.Api;
 using System;
 
 namespace OpenUtau.Core.Vogen {
-    [Phonemizer("Vogen Chinese Yue Phonemizer", "VOGEN ZH-YUE", language: "ZH")]
+    [Phonemizer("Vogen Chinese Yue Phonemizer", "VOGEN ZH-YUE", language: "ZH-YUE")]
     public class VogenYuePhonemizer : VogenBasePhonemizer {
         private static TrieNode? trie;
         private static InferenceSession? g2p;


### PR DESCRIPTION
Before this change, these two Cantonese phonemziers are under the same category with mandarin Chinese phonemizers. LotteV has created a ZH-YUE category, so here I move DIFFS ZH-YUE and VOGEN ZH-YUE into this category.