### PR TITLE
Fix openutau crash when opening a ustx project whose first time signature isn't at 0

### DIFF
--- a/OpenUtau.Core/Util/TimeAxis.cs
+++ b/OpenUtau.Core/Util/TimeAxis.cs
@@ -51,7 +51,9 @@ namespace OpenUtau.Core {
                     posTick = timeSigSegments.Last().tickPos
                         + timeSigSegments.Last().ticksPerBar * (timesig.barPosition - lastBarPos);
                 } else {
-                    Debug.Assert(timesig.barPosition == 0);
+                    if(timesig.barPosition != 0) {
+                        throw new Exception("First time signature must be at bar 0.");
+                    }
                 }
                 timeSigSegments.Add(new TimeSigSegment {
                     barPos = timesig.barPosition,
@@ -76,7 +78,9 @@ namespace OpenUtau.Core {
             for (var i = 0; i < project.tempos.Count; ++i) {
                 var tempo = project.tempos[i];
                 if (i == 0) {
-                    Debug.Assert(tempo.position == 0);
+                    if(tempo.position != 0) {
+                        throw new Exception("First tempo must be at tick 0.");
+                    }
                 }
                 var index = tempoSegments.FindIndex(seg => seg.tickPos >= tempo.position);
                 if (index < 0) {


### PR DESCRIPTION
After this fix, when opening a ustx project whose first time signature isn't at 0 (produced by third-party softwares), openutau won't crash. Instead, it will show an error dialog.
![image](https://github.com/stakira/OpenUtau/assets/54425948/b0d709b8-8a15-42b0-b2d5-f675c51bb7e1)