### PR TITLE
Add KoreanCVPhonemizer

### DIFF
--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -1,0 +1,1433 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Classic;
+using Serilog;
+using static OpenUtau.Api.Phonemizer;
+
+namespace OpenUtau.Core {
+    /// <summary>
+    /// static class that performs Korean Phoneme Variation, Jamo separation, Jamo merging, etc. 
+    /// </summary>
+    public static class KoreanPhonemizerUtil {
+        /// <summary>
+        /// First hangeul consonants, ordered in unicode sequence.
+        /// <br/><br/>유니코드 순서대로 정렬된 한국어 초성들입니다.
+        /// </summary>
+        const string FIRST_CONSONANTS = "ㄱㄲㄴㄷㄸㄹㅁㅂㅃㅅㅆㅇㅈㅉㅊㅋㅌㅍㅎ";
+        /// <summary>
+        /// Middle hangeul vowels, ordered in unicode sequence.
+        /// <br/><br/>유니코드 순서대로 정렬된 한국어 중성들입니다.
+        /// </summary>
+        const string MIDDLE_VOWELS = "ㅏㅐㅑㅒㅓㅔㅕㅖㅗㅘㅙㅚㅛㅜㅝㅞㅟㅠㅡㅢㅣ";
+
+        /// <summary>
+        /// Last hangeul consonants, ordered in unicode sequence.
+        /// <br/><br/>유니코드 순서대로 정렬된 한국어 종성들입니다.
+        /// </summary>
+        const string LAST_CONSONANTS = " ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ"; // The first blank(" ") is needed because Hangeul may not have lastConsonant.
+
+        /// <summary>
+        /// unicode index of 가
+        /// </summary>
+        const ushort HANGEUL_UNICODE_START = 0xAC00;
+
+        /// <summary>
+        /// unicode index of 힣
+        /// </summary>
+        const ushort HANGEUL_UNICODE_END = 0xD79F;
+
+        /// <summary>
+        /// A hashtable of basicsounds - ㄱ/ㄷ/ㅂ/ㅅ/ㅈ.
+        /// <br/><br/>예사소리 테이블입니다.
+        /// </summary>
+        public static readonly Hashtable basicSounds = new Hashtable() {
+            ["ㄱ"] = 0,
+            ["ㄷ"] = 1,
+            ["ㅂ"] = 2,
+            ["ㅈ"] = 3,
+            ["ㅅ"] = 4
+        };
+
+        /// <summary>
+        /// A hashtable of aspirate sounds - ㅋ/ㅌ/ㅍ/ㅊ/(ㅌ).
+        /// <br/>[4] is "ㅌ", it will be used when conducting phoneme variation - 격음화(거센소리되기).
+        /// <br/><br/>거센소리 테이블입니다. 
+        /// <br/>[4]의 중복값 "ㅌ"은 오타가 아니며 격음화(거센소리되기) 수행 시에 활용됩니다.
+        /// </summary>
+        public static readonly Hashtable aspirateSounds = new Hashtable() {
+            [0] = "ㅋ",
+            [1] = "ㅌ",
+            [2] = "ㅍ",
+            [3] = "ㅊ",
+            [4] = "ㅌ"
+        };
+
+        /// <summary>
+        /// A hashtable of fortis sounds - ㄲ/ㄸ/ㅃ/ㅆ/ㅉ.
+        /// <br/><br/>된소리 테이블입니다. 
+        /// </summary>
+        public static readonly Hashtable fortisSounds = new Hashtable() {
+            [0] = "ㄲ",
+            [1] = "ㄸ",
+            [2] = "ㅃ",
+            [3] = "ㅉ",
+            [4] = "ㅆ"
+        };
+
+        /// <summary>
+        /// A hashtable of nasal sounds - ㄴ/ㅇ/ㅁ.
+        /// <br/><br/>비음 테이블입니다. 
+        /// </summary>
+        public static readonly Hashtable nasalSounds = new Hashtable() {
+            ["ㄴ"] = 0,
+            ["ㅇ"] = 1,
+            ["ㅁ"] = 2
+        };
+
+
+        /// <summary>
+        /// Confirms if input string is hangeul.
+        /// <br/><br/>입력 문자열이 한글인지 확인합니다.
+        /// </summary>
+        /// <param name = "character"> A string of Hangeul character. 
+        /// <br/>(Example: "가", "!가", "가.")</param>
+        /// <returns> Returns true when input string is Hangeul, otherwise false. </returns>
+        public static bool IsHangeul(string? character) {
+
+            ushort unicodeIndex;
+            bool isHangeul;
+            if ((character != null) && character.StartsWith('!')) {
+                // Automatically deletes ! from start.
+                // Prevents error when user uses ! as a phonetic symbol.  
+                unicodeIndex = Convert.ToUInt16(character.TrimStart('!')[0]);
+                isHangeul = !(unicodeIndex < HANGEUL_UNICODE_START || unicodeIndex > HANGEUL_UNICODE_END);
+            } 
+            else if (character != null) {
+                try {
+                    unicodeIndex = Convert.ToUInt16(character[0]);
+                    isHangeul = !(unicodeIndex < HANGEUL_UNICODE_START || unicodeIndex > HANGEUL_UNICODE_END);
+                } 
+                catch {
+                    isHangeul = false;
+                }
+
+            } 
+            else {
+                isHangeul = false;
+            }
+
+            return isHangeul;
+        }
+        /// <summary>
+        /// Separates complete hangeul string's first character in three parts - firstConsonant(초성), middleVowel(중성), lastConsonant(종성).
+        /// <br/>입력된 문자열의 0번째 글자를 초성, 중성, 종성으로 분리합니다.
+        /// </summary>
+        /// <param name="character"> A string of complete Hangeul character.
+        /// <br/>(Example: '냥') 
+        /// </param>
+        /// <returns>{firstConsonant(초성), middleVowel(중성), lastConsonant(종성)}
+        /// (ex) {"ㄴ", "ㅑ", "ㅇ"}
+        /// </returns>
+        public static Hashtable Separate(string character) {
+
+            int hangeulIndex; // unicode index of hangeul - unicode index of '가' (ex) '냥'
+
+            int firstConsonantIndex; // (ex) 2
+            int middleVowelIndex; // (ex) 2
+            int lastConsonantIndex; // (ex) 21
+
+            string firstConsonant; // (ex) "ㄴ"
+            string middleVowel; // (ex) "ㅑ"
+            string lastConsonant; // (ex) "ㅇ"
+
+            Hashtable separatedHangeul; // (ex) {[0]: "ㄴ", [1]: "ㅑ", [2]: "ㅇ"}
+
+
+            hangeulIndex = Convert.ToUInt16(character[0]) - HANGEUL_UNICODE_START;
+
+            // seperates lastConsonant
+            lastConsonantIndex = hangeulIndex % 28;
+            hangeulIndex = (hangeulIndex - lastConsonantIndex) / 28;
+
+            // seperates middleVowel
+            middleVowelIndex = hangeulIndex % 21;
+            hangeulIndex = (hangeulIndex - middleVowelIndex) / 21;
+
+            // there's only firstConsonant now
+            firstConsonantIndex = hangeulIndex;
+
+            // separates character
+            firstConsonant = FIRST_CONSONANTS[firstConsonantIndex].ToString();
+            middleVowel = MIDDLE_VOWELS[middleVowelIndex].ToString();
+            lastConsonant = LAST_CONSONANTS[lastConsonantIndex].ToString();
+
+            separatedHangeul = new Hashtable() {
+                [0] = firstConsonant,
+                [1] = middleVowel,
+                [2] = lastConsonant
+            };
+
+
+            return separatedHangeul;
+        }
+
+        /// <summary>
+        /// merges separated hangeul into complete hangeul. (Example: {[0]: "ㄱ", [1]: "ㅏ", [2]: " "} => "가"})
+        /// <para>자모로 쪼개진 한글을 합쳐진 한글로 반환합니다.</para>
+        /// </summary>
+        /// <param name="separated">separated Hangeul. </param>
+        /// <returns>Returns complete Hangeul Character.</returns>
+        public static string Merge(Hashtable separatedHangeul){
+            
+            int firstConsonantIndex; // (ex) 2
+            int middleVowelIndex; // (ex) 2
+            int lastConsonantIndex; // (ex) 21
+
+            char firstConsonant = ((string)separatedHangeul[0])[0]; // (ex) "ㄴ"
+            char middleVowel = ((string)separatedHangeul[1])[0]; // (ex) "ㅑ"
+            char lastConsonant = ((string)separatedHangeul[2])[0]; // (ex) "ㅇ"
+
+            if (firstConsonant == ' ') {firstConsonant = 'ㅇ';}
+
+            firstConsonantIndex = FIRST_CONSONANTS.IndexOf(firstConsonant); // 초성 인덱스
+            middleVowelIndex = MIDDLE_VOWELS.IndexOf(middleVowel); // 중성 인덱스
+            lastConsonantIndex = LAST_CONSONANTS.IndexOf(lastConsonant); // 종성 인덱스
+ 
+            int mergedCode = HANGEUL_UNICODE_START + (firstConsonantIndex * 21 + middleVowelIndex) * 28 + lastConsonantIndex;
+            
+            string result = Convert.ToChar(mergedCode).ToString();
+            Debug.Print("Hangeul merged: " + $"{firstConsonant} + {middleVowel} + {lastConsonant} = " + result);
+            return result;
+        }
+
+        /// <summary>
+        /// Conducts phoneme variation with two characters input. <br/>※ This method is for only when there are more than one characters, so when there is single character only, Please use Variate(string character).  
+        /// <br/><br/>두 글자를 입력받아 음운변동을 진행합니다. <br/>※ 두 글자 이상이 아닌 단일 글자에서 음운변동을 적용할 경우, 이 메소드가 아닌 Variate(string character) 메소드를 사용해야 합니다.
+        /// </summary>
+        /// <param name="firstCharSeparated"> Separated table of first target.
+        /// <br/> 첫 번째 글자를 분리한 해시테이블 
+        /// <br/><br/>(Example: {[0]="ㅁ", [1]="ㅜ", [2]="ㄴ"} - 문)
+        /// </param>
+        /// <param name="nextCharSeparated"> Separated table of second target.
+        /// <br/>두 번째 글자를 분리한 해시테이블
+        /// <br/><br/>(Example: {[0]="ㄹ", [1]="ㅐ", [2]=" "} - 래)
+        /// </param>
+        /// <param name="returnCharIndex"> 0: returns result of first target character only. 
+        /// <br/>1: returns result of second target character only. <br/>else: returns result of both target characters. <br/>
+        /// <br/>0: 첫 번째 타겟 글자의 음운변동 결과만 반환합니다.
+        /// <br/>1: 두 번째 타겟 글자의 음운변동 결과만 반환합니다. <br/>나머지 값: 두 타겟 글자의 음운변동 결과를 모두 반환합니다. <br/>
+        /// <br/>(Example(0): {[0]="ㅁ", [1]="ㅜ", [2]="ㄹ"} - 물)
+        /// <br/>(Example(1): {[0]="ㄹ", [1]="ㅐ", [2]=" "} - 래)
+        /// <br/>(Example(-1): {[0]="ㅁ", [1]="ㅜ", [2]="ㄹ", [3]="ㄹ", [4]="ㅐ", [5]=" "} - 물래)
+        /// </param>
+        /// <returns> Example: when returnCharIndex = 0: {[0]="ㅁ", [1]="ㅜ", [2]="ㄹ"} - 물)
+        /// <br/> Example: when returnCharIndex = 1: {[0]="ㄹ", [1]="ㅐ", [2]=" "} - 래)
+        /// <br/> Example: when returnCharIndex = -1: {[0]="ㅁ", [1]="ㅜ", [2]="ㄹ", [3]="ㄹ", [4]="ㅐ", [5]=" "} - 물래)
+        /// </returns>
+        private static Hashtable Variate(Hashtable firstCharSeparated, Hashtable nextCharSeparated, int returnCharIndex = -1) {
+
+            string firstLastConsonant = (string)firstCharSeparated[2]; // 문래 에서 ㄴ, 맑다 에서 ㄺ
+            string nextFirstConsonant = (string)nextCharSeparated[0]; // 문래 에서 ㄹ, 맑다 에서 ㄷ
+
+            // 1. 연음 적용 + ㅎ탈락
+            if ((!firstLastConsonant.Equals(" ")) && nextFirstConsonant.Equals("ㅎ")) {
+                if (basicSounds.Contains(firstLastConsonant)) {
+                    // 착하다 = 차카다
+                    nextFirstConsonant = (string)aspirateSounds[basicSounds[firstLastConsonant]];
+                    firstLastConsonant = " ";
+                } else {
+                    // 뻔한 = 뻔안 (아래에서 연음 적용되서 뻐난 됨)
+                    nextFirstConsonant = "ㅇ";
+                }
+            }
+
+            if (nextFirstConsonant.Equals("ㅇ") && (! firstLastConsonant.Equals(" "))) {
+                // ㄳ ㄵ ㄶ ㄺ ㄻ ㄼ ㄽ ㄾ ㄿ ㅀ ㅄ 일 경우에도 분기해서 연음 적용
+                if (firstLastConsonant.Equals("ㄳ")) {
+                    firstLastConsonant = "ㄱ";
+                    nextFirstConsonant = "ㅅ";
+                } 
+                else if (firstLastConsonant.Equals("ㄵ")) {
+                    firstLastConsonant = "ㄴ";
+                    nextFirstConsonant = "ㅈ";
+                } 
+                else if (firstLastConsonant.Equals("ㄶ")) {
+                    firstLastConsonant = "ㄴ";
+                    nextFirstConsonant = "ㅎ";
+                } 
+                else if (firstLastConsonant.Equals("ㄺ")) {
+                    firstLastConsonant = "ㄹ";
+                    nextFirstConsonant = "ㄱ";
+                } 
+                else if (firstLastConsonant.Equals("ㄼ")) {
+                    firstLastConsonant = "ㄹ";
+                    nextFirstConsonant = "ㅂ";
+                } 
+                else if (firstLastConsonant.Equals("ㄽ")) {
+                    firstLastConsonant = "ㄹ";
+                    nextFirstConsonant = "ㅅ";
+                } 
+                else if (firstLastConsonant.Equals("ㄾ")) {
+                    firstLastConsonant = "ㄹ";
+                    nextFirstConsonant = "ㅌ";
+                } 
+                else if (firstLastConsonant.Equals("ㄿ")) {
+                    firstLastConsonant = "ㄹ";
+                    nextFirstConsonant = "ㅍ";
+                } 
+                else if (firstLastConsonant.Equals("ㅀ")) {
+                    firstLastConsonant = "ㄹ";
+                    nextFirstConsonant = "ㅎ";
+                } 
+                else if (firstLastConsonant.Equals("ㅄ")) {
+                    firstLastConsonant = "ㅂ";
+                    nextFirstConsonant = "ㅅ";
+                } 
+                else if (firstLastConsonant.Equals("ㄻ")) {
+                    firstLastConsonant = "ㄹ";
+                    nextFirstConsonant = "ㅁ";
+                } 
+                else if (firstLastConsonant.Equals("ㅇ") && nextFirstConsonant.Equals("ㅇ")) {
+                    // Do nothing
+                } 
+                else {
+                    // 겹받침 아닐 때 연음
+                    nextFirstConsonant = firstLastConsonant;
+                    firstLastConsonant = " ";
+                }
+            }
+
+
+            // 1. 유기음화 및 ㅎ탈락 1
+            if (firstLastConsonant.Equals("ㅎ") && (! nextFirstConsonant.Equals("ㅅ")) && basicSounds.Contains(nextFirstConsonant)) {
+                // ㅎ으로 끝나고 다음 소리가 ㄱㄷㅂㅈ이면 / ex) 낳다 = 나타
+                firstLastConsonant = " ";
+                nextFirstConsonant = (string)aspirateSounds[basicSounds[nextFirstConsonant]];
+            } 
+            else if (firstLastConsonant.Equals("ㅎ") && (!nextFirstConsonant.Equals("ㅅ")) && nextFirstConsonant.Equals("ㅇ")) {
+                // ㅎ으로 끝나고 다음 소리가 없으면 / ex) 낳아 = 나아
+                firstLastConsonant = " ";
+            } 
+            else if (firstLastConsonant.Equals("ㄶ") && (! nextFirstConsonant.Equals("ㅅ")) && basicSounds.Contains(nextFirstConsonant)) {
+                // ㄶ으로 끝나고 다음 소리가 ㄱㄷㅂㅈ이면 / ex) 많다 = 만타
+                firstLastConsonant = "ㄴ";
+                nextFirstConsonant = (string)aspirateSounds[basicSounds[nextFirstConsonant]];
+            } 
+            else if (firstLastConsonant.Equals("ㅀ") && (! nextFirstConsonant.Equals("ㅅ")) && basicSounds.Contains(nextFirstConsonant)) {
+                // ㅀ으로 끝나고 다음 소리가 ㄱㄷㅂㅈ이면 / ex) 끓다 = 끌타
+                firstLastConsonant = "ㄹ";
+                nextFirstConsonant = (string)aspirateSounds[basicSounds[nextFirstConsonant]];
+            }
+
+
+
+
+            // 2-1. 된소리되기 1
+            if ((firstLastConsonant.Equals("ㄳ") || firstLastConsonant.Equals("ㄵ") || firstLastConsonant.Equals("ㄽ") || firstLastConsonant.Equals("ㄾ") || firstLastConsonant.Equals("ㅄ") || firstLastConsonant.Equals("ㄼ") || firstLastConsonant.Equals("ㄺ") || firstLastConsonant.Equals("ㄿ")) && basicSounds.Contains(nextFirstConsonant)) {
+                // [ㄻ, (ㄶ, ㅀ)<= 유기음화에 따라 예외] 제외한 겹받침으로 끝나고 다음 소리가 예사소리이면
+                nextFirstConsonant = (string)fortisSounds[basicSounds[nextFirstConsonant]];
+            }
+
+            // 3. 첫 번째 글자의 자음군단순화 및 평파열음화(음절의 끝소리 규칙)
+            if (firstLastConsonant.Equals("ㄽ") || firstLastConsonant.Equals("ㄾ") || firstLastConsonant.Equals("ㄼ")) {
+                firstLastConsonant = "ㄹ";
+            } else if (firstLastConsonant.Equals("ㄵ") || firstLastConsonant.Equals("ㅅ") || firstLastConsonant.Equals("ㅆ") || firstLastConsonant.Equals("ㅈ") || firstLastConsonant.Equals("ㅉ") || firstLastConsonant.Equals("ㅊ") || firstLastConsonant.Equals("ㅌ")) {
+                firstLastConsonant = "ㄷ";
+            } else if (firstLastConsonant.Equals("ㅃ") || firstLastConsonant.Equals("ㅍ") || firstLastConsonant.Equals("ㄿ") || firstLastConsonant.Equals("ㅄ")) {
+                firstLastConsonant = "ㅂ";
+            } else if (firstLastConsonant.Equals("ㄲ") || firstLastConsonant.Equals("ㅋ") || firstLastConsonant.Equals("ㄺ") || firstLastConsonant.Equals("ㄳ")) {
+                firstLastConsonant = "ㄱ";
+            } else if (firstLastConsonant.Equals("ㄻ")) {
+                firstLastConsonant = "ㅁ";
+            }
+
+
+
+            // 2-1. 된소리되기 2
+            if (basicSounds.Contains(firstLastConsonant) && basicSounds.Contains(nextFirstConsonant)) {
+                // 예사소리로 끝나고 다음 소리가 예사소리이면 / ex) 닭장 = 닥짱
+                nextFirstConsonant = (string)fortisSounds[basicSounds[nextFirstConsonant]];
+            }
+            // else if ((firstLastConsonant.Equals("ㄹ")) && (basicSounds.Contains(nextFirstConsonant))){
+            //     // ㄹ로 끝나고 다음 소리가 예사소리이면 / ex) 솔직 = 솔찍
+            //     // 본래 관형형 어미 (으)ㄹ과 일부 한자어에서만 일어나는 변동이나, 워낙 사용되는 빈도가 많아서 기본으로 적용되게 해 두
+            //     // 려 했으나 좀 아닌 것 같아서 보류하기로 함
+            //     nextFirstConsonant = (string)fortisSounds[basicSounds[nextFirstConsonant]];
+            // }
+
+            // 1. 유기음화 2
+            if (basicSounds.Contains(firstLastConsonant) && nextFirstConsonant.Equals("ㅎ")) {
+                // ㄱㄷㅂㅈ(+ㅅ)로 끝나고 다음 소리가 ㅎ이면 / ex) 축하 = 추카, 옷하고 = 오타고
+                // ㅅ은 미리 평파열음화가 진행된 것으로 보고 ㄷ으로 간주한다
+                nextFirstConsonant = (string)aspirateSounds[basicSounds[firstLastConsonant]];
+                firstLastConsonant = " ";
+            } 
+            else if (nextFirstConsonant.Equals("ㅎ")) {
+                nextFirstConsonant = "ㅇ";
+            }
+
+            if ((!firstLastConsonant.Equals("")) && nextFirstConsonant.Equals("ㅇ") && (!firstLastConsonant.Equals("ㅇ"))) {
+                // 연음 2
+                nextFirstConsonant = firstLastConsonant;
+                firstLastConsonant = " ";
+            }
+
+
+            // 4. 비음화
+            if (firstLastConsonant.Equals("ㄱ") && (!nextFirstConsonant.Equals("ㅇ")) && (nasalSounds.Contains(nextFirstConsonant) || nextFirstConsonant.Equals("ㄹ"))) {
+                // ex) 막론 = 망론 >> 망논 
+                firstLastConsonant = "ㅇ";
+            } else if (firstLastConsonant.Equals("ㄷ") && (!nextFirstConsonant.Equals("ㅇ")) && (nasalSounds.Contains(nextFirstConsonant) || nextFirstConsonant.Equals("ㄹ"))) {
+                // ex) 슬롯머신 = 슬론머신
+                firstLastConsonant = "ㄴ";
+            } else if (firstLastConsonant.Equals("ㅂ") && (!nextFirstConsonant.Equals("ㅇ")) && (nasalSounds.Contains(nextFirstConsonant) || nextFirstConsonant.Equals("ㄹ"))) {
+                // ex) 밥먹자 = 밤먹자 >> 밤먹짜
+                firstLastConsonant = "ㅁ";
+            }
+
+            // 4'. 유음화
+            if (firstLastConsonant.Equals("ㄴ") && nextFirstConsonant.Equals("ㄹ")) {
+                // ex) 만리 = 말리
+                firstLastConsonant = "ㄹ";
+            } else if (firstLastConsonant.Equals("ㄹ") && nextFirstConsonant.Equals("ㄴ")) {
+                // ex) 칼날 = 칼랄
+                nextFirstConsonant = "ㄹ";
+            }
+
+            // 4''. ㄹ비음화
+            if (nextFirstConsonant.Equals("ㄹ") && nasalSounds.Contains(nextFirstConsonant)) {
+                // ex) 담력 = 담녁
+                firstLastConsonant = "ㄴ";
+            }
+
+
+            // 4'''. 자음동화
+            if (firstLastConsonant.Equals("ㄴ") && nextFirstConsonant.Equals("ㄱ")) {
+                // ex) ~라는 감정 = ~라능 감정
+                firstLastConsonant = "ㅇ";
+            }
+
+            // return results
+            if (returnCharIndex == 0) {
+                // return result of first target character
+                return new Hashtable() {
+                    [0] = firstCharSeparated[0],
+                    [1] = firstCharSeparated[1],
+                    [2] = firstLastConsonant
+                };
+            } else if (returnCharIndex == 1) {
+                // return result of second target character
+                return new Hashtable() {
+                    [0] = nextFirstConsonant,
+                    [1] = nextCharSeparated[1],
+                    [2] = nextCharSeparated[2]
+                };
+            } else {
+                // 두 글자 다 반환
+                return new Hashtable() {
+                    [0] = firstCharSeparated[0],
+                    [1] = firstCharSeparated[1],
+                    [2] = firstLastConsonant,
+                    [3] = nextFirstConsonant,
+                    [4] = nextCharSeparated[1],
+                    [5] = nextCharSeparated[2]
+                };
+            }
+        }
+
+        /// <summary>
+        /// Conducts phoneme variation with one character input. <br/>※ This method is only for when there are single character, so when there are more than one character, Please use Variate(Hashtable firstCharSeparated, Hashtable nextCharSeparated, int returnCharIndex=-1).  
+        /// <br/><br/>단일 글자를 입력받아 음운변동을 진행합니다. <br/>※ 단일 글자가 아닌 두 글자 이상에서 음운변동을 적용할 경우, 이 메소드가 아닌 Variate(Hashtable firstCharSeparated, Hashtable nextCharSeparated, int returnCharIndex=-1) 메소드를 사용해야 합니다.
+        /// </summary>
+        /// <param name="character"> String of single target.
+        /// <br/> 음운변동시킬 단일 글자.
+        /// </param>
+        /// <returns>(Example(삵): {[0]="ㅅ", [1]="ㅏ", [2]="ㄱ"} - 삭)
+        /// </returns>
+        public static Hashtable Variate(string character) {
+            /// 맨 끝 노트에서 음운변동 적용하는 함수
+            /// 자음군 단순화와 평파열음화
+            Hashtable separated = Separate(character);
+
+            if (separated[2].Equals("ㄽ") || separated[2].Equals("ㄾ") || separated[2].Equals("ㄼ") || separated[2].Equals("ㅀ")) {
+                separated[2] = "ㄹ";
+            } 
+            else if (separated[2].Equals("ㄵ") || separated[2].Equals("ㅅ") || separated[2].Equals("ㅆ") || separated[2].Equals("ㅈ") || separated[2].Equals("ㅉ") || separated[2].Equals("ㅊ")) {
+                separated[2] = "ㄷ";
+            } 
+            else if (separated[2].Equals("ㅃ") || separated[2].Equals("ㅍ") || separated[2].Equals("ㄿ") || separated[2].Equals("ㅄ")) {
+                separated[2] = "ㅂ";
+            } 
+            else if (separated[2].Equals("ㄲ") || separated[2].Equals("ㅋ") || separated[2].Equals("ㄺ") || separated[2].Equals("ㄳ")) {
+                separated[2] = "ㄱ";
+            } 
+            else if (separated[2].Equals("ㄻ")) {
+                separated[2] = "ㅁ";
+            } 
+            else if (separated[2].Equals("ㄶ")) {
+                separated[2] = "ㄴ";
+            }
+
+
+            return separated;
+
+        }
+        /// <summary>
+        /// Conducts phoneme variation with one character input. <br/>※ This method is only for when there are single character, so when there are more than one character, Please use Variate(Hashtable firstCharSeparated, Hashtable nextCharSeparated, int returnCharIndex=-1).  
+        /// <br/><br/>단일 글자의 분리된 값을 입력받아 음운변동을 진행합니다. <br/>※ 단일 글자가 아닌 두 글자 이상에서 음운변동을 적용할 경우, 이 메소드가 아닌 Variate(Hashtable firstCharSeparated, Hashtable nextCharSeparated, int returnCharIndex=-1) 메소드를 사용해야 합니다.
+        /// </summary>
+        /// <param name="separated"> Separated table of target.
+        /// <br/> 글자를 분리한 해시테이블 
+        /// </param>
+        /// <returns>(Example({[0]="ㅅ", [1]="ㅏ", [2]="ㄺ"}): {[0]="ㅅ", [1]="ㅏ", [2]="ㄱ"} - 삭)
+        /// </returns>
+        private static Hashtable Variate(Hashtable separated) {
+            /// 맨 끝 노트에서 음운변동 적용하는 함수
+
+            if (separated[2].Equals("ㄽ") || separated[2].Equals("ㄾ") || separated[2].Equals("ㄼ") || separated[2].Equals("ㅀ")) {
+                separated[2] = "ㄹ";
+            } 
+            else if (separated[2].Equals("ㄵ") || separated[2].Equals("ㅅ") || separated[2].Equals("ㅆ") || separated[2].Equals("ㅈ") || separated[2].Equals("ㅉ") || separated[2].Equals("ㅊ")) {
+                separated[2] = "ㄷ";
+            } 
+            else if (separated[2].Equals("ㅃ") || separated[2].Equals("ㅍ") || separated[2].Equals("ㄿ") || separated[2].Equals("ㅄ")) {
+                separated[2] = "ㅂ";
+            } 
+            else if (separated[2].Equals("ㄲ") || separated[2].Equals("ㅋ") || separated[2].Equals("ㄺ") || separated[2].Equals("ㄳ")) {
+                separated[2] = "ㄱ";
+            } 
+            else if (separated[2].Equals("ㄻ")) {
+                separated[2] = "ㅁ";
+            } 
+            else if (separated[2].Equals("ㄶ")) {
+                separated[2] = "ㄴ";
+            }
+
+            return separated;
+        }
+
+        /// <summary>
+        /// Conducts phoneme variation with two characters input. <br/>※ This method is for only when there are more than one characters, so when there is single character only, Please use Variate(string character).  
+        /// <br/><br/>두 글자를 입력받아 음운변동을 진행합니다. <br/>※ 두 글자 이상이 아닌 단일 글자에서 음운변동을 적용할 경우, 이 메소드가 아닌 Variate(string character) 메소드를 사용해야 합니다.
+        /// </summary>
+        /// <param name="firstChar"> String of first target.
+        /// <br/> 첫 번째 글자.
+        /// <br/><br/>(Example: 문)
+        /// </param>
+        /// <param name="nextChar"> String of second target.
+        /// <br/>두 번째 글자.
+        /// <br/><br/>(Example: 래)
+        /// </param>
+        /// <param name="returnCharIndex"> 0: returns result of first target character only. 
+        /// <br/>1: returns result of second target character only. <br/>else: returns result of both target characters. <br/>
+        /// <br/>0: 첫 번째 타겟 글자의 음운변동 결과만 반환합니다.
+        /// <br/>1: 두 번째 타겟 글자의 음운변동 결과만 반환합니다. <br/>나머지 값: 두 타겟 글자의 음운변동 결과를 모두 반환합니다. <br/>
+        /// <br/>(Example(0): {[0]="ㅁ", [1]="ㅜ", [2]="ㄹ"} - 물)
+        /// <br/>(Example(1): {[0]="ㄹ", [1]="ㅐ", [2]=" "} - 래)
+        /// <br/>(Example(-1): {[0]="ㅁ", [1]="ㅜ", [2]="ㄹ", [3]="ㄹ", [4]="ㅐ", [5]=" "} - 물래)
+        /// </param>
+        /// <returns> Example: when returnCharIndex = 0: {[0]="ㅁ", [1]="ㅜ", [2]="ㄹ"} - 물)
+        /// <br/> Example: when returnCharIndex = 1: {[0]="ㄹ", [1]="ㅐ", [2]=" "} - 래)
+        /// <br/> Example: when returnCharIndex = -1: {[0]="ㅁ", [1]="ㅜ", [2]="ㄹ", [3]="ㄹ", [4]="ㅐ", [5]=" "} - 물래)
+        /// </returns>
+        private static Hashtable Variate(string firstChar, string nextChar, int returnCharIndex = 0) {
+            // 글자 넣어도 쓸 수 있음
+            
+            Hashtable firstCharSeparated = Separate(firstChar);
+            Hashtable nextCharSeparated = Separate(nextChar);
+            return Variate(firstCharSeparated, nextCharSeparated, returnCharIndex);
+        }
+
+        /// <summary>
+        /// Conducts phoneme variation automatically with prevNeighbour, note, nextNeighbour.  
+        /// <br/><br/> prevNeighbour, note, nextNeighbour를 입력받아 자동으로 음운 변동을 진행합니다.
+        /// </summary>
+        /// <param name="prevNeighbour"> Note of prev note, if exists(otherwise null).
+        /// <br/> 이전 노트 혹은 null.
+        /// <br/><br/>(Example: Note with lyric '춘')
+        /// </param>
+        /// <param name="note"> Note of current note. 
+        /// <br/> 현재 노트.
+        /// <br/><br/>(Example: Note with lyric '향')
+        /// </param>
+        /// <param name="nextNeighbour"> Note of next note, if exists(otherwise null).
+        /// <br/> 다음 노트 혹은 null.
+        /// <br/><br/>(Example: null)
+        /// </param>
+        /// <returns> Returns phoneme variation result of prevNote, currentNote, nextNote.
+        /// <br/>이전 노트, 현재 노트, 다음 노트의 음운변동 결과를 반환합니다.
+        /// <br/>Example: 춘 [향] null: {[0]="ㅊ", [1]="ㅜ", [2]=" ", [3]="ㄴ", [4]="ㅑ", [5]="ㅇ", [6]="null", [7]="null", [8]="null"} [추 냥 null]
+        /// </returns>
+        public static Hashtable Variate(Note? prevNeighbour, Note note, Note? nextNeighbour) {
+            // prevNeighbour와 note와 nextNeighbour의 음원변동된 가사를 반환
+            // prevNeighbour : VV 정렬에 사용
+            // nextNeighbour : VC 정렬에 사용
+            // 뒤의 노트가 없으면 리턴되는 값의 6~8번 인덱스가 null로 채워진다.
+
+            /// whereYeonEum : 발음기호 .을 사용하기 위한 변수
+            /// .을 사용하면 앞에서 단어가 끝났다고 간주하고, 끝소리에 음운변동을 적용한 후 연음합니다. 
+            /// ex) 무 릎 위 [무르퓌] 무 릎. 위[무르뷔]
+            /// 
+            /// -1 : 해당사항 없음
+            /// 0 : 이전 노트를 연음하지 않음
+            /// 1 : 현재 노트를 연음하지 않음
+            int whereYeonEum = -1;
+
+            string?[] lyrics = new string?[] { prevNeighbour?.lyric, note.lyric, nextNeighbour?.lyric };
+
+            if (!IsHangeul(lyrics[0])) {
+                // 앞노트 한국어 아니거나 null일 경우 null처리
+                if (lyrics[0] != null) {lyrics[0] = null;}
+            } else if (!IsHangeul(lyrics[2])) {
+                // 뒤노트 한국어 아니거나 null일 경우 null처리
+                if (lyrics[2] != null) {lyrics[2] = null;}
+            }
+            if ((lyrics[0] != null) && lyrics[0].StartsWith('!')) {
+                /// 앞노트 ! 기호로 시작함 ex) [!냥]냥냥
+                if (lyrics[0] != null) {lyrics[0] = null;} // 0번가사 없는 걸로 간주함 null냥냥
+            }
+            if ((lyrics[1] != null) && lyrics[1].StartsWith('!')) {
+                /// 중간노트 ! 기호로 시작함 ex) 냥[!냥]냥
+                /// 음운변동 미적용
+                lyrics[1] = lyrics[1].TrimStart('!');
+                if (lyrics[0] != null) {lyrics[0] = null;} // 0번가사 없는 걸로 간주함 null[!냥]냥
+                if (lyrics[2] != null) {lyrics[2] = null;} // 2번가사도 없는 걸로 간주함 null[!냥]null
+            }
+            if ((lyrics[2] != null) && lyrics[2].StartsWith('!')) {
+                /// 뒤노트 ! 기호로 시작함 ex) 냥냥[!냥]
+                if (lyrics[2] != null) {lyrics[2] = null;} // 2번가사 없는 걸로 간주함 냥냥b
+            }
+
+            if ((lyrics[0] != null) && lyrics[0].EndsWith('.')) {
+                /// 앞노트 . 기호로 끝남 ex) [냥.]냥냥
+                lyrics[0] = lyrics[0].TrimEnd('.');
+                whereYeonEum = 0;
+            }
+            if ((lyrics[1] != null) && lyrics[1].EndsWith('.')) {
+                /// 중간노트 . 기호로 끝남 ex) 냥[냥.]냥
+                /// 음운변동 없이 연음만 적용
+                lyrics[1] = lyrics[1].TrimEnd('.');
+                whereYeonEum = 1;
+            }
+            if ((lyrics[2] != null) && lyrics[2].EndsWith('.')) {
+                /// 뒤노트 . 기호로 끝남 ex) 냥냥[냥.]
+                /// 중간노트의 발음에 관여하지 않으므로 간단히 . 만 지워주면 된다
+                lyrics[2] = lyrics[2].TrimEnd('.');
+            }
+
+            // 음운변동 적용 --
+            if ((lyrics[0] == null) && (lyrics[2] != null)) {
+                /// 앞이 없고 뒤가 있음
+                /// null[냥]냥
+                if (whereYeonEum == 1) {
+                    // 현재 노트에서 단어가 끝났다고 가정
+                    Hashtable result = new Hashtable() {
+                        [0] = "null", // 앞 글자 없음
+                        [1] = "null",
+                        [2] = "null"
+                    };
+                    Hashtable thisNoteSeparated = Variate(Variate(lyrics[1]), Separate(lyrics[2]), -1); // 현 글자 / 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return result;
+                } 
+                else {
+                    Hashtable result = new Hashtable() {
+                        [0] = "null", // 앞 글자 없음
+                        [1] = "null",
+                        [2] = "null"
+                    };
+
+                    if (IsHangeul(lyrics[2])) {
+                        Hashtable thisNoteSeparated = Variate(lyrics[1], lyrics[2], -1); // 현글자 뒤글자
+                    
+                        result.Add(3, thisNoteSeparated[0]); // 현 글자
+                        result.Add(4, thisNoteSeparated[1]);
+                        result.Add(5, thisNoteSeparated[2]);
+
+                        result.Add(6, thisNoteSeparated[3]); 
+                        result.Add(7, thisNoteSeparated[4]);
+                        result.Add(8, thisNoteSeparated[5]);
+                    }
+                    else {
+                        Hashtable thisNoteSeparated = Variate(lyrics[1]);
+                        result.Add(3, thisNoteSeparated[0]); // 현 글자
+                        result.Add(4, thisNoteSeparated[1]);
+                        result.Add(5, thisNoteSeparated[2]);
+
+                        result.Add(6, "null"); 
+                        result.Add(7, "null");
+                        result.Add(8, "null");
+                    }
+                    
+
+                    return result;
+                }
+            } 
+            else if ((lyrics[0] != null) && (lyrics[2] == null)) {
+                /// 앞이 있고 뒤는 없음
+                /// 냥[냥]null
+                if (whereYeonEum == 1) {
+                    // 현재 노트에서 단어가 끝났다고 가정
+                    Hashtable result = Variate(Separate(lyrics[0]), Variate(lyrics[1]), 0); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(Separate(lyrics[0]), Variate(lyrics[1]), 1)); // 현 글자 / 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, "null"); // 뒤 글자 없음
+                    result.Add(7, "null");
+                    result.Add(8, "null");
+
+                    return result;
+                } 
+                else if (whereYeonEum == 0) {
+                    // 앞 노트에서 단어가 끝났다고 가정 
+                    Hashtable result = Variate(Variate(lyrics[0]), Separate(lyrics[1]), 0); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(Variate(lyrics[0]), Separate(lyrics[1]), 1)); // 첫 글자와 현 글자 / 앞글자를 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, "null"); // 뒤 글자 없음
+                    result.Add(7, "null");
+                    result.Add(8, "null");
+
+                    return result;
+                } 
+                else {
+                    Hashtable result = Variate(lyrics[0], lyrics[1], 0); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(lyrics[0], lyrics[1], 1)); // 첫 글자와 현 글자 / 뒷글자 없으니까 글자 혼자 있는걸로 음운변동 한 번 더 시키기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, "null"); // 뒤 글자 없음
+                    result.Add(7, "null");
+                    result.Add(8, "null");
+
+                    return result;
+                }
+            } 
+            else if ((lyrics[0] != null) && (lyrics[2] != null)) {
+                /// 앞도 있고 뒤도 있음
+                /// 냥[냥]냥
+                if (whereYeonEum == 1) {
+                    // 현재 노트에서 단어가 끝났다고 가정 / 무 [릎.] 위
+                    Hashtable result = Variate(Separate(lyrics[0]), Variate(lyrics[1]), 1); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(Separate(lyrics[0]), Variate(lyrics[1]), 1), Separate(lyrics[2]), -1);// 현글자와 다음 글자 / 현 글자를 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return result;
+                } 
+                else if (whereYeonEum == 0) {
+                    // 앞 노트에서 단어가 끝났다고 가정 / 릎. [위] 놓
+                    Hashtable result = Variate(Variate(lyrics[0]), Separate(lyrics[1]), 0); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(Variate(lyrics[0]), Separate(lyrics[1]), 1), Separate(lyrics[2]), -1); // 현 글자와 뒤 글자 / 앞글자 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return result;
+                } 
+                else {
+                    Hashtable result = Variate(lyrics[0], lyrics[1], 0);
+                    Hashtable thisNoteSeparated = Variate(Variate(lyrics[0], lyrics[1], 1), Separate(lyrics[2]), -1);
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return result;
+                }
+            } 
+            else {
+                /// 앞이 없고 뒤도 없음
+                /// null[냥]null
+
+                Hashtable result = new Hashtable() {
+                    // 첫 글자 >> 비어 있음
+                    [0] = "null",
+                    [1] = "null",
+                    [2] = "null"
+                };
+
+                Hashtable thisNoteSeparated = Variate(lyrics[1]); // 현 글자
+
+                result.Add(3, thisNoteSeparated[0]); // 현 글자
+                result.Add(4, thisNoteSeparated[1]);
+                result.Add(5, thisNoteSeparated[2]);
+
+
+                result.Add(6, "null"); // 뒤 글자 비어있음
+                result.Add(7, "null");
+                result.Add(8, "null");
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// (for diffsinger phonemizer)
+        /// Conducts phoneme variation automatically with prevNeighbour, note, nextNeighbour.  
+        /// <br/><br/> prevNeighbour, note, nextNeighbour를 입력받아 자동으로 음운 변동을 진행합니다.
+        /// </summary>
+        /// <param name="prevNeighbour"> lyric String of prev note, if exists(otherwise null).
+        /// <br/> 이전 가사 혹은 null.
+        /// <br/><br/>(Example: lyric String with lyric '춘')
+        /// </param>
+        /// <param name="note"> lyric String of current note. 
+        /// <br/> 현재 가사.
+        /// <br/><br/>(Example: Note with lyric '향')
+        /// </param>
+        /// <param name="nextNeighbour"> lyric String of next note, if exists(otherwise null).
+        /// <br/> 다음 가사 혹은 null.
+        /// <br/><br/>(Example: null)
+        /// </param>
+        /// <returns> Returns phoneme variation result of prevNote, currentNote, nextNote.
+        /// <br/>이전 노트, 현재 노트, 다음 노트의 음운변동 결과를 반환합니다.
+        /// <br/>Example: 춘 [향] null: {[0]="ㅊ", [1]="ㅜ", [2]=" ", [3]="ㄴ", [4]="ㅑ", [5]="ㅇ", [6]="null", [7]="null", [8]="null"} [추 냥 null]
+        /// </returns>
+        public static String Variate(String? prevNeighbour, String note, String? nextNeighbour) {
+            // prevNeighbour와 note와 nextNeighbour의 음원변동된 가사를 반환
+            // prevNeighbour : VV 정렬에 사용
+            // nextNeighbour : VC 정렬에 사용
+            // 뒤의 노트가 없으면 리턴되는 값의 6~8번 인덱스가 null로 채워진다.
+
+            /// whereYeonEum : 발음기호 .을 사용하기 위한 변수
+            /// .을 사용하면 앞에서 단어가 끝났다고 간주하고, 끝소리에 음운변동을 적용한 후 연음합니다. 
+            /// ex) 무 릎 위 [무르퓌] 무 릎. 위[무르뷔]
+            /// 
+            /// -1 : 해당사항 없음
+            /// 0 : 이전 노트를 연음하지 않음
+            /// 1 : 현재 노트를 연음하지 않음
+            int whereYeonEum = -1;
+
+            string?[] lyrics = new string?[] { prevNeighbour, note, nextNeighbour};
+
+            if (!IsHangeul(lyrics[0])) {
+                // 앞노트 한국어 아니거나 null일 경우 null처리
+                if (lyrics[0] != null) {lyrics[0] = null;}
+            } else if (!IsHangeul(lyrics[2])) {
+                // 뒤노트 한국어 아니거나 null일 경우 null처리
+                if (lyrics[2] != null) {lyrics[2] = null;}
+            }
+            if ((lyrics[0] != null) && lyrics[0].StartsWith('!')) {
+                /// 앞노트 ! 기호로 시작함 ex) [!냥]냥냥
+                if (lyrics[0] != null) {lyrics[0] = null;} // 0번가사 없는 걸로 간주함 null냥냥
+            }
+            if ((lyrics[1] != null) && lyrics[1].StartsWith('!')) {
+                /// 중간노트 ! 기호로 시작함 ex) 냥[!냥]냥
+                /// 음운변동 미적용
+                lyrics[1] = lyrics[1].TrimStart('!');
+                if (lyrics[0] != null) {lyrics[0] = null;} // 0번가사 없는 걸로 간주함 null[!냥]냥
+                if (lyrics[2] != null) {lyrics[2] = null;} // 2번가사도 없는 걸로 간주함 null[!냥]null
+            }
+            if ((lyrics[2] != null) && lyrics[2].StartsWith('!')) {
+                /// 뒤노트 ! 기호로 시작함 ex) 냥냥[!냥]
+                if (lyrics[2] != null) {lyrics[2] = null;} // 2번가사 없는 걸로 간주함 냥냥b
+            }
+
+            if ((lyrics[0] != null) && lyrics[0].EndsWith('.')) {
+                /// 앞노트 . 기호로 끝남 ex) [냥.]냥냥
+                lyrics[0] = lyrics[0].TrimEnd('.');
+                whereYeonEum = 0;
+            }
+            if ((lyrics[1] != null) && lyrics[1].EndsWith('.')) {
+                /// 중간노트 . 기호로 끝남 ex) 냥[냥.]냥
+                /// 음운변동 없이 연음만 적용
+                lyrics[1] = lyrics[1].TrimEnd('.');
+                whereYeonEum = 1;
+            }
+            if ((lyrics[2] != null) && lyrics[2].EndsWith('.')) {
+                /// 뒤노트 . 기호로 끝남 ex) 냥냥[냥.]
+                /// 중간노트의 발음에 관여하지 않으므로 간단히 . 만 지워주면 된다
+                lyrics[2] = lyrics[2].TrimEnd('.');
+            }
+
+            // 음운변동 적용 --
+            if ((lyrics[0] == null) && (lyrics[2] != null)) {
+                /// 앞이 없고 뒤가 있음
+                /// null[냥]냥
+                if (whereYeonEum == 1) {
+                    // 현재 노트에서 단어가 끝났다고 가정
+                    Hashtable result = new Hashtable() {
+                        [0] = "null", // 앞 글자 없음
+                        [1] = "null",
+                        [2] = "null"
+                    };
+                    Hashtable thisNoteSeparated = Variate(Variate(lyrics[1]), Separate(lyrics[2]), -1); // 현 글자 / 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]});
+                } 
+                else {
+                    Hashtable result = new Hashtable() {
+                        [0] = "null", // 앞 글자 없음
+                        [1] = "null",
+                        [2] = "null"
+                    };
+
+                    Hashtable thisNoteSeparated = Variate(lyrics[1], lyrics[2], -1); // 현글자 뒤글자
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자 없음
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]});
+                }
+            } 
+            else if ((lyrics[0] != null) && (lyrics[2] == null)) {
+                /// 앞이 있고 뒤는 없음
+                /// 냥[냥]null
+                if (whereYeonEum == 1) {
+                    // 현재 노트에서 단어가 끝났다고 가정
+                    Hashtable result = Variate(Separate(lyrics[0]), Variate(lyrics[1]), 0); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(Separate(lyrics[0]), Variate(lyrics[1]), 1)); // 현 글자 / 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, "null"); // 뒤 글자 없음
+                    result.Add(7, "null");
+                    result.Add(8, "null");
+
+                    return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]});
+                } 
+                else if (whereYeonEum == 0) {
+                    // 앞 노트에서 단어가 끝났다고 가정 
+                    Hashtable result = Variate(Variate(lyrics[0]), Separate(lyrics[1]), 0); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(Variate(lyrics[0]), Separate(lyrics[1]), 1)); // 첫 글자와 현 글자 / 앞글자를 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, "null"); // 뒤 글자 없음
+                    result.Add(7, "null");
+                    result.Add(8, "null");
+
+                    return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]});
+                } 
+                else {
+                    Hashtable result = Variate(lyrics[0], lyrics[1], 0); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(lyrics[0], lyrics[1], 1)); // 첫 글자와 현 글자 / 뒷글자 없으니까 글자 혼자 있는걸로 음운변동 한 번 더 시키기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, "null"); // 뒤 글자 없음
+                    result.Add(7, "null");
+                    result.Add(8, "null");
+
+                    return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]});
+                }
+            } 
+            else if ((lyrics[0] != null) && (lyrics[2] != null)) {
+                /// 앞도 있고 뒤도 있음
+                /// 냥[냥]냥
+                if (whereYeonEum == 1) {
+                    // 현재 노트에서 단어가 끝났다고 가정 / 무 [릎.] 위
+                    Hashtable result = Variate(Separate(lyrics[0]), Variate(lyrics[1]), 1); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(Separate(lyrics[0]), Variate(lyrics[1]), 1), Separate(lyrics[2]), -1);// 현글자와 다음 글자 / 현 글자를 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]});
+                } 
+                else if (whereYeonEum == 0) {
+                    // 앞 노트에서 단어가 끝났다고 가정 / 릎. [위] 놓
+                    Hashtable result = Variate(Variate(lyrics[0]), Separate(lyrics[1]), 0); // 첫 글자
+                    Hashtable thisNoteSeparated = Variate(Variate(Variate(lyrics[0]), Separate(lyrics[1]), 1), Separate(lyrics[2]), -1); // 현 글자와 뒤 글자 / 앞글자 끝글자처럼 음운변동시켜서 음원변동 한 번 더 하기
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]});
+                } 
+                else {
+                    Hashtable result = Variate(lyrics[0], lyrics[1], 0);
+                    Hashtable thisNoteSeparated = Variate(Variate(lyrics[0], lyrics[1], 1), Separate(lyrics[2]), -1);
+
+                    result.Add(3, thisNoteSeparated[0]); // 현 글자
+                    result.Add(4, thisNoteSeparated[1]);
+                    result.Add(5, thisNoteSeparated[2]);
+
+                    result.Add(6, thisNoteSeparated[3]); // 뒤 글자
+                    result.Add(7, thisNoteSeparated[4]);
+                    result.Add(8, thisNoteSeparated[5]);
+
+                    return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]});
+                }
+            } 
+            else {
+                /// 앞이 없고 뒤도 없음
+                /// null[냥]null
+                Hashtable result = new Hashtable() {
+                    // 첫 글자 >> 비어 있음
+                    [0] = "null",
+                    [1] = "null",
+                    [2] = "null"
+                };
+
+                Hashtable thisNoteSeparated = Variate(lyrics[1]); // 현 글자
+
+                result.Add(3, thisNoteSeparated[0]); // 현 글자
+                result.Add(4, thisNoteSeparated[1]);
+                result.Add(5, thisNoteSeparated[2]);
+
+
+                result.Add(6, "null"); // 뒤 글자 비어있음
+                result.Add(7, "null");
+                result.Add(8, "null");
+
+                return Merge(new Hashtable{
+                    [0] = (string)result[3],
+                    [1] = (string)result[4],
+                    [2] = (string)result[5]
+                });
+            }
+        }
+        
+        public static Note[] ChangeLyric(Note[] group, string lyric) {
+            // for ENUNU Phonemizer
+            var oldNote = group[0];
+            group[0] = new Note {
+                lyric = lyric,
+                phoneticHint = oldNote.phoneticHint,
+                tone = oldNote.tone,
+                position = oldNote.position,
+                duration = oldNote.duration,
+                phonemeAttributes = oldNote.phonemeAttributes,
+            };
+            return group;
+        }
+        public static void RomanizeNotes(Note[][] groups, Dictionary<string, string[]> firstConsonants, Dictionary<string, string[]> vowels, Dictionary<string, string[]> lastConsonants, string semivowelSeparator=" ") {
+            // for ENUNU Phonemizer
+            
+            int noteIdx = 0;
+            Note[] currentNote;
+            Note[]? prevNote = null;
+            Note[]? nextNote;
+            
+            Note? prevNote_;
+            Note? nextNote_;
+
+
+            List<string> ResultLyrics = new List<string>();
+            foreach (Note[] group in groups){    
+                currentNote = groups[noteIdx];
+                if (groups.Length > noteIdx + 1 && IsHangeul(groups[noteIdx + 1][0].lyric)) {
+                    nextNote = groups[noteIdx + 1];
+                }
+                else {
+                    nextNote = null;
+                }
+
+                if (prevNote != null) {
+                    prevNote_ = prevNote[0];
+                    if (prevNote[0].position + prevNote.Sum(note => note.duration) != currentNote[0].position) {
+                        prevNote_ = null;
+                    }
+                }
+                else {prevNote_ = null;}
+
+                if (nextNote != null) {
+                    nextNote_ = nextNote[0];
+                
+                    if (nextNote[0].position != currentNote[0].position + currentNote.Sum(note => note.duration)) {
+                        nextNote_ = null;
+                    }
+                }
+                else{nextNote_ = null;}
+            
+                string lyric = "";
+
+                if (! IsHangeul(currentNote[0].lyric)){
+                    ResultLyrics.Add(currentNote[0].lyric);
+                    prevNote = currentNote;            
+                    noteIdx++;
+                    continue;
+                }
+
+                Hashtable lyricSeparated = Variate(prevNote_, currentNote[0], nextNote_);
+                lyric += firstConsonants[(string)lyricSeparated[3]][0];
+                if (vowels[(string)lyricSeparated[4]][1] != "") {
+                    // this vowel contains semivowel
+                    lyric += semivowelSeparator + vowels[(string)lyricSeparated[4]][1] + vowels[(string)lyricSeparated[4]][2];
+                }
+                else{
+                    lyric += " " + vowels[(string)lyricSeparated[4]][2];
+                }
+                
+                lyric += lastConsonants[(string)lyricSeparated[5]][0];
+
+                ResultLyrics.Add(lyric.Trim());
+
+                prevNote = currentNote;
+                
+                noteIdx++;
+            }
+            Enumerable.Zip(groups, ResultLyrics.ToArray(), ChangeLyric).Last();
+        }
+
+    /// <summary>
+    /// abstract class for Ini Management
+    /// To use, child phonemizer should implement this class(BaseIniManager) with its own setting values!
+    /// </summary>
+    public abstract class BaseIniManager {
+        protected USinger singer;
+        protected Hashtable iniSetting = new Hashtable();
+        protected string iniFileName;
+        protected string filePath;
+        protected List<IniBlock> blocks;
+
+        public BaseIniManager() { }
+
+        /// <summary>
+        /// if no [iniFileName] in Singer Directory, it makes new [iniFileName] with [iniFile]].
+        /// </summary>
+        /// <param name="singer"></param>
+        /// <param name="iniFileName"></param>
+        /// <param name="defaultIniSetting"></param>
+        public void Initialize(USinger singer, string iniFileName, Hashtable defaultIniSetting) {
+            this.singer = singer;
+            this.iniFileName = iniFileName;
+            iniSetting = defaultIniSetting;
+            filePath = Path.Combine(singer.Location, iniFileName);
+            try {
+                using (StreamReader reader = new StreamReader(filePath, singer.TextFileEncoding)){
+                    List<IniBlock> blocks = Ini.ReadBlocks(reader, filePath, @"\[\w+\]");
+                    if (blocks.Count == 0) {
+                        throw new IOException($"[{iniFileName}] is empty.");
+                    }
+                    this.blocks = blocks;
+                    IniSetUp(iniSetting); // you can override IniSetUp() to use.
+                };
+            } 
+            catch (IOException e) {
+                Log.Error(e, $"failed to read {iniFileName}, Making new {iniFileName}...");
+                using (StreamWriter writer = new StreamWriter(filePath)){
+                    iniSetting = defaultIniSetting;
+                    try{
+                        writer.Write(ConvertSettingsToString());
+                        writer.Close();
+                    }
+                    catch (IOException e_){
+                        Log.Error(e_, $"[{iniFileName}] Failed to Write new {iniFileName}.");
+                    }
+                };
+                using (StreamReader reader = new StreamReader(filePath)){
+                    List<IniBlock> blocks = Ini.ReadBlocks(reader, filePath, @"\[\w+\]");
+                    this.blocks = blocks;
+                };
+            }
+       }
+
+        /// <summary>
+        /// <para>you can override this method with your own values. </para> 
+        /// !! when implement this method, you have to use [SetOrReadThisValue(string sectionName, string keyName, bool/string/int/double value)] when setting or reading values.
+        /// <para>(ex)
+        /// SetOrReadThisValue("sectionName", "keyName", true);</para>
+        /// </summary>
+       protected virtual void IniSetUp(Hashtable iniSetting) {
+       }
+
+        /// <summary>
+        /// for file writing, converts iniSetting to string.
+        /// </summary>
+        /// <returns></returns>
+        protected string ConvertSettingsToString(){
+            string result = "";
+            foreach (DictionaryEntry section in iniSetting) {
+                result += $"[{section.Key}]\n";
+                foreach (DictionaryEntry key in (Hashtable)iniSetting[section.Key]){
+                    result += $"{key.Key}={key.Value}\n";
+                }
+            }
+            return result;
+        } 
+       /// <summary>
+       /// <param name="sectionName"> section's name in .ini config file. </param>
+       /// <param name="keyName"> key's name in .ini config file's [sectionName] section. </param>
+       /// <param name="defaultValue"> default value to overwrite if there's no valid value in config file. </param>
+       /// inputs section name & key name & default value. If there's valid bool vaule, nothing happens. But if there's no valid bool value, overwrites current value with default value.
+       /// 섹션과 키 이름을 입력받고, bool 값이 존재하면 넘어가고 존재하지 않으면 defaultValue 값으로 덮어씌운다 
+       /// /// </summary>
+        protected void SetOrReadThisValue(string sectionName, string keyName, bool defaultValue, out bool resultValue) {
+            List<IniLine> iniLines = blocks.Find(block => block.header == $"[{sectionName}]").lines;
+            if (! iniSetting.ContainsKey(sectionName)){
+                    iniSetting.Add(sectionName, new Hashtable());
+                }
+            if (iniLines != null) {
+                string result = iniLines.Find(l => l.line.Trim().Split("=")[0] == keyName).line.Trim().Split("=")[1];
+                if (result != null) {
+                    try{
+                        ((Hashtable)iniSetting[sectionName]).Add(keyName, result);
+                    }
+                    catch (ArgumentException){
+                        ((Hashtable)iniSetting[sectionName])[keyName] = result;
+                    }
+                    
+                    resultValue = result.ToLower() == "true" ? true : false;
+                }
+                else {
+                    try{
+                        ((Hashtable)iniSetting[sectionName]).Add(keyName, defaultValue.ToString());
+                    }
+                    catch (ArgumentException){
+                        ((Hashtable)iniSetting[sectionName])[keyName] = defaultValue.ToString();
+                    }
+                    resultValue = defaultValue;
+                }
+            }
+            else{
+                using (StreamWriter writer = new StreamWriter(filePath)) {
+                    ((Hashtable)iniSetting[sectionName]).Add(keyName, defaultValue.ToString().ToLower());
+                resultValue = defaultValue;
+                try{
+                    writer.Write(ConvertSettingsToString());
+                }
+                catch (IOException e){
+                    Log.Error(e, $"[{iniFileName}] Failed to Write new {iniFileName}.");
+                }
+            
+                Log.Information($"[{iniFileName}] failed to parse setting '{keyName}', modified {defaultValue} as default value.");
+                };
+            }
+        } 
+
+       /// <summary>
+       /// <param name="sectionName"> section's name in .ini config file. </param>
+       /// <param name="keyName"> key's name in .ini config file's [sectionName] section. </param>
+       /// <param name="defaultValue"> default value to overwrite if there's no valid value in config file. </param>
+       /// inputs section name & key name & default value. If there's valid string vaule, nothing happens. But if there's no valid string value, overwrites current value with default value.
+       /// 섹션과 키 이름을 입력받고, string 값이 존재하면 넘어가고 존재하지 않으면 defaultValue 값으로 덮어씌운다 
+       /// </summary>
+        protected string SetOrReadThisValue(string sectionName, string keyName, string defaultValue) {
+            string resultValue;
+            List<IniLine> iniLines = blocks.Find(block => block.header == $"[{sectionName}]").lines;
+            if (! iniSetting.ContainsKey(sectionName)){
+                    iniSetting.Add(sectionName, new Hashtable());
+                }
+            if (iniLines != null) {
+                string result = iniLines.Find(l => l.line.Trim().Split("=")[0] == keyName).line.Trim().Split("=")[1];
+                if (result != null) {
+                    try{
+                        ((Hashtable)iniSetting[sectionName]).Add(keyName, result);
+                    }
+                    catch (ArgumentException){
+                        ((Hashtable)iniSetting[sectionName])[keyName] = result;
+                    }
+                    resultValue = result;
+                }
+                else {
+                    try{
+                        ((Hashtable)iniSetting[sectionName]).Add(keyName, defaultValue);
+                    }
+                    catch (ArgumentException){
+                        ((Hashtable)iniSetting[sectionName])[keyName] = defaultValue;
+                    }
+                    resultValue = defaultValue;
+                }
+            }
+            else{
+                StreamWriter writer = new StreamWriter(filePath);
+                ((Hashtable)iniSetting[sectionName]).Add(keyName, defaultValue);
+                resultValue = defaultValue;
+                try{
+                    writer.Write(ConvertSettingsToString());
+                    writer.Close();
+                }
+                catch (IOException e){
+                    Log.Error(e, $"[{iniFileName}] Failed to Write new {iniFileName}.");
+                }
+                Log.Information($"[{iniFileName}] failed to parse setting '{keyName}', modified {defaultValue} as default value.");
+            }
+            return resultValue;
+       }
+
+       /// <summary>
+       /// 
+       /// <param name="sectionName"> section's name in .ini config file. </param>
+       /// <param name="keyName"> key's name in .ini config file's [sectionName] section. </param>
+       /// <param name="defaultValue"> default value to overwrite if there's no valid value in config file. </param>
+       /// inputs section name & key name & default value. If there's valid int vaule, nothing happens. But if there's no valid int value, overwrites current value with default value.
+       /// 섹션과 키 이름을 입력받고, int 값이 존재하면 넘어가고 존재하지 않으면 defaultValue 값으로 덮어씌운다 
+       /// </summary>
+       protected void SetOrReadThisValue(string sectionName, string keyName, int defaultValue, out int resultValue) {
+           List<IniLine> iniLines = blocks.Find(block => block.header == $"[{sectionName}]").lines;
+            if (! iniSetting.ContainsKey(sectionName)){
+                    iniSetting.Add(sectionName, new Hashtable());
+                }
+            if (iniLines != null) {
+                string result = iniLines.Find(l => l.line.Trim().Split("=")[0] == keyName).line.Trim().Split("=")[1];
+                if (result != null && int.TryParse(result, out var resultInt)) {
+                    try{
+                        ((Hashtable)iniSetting[sectionName]).Add(keyName, result);
+                    }
+                    catch (ArgumentException){
+                        ((Hashtable)iniSetting[sectionName])[keyName] = result;
+                    }
+                    resultValue = resultInt;
+                }
+                else {
+                    try{
+                        ((Hashtable)iniSetting[sectionName]).Add(keyName, defaultValue.ToString());
+                    }
+                    catch (ArgumentException){
+                        ((Hashtable)iniSetting[sectionName])[keyName] = defaultValue.ToString();
+                    }
+                    resultValue = defaultValue;
+                }
+            }
+            else{
+                StreamWriter writer = new StreamWriter(filePath);
+                ((Hashtable)iniSetting[sectionName]).Add(keyName, defaultValue);
+                resultValue = defaultValue;
+                try{
+                    writer.Write(ConvertSettingsToString());
+                    writer.Close();
+                }
+                catch (IOException e){
+                    Log.Error(e, $"[{iniFileName}] Failed to Write new {iniFileName}.");
+                }
+                Log.Information($"[{iniFileName}] failed to parse setting '{keyName}', modified {defaultValue} as default value.");
+            }
+       }
+    }
+        /// <summary>
+        /// Data class used to deserialize yaml dictionary.
+        ///  (for user-defined Korean jamo dictionary)
+        /// </summary>
+       public class JamoDictionary{
+            public FirstConsonantData[] firstConsonants;
+            public PlainVowelData[] plainVowels;
+            public SemivowelData[] semivowels;
+            public FinalConsonantData[] finalConsonants;
+            public JamoDictionary() { }
+            public JamoDictionary(FirstConsonantData[] firstConsonants, PlainVowelData[] plainVowels, SemivowelData[] semivowels, FinalConsonantData[] finalConsonants){
+                this.firstConsonants = firstConsonants;
+                this.plainVowels = plainVowels;
+                this.semivowels = semivowels;
+                this.finalConsonants = finalConsonants;
+            }
+            public struct FirstConsonantData {
+                public string grapheme; // ㄱ
+                public string phoneme; // g
+                public FirstConsonantData(string grapheme, string phoneme) {
+                    this.grapheme = grapheme;
+                    this.phoneme = phoneme;
+                }
+            }
+
+            public struct PlainVowelData {
+                public string grapheme; // ㅏ
+                public string phoneme; // a
+
+                public PlainVowelData(string grapheme, string phoneme) {
+                    this.grapheme = grapheme;
+                    this.phoneme = phoneme;
+                }
+            }
+            public struct SemivowelData {
+                public string grapheme; // w
+                public string phoneme; // w
+
+                public SemivowelData(string grapheme, string phoneme) {
+                    this.grapheme = grapheme;
+                    this.phoneme = phoneme;
+                }
+            }
+
+            public struct FinalConsonantData {
+                public string grapheme; // ㄱ
+                public string phoneme; // K
+                public FinalConsonantData(string grapheme, string phoneme) {
+                    this.grapheme = grapheme;
+                    this.phoneme = phoneme;
+                }
+            }
+        }
+    }
+    
+}

--- a/OpenUtau.Plugin.Builtin/BaseKoreanPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/BaseKoreanPhonemizer.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenUtau.Api;
+using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+
+
+namespace OpenUtau.Plugin.Builtin {
+    /// <summary>
+    /// Base Phonemizer for Korean Phonemizers.
+    /// <para>1. Can process Phoneme variation(음운 변동), through Hangeul.Variate().</para>
+    /// <para>2. Can find Alias in oto, including Voice color etc, through FindInOto().</para>
+    /// <para>3. Can manage .ini configuring, through implementing IniParser at child class. (Usage is in KoreanCVPhonemizer.cs)</para>
+    /// <para>4. Can generate phonemes according to Phoneme hints.</para>
+    /// </summary>
+    public abstract class BaseKoreanPhonemizer : Phonemizer {
+        
+        protected USinger singer;
+
+        protected int vcLengthShort = 90;
+
+        protected static readonly string[] PLAIN_VOWELS = new string[]{"ㅏ", "ㅣ", "ㅜ", "ㅔ", "ㅗ", "ㅡ", "ㅓ", "ㅢ"};
+        protected static readonly string[] SOFT_BATCHIMS = new string[]{"ㄴ", "ㄹ", "ㅇ"};
+        protected static readonly string[] HARD_BATCHIMS = new string[]{"ㄱ", "ㄷ", "ㅂ", "ㅁ"};
+        public override void SetSinger(USinger singer) => this.singer = singer;
+        public static string? FindInOto(USinger singer, string phoneme, Note note, bool nullIfNotFound = false) {
+            // 음소와 노트를 입력받고, 다음계 및 보이스컬러 에일리어스를 적용한다. 
+            // nullIfNotFound가 true이면 음소가 찾아지지 않을 때 음소가 아닌 null을 리턴한다.
+            // nullIfNotFound가 false면 음소가 찾아지지 않을 때 그대로 음소를 반환
+            string phonemeToReturn;
+            string color = string.Empty;
+            int toneShift = 0;
+            int? alt = null;
+            if (phoneme.Equals("")) {return phoneme;}
+
+            if (singer.TryGetMappedOto(phoneme + alt, note.tone + toneShift, color, out var otoAlt)) {
+                phonemeToReturn = otoAlt.Alias;
+            } 
+            else if (singer.TryGetMappedOto(phoneme, note.tone + toneShift, color, out var oto)) {
+                phonemeToReturn = oto.Alias;
+            } 
+            else if (singer.TryGetMappedOto(phoneme, note.tone, color, out oto)) {
+                phonemeToReturn = oto.Alias;
+            } 
+            else if (nullIfNotFound) {
+                phonemeToReturn = null;
+            } 
+            else {
+                phonemeToReturn = phoneme;
+            }
+
+            return phonemeToReturn;
+        }
+        
+        /// <summary>
+        /// <para>All child Korean Phonemizer have to do is implementing this (1). </para>
+        /// <para> This Function manages phoneme conversion at Notes that are not in last position. </para>
+        /// </summary>
+        /// <param name="notes"></param>
+        /// <param name="prev"></param>
+        /// <param name="next"></param>
+        /// <param name="prevNeighbour"></param>
+        /// <param name="nextNeighbour"></param>
+        /// <param name="prevNeighbours"></param>
+        /// <returns>Same as BasePhonemizer.Process(), but just manages Notes that are not in last position.</returns>
+        public virtual Result ConvertPhonemes(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
+            // below return is Dummy
+            return new Result() {
+                phonemes = new Phoneme[] {
+                        new Phoneme { phoneme = $""},
+                    }
+            };
+        }
+
+        /// <summary>
+        /// <para>All child Korean Phonemizer have to do is implementing this (2). </para>
+        /// <para> This Function manages phoneme conversion at Note in last position. </para>
+        /// </summary>
+        /// <param name="notes"></param>
+        /// <param name="prev"></param>
+        /// <param name="next"></param>
+        /// <param name="prevNeighbour"></param>
+        /// <param name="nextNeighbour"></param>
+        /// <param name="prevNeighbours"></param>
+        /// <returns>Same as BasePhonemizer.Process(), but just manages Note that in last position.</returns>
+        public virtual Result GenerateEndSound(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
+            // below return is Dummy
+            return new Result() {
+                phonemes = new Phoneme[] {
+                        new Phoneme { phoneme = $""},
+                    }
+            };
+        }
+
+        /// <summary>
+        /// Returns Result with two input Phonemes. 
+        /// <param name="firstPhoneme"></param>
+        /// <param name="secondPhoneme"></param>
+        /// <param name="totalDuration"></param>
+        /// <param name="totalDurationDivider"></param>
+        /// </summary>
+        public Result GenerateResult(String firstPhoneme, String secondPhoneme, int totalDuration, int secondPhonemePosition, int totalDurationDivider=3){
+            return new Result() {
+                phonemes = new Phoneme[] {
+                    new Phoneme { phoneme = firstPhoneme },
+                    new Phoneme { phoneme = secondPhoneme,
+                    position = totalDuration - Math.Min(totalDuration / totalDurationDivider, secondPhonemePosition)},
+                }
+            };
+        }
+
+        /// <summary>
+        /// Returns Result with two input Phonemes. 
+        /// <param name="firstPhoneme"></param>
+        /// <param name="secondPhoneme"></param>
+        /// <param name="totalDuration"></param>
+        /// <param name="totalDurationDivider"></param>
+        /// </summary>
+        public Result GenerateResult(String firstPhoneme, String secondPhoneme, int totalDuration, int totalDurationDivider=3){
+            return new Result() {
+                phonemes = new Phoneme[] {
+                    new Phoneme { phoneme = firstPhoneme },
+                    new Phoneme { phoneme = secondPhoneme,
+                    position = totalDuration - totalDuration / totalDurationDivider},
+                }
+            };
+        }
+
+        /// <summary>
+        /// Returns Result with one input Phonemes. 
+        /// </summary>
+        public Result GenerateResult(String firstPhoneme){
+            return new Result() {
+                phonemes = new Phoneme[] {
+                    new Phoneme { phoneme = firstPhoneme },
+                }
+            };
+        }
+
+        /// <summary>
+        /// Returns Result with three input Phonemes. 
+        /// 
+        /// </summary>
+        /// <param name="firstPhoneme"></param>
+        /// <param name="secondPhoneme"></param>
+        /// <param name="thirdPhoneme"></param>
+        /// <param name="totalDuration"></param>
+        /// <param name="secondPhonemePosition"></param>
+        /// <param name="secondTotalDurationDivider"></param>
+        /// <param name="thirdTotalDurationDivider"></param>
+        /// <returns> Result  </returns>
+        public Result GenerateResult(String firstPhoneme, String secondPhoneme, String thirdPhoneme, int totalDuration, int secondPhonemePosition, int secondTotalDurationDivider=3, int thirdTotalDurationDivider=8){
+            return new Result() {
+                phonemes = new Phoneme[] {
+                    new Phoneme { phoneme = firstPhoneme},
+                    new Phoneme { phoneme = secondPhoneme,
+                    position = totalDuration - Math.Min(totalDuration / secondTotalDurationDivider, secondPhonemePosition)},
+                    new Phoneme { phoneme = thirdPhoneme,
+                    position = totalDuration - totalDuration / thirdTotalDurationDivider},
+                }// -음소 있이 이어줌
+            };
+        }
+
+        /// <summary>
+        /// Returns Result with three input Phonemes. 
+        /// 
+        /// </summary>
+        /// <param name="firstPhoneme"></param>
+        /// <param name="secondPhoneme"></param>
+        /// <param name="thirdPhoneme"></param>
+        /// <param name="totalDuration"></param>
+        /// <param name="secondPhonemePosition"></param>
+        /// <param name="secondTotalDurationDivider"></param>
+        /// <param name="thirdTotalDurationDivider"></param>
+        /// <returns> Result  </returns>
+        public Result GenerateResult(String firstPhoneme, String secondPhoneme, String thirdPhoneme, int totalDuration, int secondTotalDurationDivider=3, int thirdTotalDurationDivider=8){
+            return new Result() {
+                phonemes = new Phoneme[] {
+                    new Phoneme { phoneme = firstPhoneme},
+                    new Phoneme { phoneme = secondPhoneme,
+                    position = totalDuration - totalDuration / secondTotalDurationDivider},
+                    new Phoneme { phoneme = thirdPhoneme,
+                    position = totalDuration - totalDuration / thirdTotalDurationDivider},
+                }// -음소 있이 이어줌
+            };
+        }
+        /// <summary>
+        /// <para> It AUTOMATICALLY generates phonemes based on phoneme hints (each phonemes should be separated by ",". (Example: [a, a i, ya])) </para>
+        /// <para> But it can't generate phonemes automatically, so should implement ConvertPhonemes() Method in child class. </para>
+        /// <para> Also it can't generate Endsounds automatically, so should implement GenerateEndSound() Method in child class.</para>
+        /// </summary>
+        public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
+            Note note = notes[0];
+            string lyric = note.lyric;
+            string phoneticHint = note.phoneticHint;
+
+            Note? prevNote = prevNeighbour; // null or Note
+            Note thisNote = note;
+            Note? nextNote = nextNeighbour; // null or Note
+
+            int totalDuration = notes.Sum(n => n.duration);
+
+            if (phoneticHint != null) {
+                // if there are phonetic hint
+                // 발음 힌트가 있음 
+                // 냥[nya2, ang]
+                string[] phoneticHints = phoneticHint.Split(','); // phonemes are seperated by ','.
+                int phoneticHintsLength = phoneticHints.Length;
+
+                Phoneme[] phonemes = new Phoneme[phoneticHintsLength];
+
+                Dictionary<string, string> VVdictionary = new Dictionary<string, string>() { };
+
+                string[] VVsource = new string[] { "a", "i", "u", "e", "o", "eo", "eu" };
+
+                for (int i = 0; i < 7; i++) {
+                    // VV 딕셔너리를 채운다
+                    // 나중에 발음기호에 ["a a"]를 입력하고 만일 음원에게 "a a"가 없을 경우, 자동으로 VVDictionary에서 "a a"에 해당하는 값인 "a"를 호출해 사용
+                    // (반대도 똑같이 적용)
+
+                    // VVDictionary 예시: {"a a", "a"} ...
+                    for (int j = 6; j >= 0; j--) {
+                        VVdictionary[$"{VVsource[i]} {VVsource[j]}"] = $"{VVsource[j]}"; // CV/CVC >> CBNN 호환용
+                        VVdictionary[$"{VVsource[j]}"] = $"{VVsource[i]} {VVsource[j]}"; // CBNN >> CV/CVC 호환용
+                    }
+                }
+
+                for (int i = 0; i < phoneticHintsLength; i++) {
+                    string? alias = FindInOto(singer, phoneticHints[i].Trim(), note, true); // alias if exists, otherwise null
+
+                    if (alias != null) {
+                        // 발음기호에 입력된 phoneme이 음원에 존재함
+
+                        if (i == 0) {
+                            // first syllable
+                            phonemes[i] = new Phoneme { phoneme = alias };
+                        } 
+                        else if ((i == phoneticHintsLength - 1) && ((phoneticHints[i].Trim().EndsWith('-')) || phoneticHints[i].Trim().EndsWith('R'))) {
+                            // 마지막 음소이고 끝음소(ex: a -, a R)일 경우, VCLengthShort에 맞춰 음소를 배치
+                            phonemes[i] = new Phoneme {
+                                phoneme = alias,
+                                position = totalDuration - Math.Min(vcLengthShort, totalDuration / 8)
+                                // 8등분한 길이로 끝에 숨소리 음소 배치, n등분했을 때의 음소 길이가 이보다 작다면 n등분했을 때의 길이로 간다
+                            };
+                        } 
+                        else if (phoneticHintsLength == 2) {
+                            // 입력되는 발음힌트가 2개일 경우, 2등분되어 음소가 배치된다.
+                            // 이 경우 부자연스러우므로 3등분해서 음소 배치하게 조정
+                            phonemes[i] = new Phoneme {
+                                phoneme = alias,
+                                position = totalDuration - totalDuration / 3
+                                // 3등분해서 음소가 배치됨
+                            };
+                        } 
+                        else {
+                            phonemes[i] = new Phoneme {
+                                phoneme = alias,
+                                position = totalDuration - ((totalDuration / phoneticHintsLength) * (phoneticHintsLength - i))
+                                // 균등하게 n등분해서 음소가 배치됨
+                            };
+                        }
+                    } else if (VVdictionary.ContainsKey(phoneticHints[i].Trim())) {
+                        // 입력 실패한 음소가 VV 혹은 V일 때
+                        if (phoneticHintsLength == 2) {
+                            // 입력되는 발음힌트가 2개일 경우, 2등분되어 음소가 배치된다.
+                            // 이 경우 부자연스러우므로 3등분해서 음소 배치하게 조정
+                            phonemes[i] = new Phoneme {
+                                phoneme = FindInOto(singer, VVdictionary[phoneticHints[i].Trim()], note),
+                                position = totalDuration - totalDuration / 3
+                                // 3등분해서 음소가 배치됨
+                            };
+                        } 
+                        else {
+                            phonemes[i] = new Phoneme {
+                                phoneme = FindInOto(singer, VVdictionary[phoneticHints[i].Trim()], note),
+                                position = totalDuration - ((totalDuration / phoneticHintsLength) * (phoneticHintsLength - i))
+                                // 균등하게 n등분해서 음소가 배치됨
+                            };
+                        }
+                    } else {
+                        // 그냥 음원에 음소가 없음
+                        phonemes[i] = new Phoneme {
+                            phoneme = phoneticHints[i].Trim(),
+                            position = totalDuration - ((totalDuration / phoneticHintsLength) * (phoneticHintsLength - i))
+                            // 균등하게 n등분해서 음소가 배치됨
+                        };
+                    }
+                }
+
+                return new Result() {
+                    phonemes = phonemes
+                };
+            } 
+            else if (KoreanPhonemizerUtil.IsHangeul(lyric)) {
+                return ConvertPhonemes(notes, prev, next, prevNeighbour, nextNeighbour, prevNeighbours);
+            } 
+            else {
+                return GenerateEndSound(notes, prev, next, prevNeighbour, nextNeighbour, prevNeighbours);
+            }
+        }
+
+        /// <summary>
+        /// abstract class for Ini Management
+        /// To use, child phonemizer should implement this class(BaseIniManager) with its own setting values!
+        /// </summary>
+        public abstract class BaseIniManager : KoreanPhonemizerUtil.BaseIniManager{}
+    }
+}

--- a/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
@@ -1,854 +1,280 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core;
 
 namespace OpenUtau.Plugin.Builtin {
-     /// This phonemizer is based on 'KOR CVC Phonemizer'(by NANA). ///
-    [Phonemizer("Korean CBNN Phonemizer", "KO CBNN", "EX3", language:"KO")]
+    /// Phonemizer for 'KOR CBNN' ///
+    [Phonemizer("Korean CBNN Phonemizer", "KO CBNN", "EX3", language: "KO")]
 
-    public class KoreanCBNNPhonemizer : Phonemizer {
+    public class KoreanCBNNPhonemizer : BaseKoreanPhonemizer {
 
-        // ↓ Plainvowels of [ㅏ ㅐ ㅑ ㅒ ㅓ ㅔ ㅕ ㅖ ㅗ ㅘ ㅙ ㅚ ㅛ ㅜ ㅝ ㅞ ㅟ ㅠ ㅡ ㅢ ㅣ]. //
-        static readonly string[] naPlainVowels = new string[] { "a", "e", "a", "e", "eo", "e", "eo", "e", "o", "a", "e", "e", "o", "u", "eo", "e", "i", "u", "eu", "i", "i" };
-        static readonly string[] naConsonants = new string[] {
-            "ㄱ:g","ㄲ:gg","ㄴ:n","ㄷ:d","ㄸ:dd","ㄹ:r","ㅁ:m","ㅂ:b","ㅃ:bb","ㅅ:s","ㅆ:ss","ㅇ:","ㅈ:j","ㅉ:jj","ㅊ:ch","ㅋ:k","ㅌ:t","ㅍ:p","ㅎ:h"
-        };
+        public override void SetSinger(USinger singer) {
+            if (this.singer == singer) {return;}
+            this.singer = singer;
+            if (this.singer == null) {return;}
 
-        // ↓ ㅢ is e (* There's no "eui" in Kor CBNN *).//
-        static readonly string[] naVowels = new string[] {
-            "ㅏ:a","ㅐ:e","ㅑ:ya","ㅒ:ye","ㅓ:eo","ㅔ:e","ㅕ:yeo","ㅖ:ye","ㅗ:o","ㅘ:wa","ㅙ:we","ㅚ:we","ㅛ:yo","ㅜ:u","ㅝ:weo","ㅞ:we","ㅟ:wi","ㅠ:yu","ㅡ:eu","ㅢ:e","ㅣ:i"
-        };
-
-        // ↓ ["Grapheme : Phoneme"] of batchims.
-        static readonly string[] naFinals = new string[] {
-            ":","ㄱ:k","ㄲ:k","ㄳ:k","ㄴ:n","ㄵ:n","ㄶ:n","ㄷ:t","ㄹ:l","ㄺ:l","ㄻ:m","ㄼ:l","ㄽ:l","ㄾ:l","ㄿ:p","ㅀ:l","ㅁ:m","ㅂ:p","ㅄ:p","ㅅ:t","ㅆ:t","ㅇ:ng","ㅈ:t","ㅊ:t","ㅋ:k","ㅌ:t","ㅍ:p:1","ㅎ:t:2"
-        };
-        private const int hangeulStartIndex = 0xAC00; // unicode of '가'
-        private const int hangeulEndIndex = 0xD7A3; // unicode of '힣'
-
-        // ======================================================================================
-
-
-        // ↓ Plain vowels of Korean.
-        static readonly string[] plainVowels = new string[] { "eu", "eo", "a", "i", "u", "e", "o" };
-
-        // ↓ Vowels of romanized CVs.
-        static readonly string[] vowels = new string[] {
-            "eu=geu,neu,deu,reu,meu,beu,seu,eu,jeu,cheu,keu,teu,peu,heu,ggeu,ddeu,bbeu,sseu,jjeu",
-            "eo=geo,neo,deo,reo,meo,beo,seo,eo,jeo,cheo,keo,teo,peo,heo,ggeo,ddeo,bbeo,sseo,jjeo,gyeo,nyeo,dyeo,ryeo,myeo,byeo,syeo,yeo,jyeo,chyeo,kyeo,tyeo,pyeo,hyeo,ggyeo,ddyeo,bbyeo,ssyeo,jjyeo,gweo,nweo,dweo,rweo,mweo,bweo,sweo,weo,jweo,chweo,kweo,tweo,pweo,hweo,ggweo,ddweo,bbweo,ssweo,jjweo",
-            "a=ga,na,da,ra,ma,ba,sa,a,ja,cha,ka,ta,pa,ha,gga,dda,bba,ssa,jja,gya,nya,dya,rya,mya,bya,sya,ya,jya,chya,kya,tya,pya,hya,ggya,ddya,bbya,ssya,jjya,gwa,nwa,dwa,rwa,mwa,bwa,swa,wa,jwa,chwa,kwa,twa,pwa,hwa,ggwa,ddwa,bbwa,sswa,jjwa",
-            "e=ge,ne,de,re,me,be,se,e,je,che,ke,te,pe,he,gge,dde,bbe,sse,jje,gye,nye,dye,rye,mye,bye,sye,ye,jye,chye,kye,tye,pye,hye,ggye,ddye,bbye,ssye,jjye,gwe,nwe,dwe,rwe,mwe,bwe,swe,we,jwe,chwe,kwe,twe,pwe,hwe,ggwe,ddwe,bbwe,sswe,jjwe",
-            "i=gi,ni,di,ri,mi,bi,si,i,ji,chi,ki,ti,pi,hi,ggi,ddi,bbi,ssi,jji,gwi,nwi,dwi,rwi,mwi,bwi,swi,wi,jwi,chwi,kwi,twi,pwi,hwi,ggwi,ddwi,bbwi,sswi,jjwi",
-            "o=go,no,do,ro,mo,bo,so,o,jo,cho,ko,to,po,ho,ggo,ddo,bbo,sso,jjo,gyo,nyo,dyo,ryo,myo,byo,syo,yo,jyo,chyo,kyo,tyo,pyo,hyo,ggyo,ddyo,bbyo,ssyo,jjyo",
-            "u=gu,nu,du,ru,mu,bu,su,u,ju,chu,ku,tu,pu,hu,ggu,ddu,bbu,ssu,jju,gyu,nyu,dyu,ryu,myu,byu,syu,yu,jyu,chyu,kyu,tyu,pyu,hyu,ggyu,ddyu,bbyu,ssyu,jjyu",
-            "ng=ang,ing,ung,eng,ong,eung,eong",
-            "n=an,in,un,en,on,eun,eon",
-            "m=am,im,um,em,om,eum,eom",
-            "l=al,il,ul,el,ol,eul,eol",
-            "p=ap,ip,up,ep,op,eup,eop",
-            "t=at,it,ut,et,ot,eut,eot",
-            "k=ak,ik,uk,ek,ok,euk,eok"
-        };
-
-        // ↓ consonants of romanized CVs.
-        static readonly string[] consonants = new string[] {
-            "ggy=ggya,ggyu,ggye,ggyo,ggyeo",
-            "ggw=ggwa,ggwi,ggwe,ggweo",
-            "gg=gg,gga,ggi,ggu,gge,ggo,ggeu,ggeo",
-            "ddy=ddya,ddyu,ddye,ddyo,ddyeo",
-            "ddw=ddwa,ddwi,ddwe,ddweo",
-            "dd=dd,dda,ddi,ddu,dde,ddo,ddeu,ddeo",
-            "bby=bbya,bbyu,bbye,bbyo,bbyeo",
-            "bbw=bbwa,bbwi,bbwe,bbweo",
-            "bb=bb,bba,bbi,bbu,bbe,bbo,bbeu,bbeo",
-            "ssy=ssya,ssyu,ssye,ssyo,ssyeo",
-            "ssw=sswa,sswi,sswe,ssweo",
-            "ss=ss,ssa,ssi,ssu,sse,sso,sseu,sseo",
-            "gy=gya,gyu,gye,gyo,gyeo",
-            "gw=gwa,gwi,gwe,gweo",
-            "g=g,ga,gi,gu,ge,go,geu,geo",
-            "ny=nya,nyu,nye,nyo,nyeo",
-            "nw=nwa,nwi,nwe,nweo",
-            "n=n,na,ni,nu,ne,no,neu,neo",
-            "dy=dya,dyu,dye,dyo,dyeo",
-            "dw=dwa,dwi,dwe,dweo",
-            "d=d,da,di,du,de,do,deu,deo",
-            "ry=rya,ryu,rye,ryo,ryeo",
-            "rw=rwa,rwi,rwe,rweo",
-            "r=r,ra,ri,ru,re,ro,reu,reo",            
-            "my=mya,myu,mye,myo,myeo",
-            "mw=mwa,mwi,mwe,mweo",
-            "m=m,ma,mi,mu,me,mo,meu,meo",
-            "by=bya,byu,bye,byo,byeo",
-            "bw=bwa,bwi,bwe,bweo",
-            "b=b,ba,bi,bu,be,bo,beu,beo",
-            "sy=sya,syu,sye,syo,syeo",
-            "sw=swa,swi,swe,sweo",
-            "s=s,sa,si,su,se,so,seu,seo",
-            "jy=jya,jyu,jye,jyo,jyeo",
-            "jw=jwa,jwi,jwe,jweo",
-            "j=j,ja,ji,ju,je,jo,jeu,jeo",            
-            "chy=chya,chyu,chye,chyo,chyeo,chwa",
-            "chw=chwi,chwe,chweo",
-            "ch=ch,cha,chi,chu,che,cho,cheu,cheo",
-            "ky=kya,kyu,kye,kyo,kyeo",
-            "kw=kwa,kwi,kwe,kweo",
-            "k=k,ka,ki,ku,ke,ko,keu,keo",
-            "ty=tya,tyu,tye,tyo,tyeo",
-            "tw=twa,twi,twe,tweo",
-            "t=t,ta,ti,tu,te,to,teu,teo",
-            "py=pya,pyu,pye,pyo,pyeo",
-            "pw=pwa,pwi,pwe,pweo",
-            "p=p,pa,pi,pu,pe,po,peu,peo",
-            "hy=hya,hyu,hye,hyo,hyeo",
-            "hw=hwa,hwi,hwe,hweo",
-            "h=h,ha,hi,hu,he,ho,heu,heo"
-            };
-
-        static readonly Dictionary<string, string> vowelLookup;
-        static readonly Dictionary<string, string> consonantLookup;
-
-        string getConsonant(string str) {
-            str = str.Replace('a', ' ');
-            str = str.Replace('i', ' ');
-            str = str.Replace('u', ' ');
-            str = str.Replace('e', ' ');
-            str = str.Replace('o', ' ');
-            str = str.Trim();
-
-            return str;
+            if (this.singer.SingerType != USingerType.Classic){return;}
         }
 
-        bool isAlphaCon(string consStr) {
-            String str = consStr.Replace('w', ' ');
-            str = consStr.Replace('y', ' ');
-            str = str.Trim();
+
+        static readonly Dictionary<string, string> FIRST_CONSONANTS = new Dictionary<string, string>(){
+            {"ㄱ", "g"},
+            {"ㄲ", "gg"},
+            {"ㄴ", "n"},
+            {"ㄷ", "d"},
+            {"ㄸ", "dd"},
+            {"ㄹ", "r"},
+            {"ㅁ", "m"},
+            {"ㅂ", "b"},
+            {"ㅃ", "bb"},
+            {"ㅅ", "s"},
+            {"ㅆ", "ss"},
+            {"ㅇ", ""},
+            {"ㅈ", "j"},
+            {"ㅉ", "jj"},
+            {"ㅊ", "ch"},
+            {"ㅋ", "k"},
+            {"ㅌ", "t"},
+            {"ㅍ", "p"},
+            {"ㅎ", "h"},
+            {"null", ""} // 뒤 글자가 없을 때를 대비
+            };
         
-            if (str == "gg") { return true; }
-            else if (str == "dd") { return true; }
-            else if (str == "bb") { return true; }
-            else if (str == "ss") { return true; }
-            else if (str == "g") { return true; }
-            else if (str == "n") { return true; }
-            else if (str == "d") { return true; }
-            else if (str == "r") { return true; }
-            else if (str == "m") { return true; }
-            else if (str == "b") { return true; }
-            else if (str == "s") { return true; }
-            else if (str == "j") { return true; }
-            else if (str == "ch") { return true; }
-            else if (str == "k") { return true; }
-            else if (str == "t") { return true; }
-            else if (str == "p") { return true; }
-            else if (str == "h") { return true; }else { return false; }
-        }
-
-        static KoreanCBNNPhonemizer() {
-            vowelLookup = vowels.ToList()
-                .SelectMany(line => {
-                    var parts = line.Split('=');
-                    return parts[1].Split(',').Select(cv => (cv, parts[0]));
-                })
-                .ToDictionary(t => t.Item1, t => t.Item2);
-            consonantLookup = consonants.ToList()
-                .SelectMany(line => {
-                    var parts = line.Split('=');
-                    return parts[1].Split(',').Select(cv => (cv, parts[0]));
-                })
-                .ToDictionary(t => t.Item1, t => t.Item2);
-        }
-
-
-        // ======================================================================================
-
-
-        private USinger singer;
-        public override void SetSinger(USinger singer) => this.singer = singer;
-
-        // make it quicker to check multiple oto occurrences at once rather than spamming if else if
-            private bool checkOtoUntilHit(string[] input, Note note, out UOto oto){
-                oto = default;
-
-                var attr0 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
-                var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
-
-                foreach (string test in input){
-                    if (singer.TryGetMappedOto(test, note.tone + attr0.toneShift, attr0.voiceColor, out oto)){
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-        public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
-            var note = notes[0];
-            var currentUnicode = ToUnicodeElements(note.lyric); // ← unicode of current lyric
-            string currentLyric = note.lyric; // ← string of current lyric
-            var attr0 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
-            var attr1 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 1) ?? default;
-            
-            //-----------------------------------------------------------------------//
-            ////// ***   ↓↓↓ Seperates Lyrics in:                                     //
-            /////           - first consonant letter(초성, "consonant" in below),    //
-            /////           -  middle vowel letter(중성, "vowel" in below),          //
-            /////           -  last consonant letter(종성, "final" in below) ↓↓↓  *** //.
-
-
-            ////  ↓↓ 1 ** Variables for 'Current Notes' ** --
-            // ↓ index of "consonant", "vowel", "final".
-            int CLconsonant = 0;
-            int CLvowel = 0;
-            int CLfinal = 0; 
-
-            // ↓ Use for Temp
-            string[] TCLtemp;
-
-            // ↓ use these for applying phonological rules
-            string TCLconsonant = "";
-            string TCLvowel = "";
-            string TCLfinal = "";
-            string TCLplainvowel = ""; //← Simplifies vowels
-
-            int TCLsemivowel = 0; // semi vowel is 'y', 'w'. [0 means "there's no semi vowel], [1 means "there is 'y'"], [2 means "there is 'w'"]]
-            
-            // ↓ use these for generating phonemes in phonemizers 
-            string TCLconsonantCBNN = "";
-            string TCLvowelCBNN = "";
-
-            ////  ↓↓ 2 ** Variables for 'Next Notes' ** --
-            // ↓ index of "consonant", "vowel", "final".
-            int NLconsonant = 0;
-            int NLvowel = 0;
-            int NLfinal = 0;
-
-            // ↓ Use for Temp
-            string[] TNLtemp;
-
-            // ↓ use these for applying phonological rules
-            string TNLconsonant = "";
-            string TNLvowel = "";
-            string TNLfinal = "";
-            string TNLplainvowel = "";
-
-            // ↓ use these for generating phonemes in phonemizers 
-            string TNLconsonantCBNN = "";
-            //string TNLvowelCBNN = "";
-
-            int TNLsemivowel = 0; // semi vowel is 'y', 'w'. [0 means "there's no semi vowel], [1 means "there is 'y'"], [2 means "there is 'w'"]]
-
-            ////  ↓↓ 3 ** Variables for 'Previous Notes' ** --
-            // ↓ index of "consonant", "vowel", "final".
-            int PLconsonant = 0;
-            int PLvowel = 0;
-            int PLfinal = 0;
-            
-            // ↓ Use for Temp
-            string[] TPLtemp;
-
-            // ↓ use these for applying phonological rules
-            string TPLconsonant = "";
-            string TPLvowel = "";
-            string TPLfinal = "";
-            string TPLplainvowel = "";
-            string TPLplainfinal = "";
-
-            // ↓ use these for generating phonemes in phonemizers 
-            //string TPLconsonantCBNN = "";
-            //string TPLvowelCBNN = "";
-
-            //int TPLsemivowel = 0; // semi vowel is 'y', 'w'. [0 means "there's no semi vowel], [1 means "there is 'y'"], [2 means "there is 'w'"]]
-
-
-            ////  ↓↓ 4 ** Variables for checking notes ** --
-            bool currentHangeul = false;
-            bool prevHangeul = false;
-            bool nextHangeul = false;
-
-            bool prevExist = false;
-            bool nextExist = false;
-
-            char firstCL, firstPL, firstNL;
-            int uCL, uPL, uNL;
-            bool prevIsBreath = false;
-
-
-            // check first lyric
-            firstCL = currentLyric[0];
-            
-            uCL = (int)firstCL;
-            if ((uCL >= hangeulStartIndex) && (uCL <= hangeulEndIndex)) {
-                currentHangeul = true;
-                CLconsonant = (uCL - hangeulStartIndex) / (21 * 28);
-                CLvowel = (uCL - hangeulStartIndex) % (21 * 28) / 28;
-                CLfinal = (uCL - hangeulStartIndex) % 28;
- 
-
-                TCLtemp = naVowels[CLvowel].Split(":");
-                TCLvowel = TCLtemp[1];
-                TCLplainvowel = naPlainVowels[CLvowel];
-                
-                if (TCLvowel.StartsWith('y')) {TCLsemivowel = 1;} 
-                else if (TCLvowel.StartsWith('w')) {TCLsemivowel = 2;}
-                
-                TCLtemp = naConsonants[CLconsonant].Split(":");
-                TCLconsonant = TCLtemp[1];
-
-                TCLtemp = naFinals[CLfinal].Split(":");
-                TCLfinal = TCLtemp[1];
-
-
-                // TCLconsonant : 현노트 초성    TCLvowel : 현노트 중성    TCLfinal : 현노트 종성
-
-            }
-
-            // 이전 노트 존재 여부 확인 + 이전 노트 첫번째 글자 확인
-            if (prevNeighbour != null) {
-                firstPL = (prevNeighbour?.lyric)[0]; // 가사 받아오기
-                prevExist = true; // 이전 노트 존재한다 반짝
-                
-                uPL = (int)firstPL; // 가사를 int로 변환
-
-                if ((uPL >= hangeulStartIndex) && (uPL <= hangeulEndIndex)) {
-                    prevHangeul = true;
-
-                    PLconsonant = (uPL - hangeulStartIndex) / (21 * 28);
-                    PLvowel = (uPL - hangeulStartIndex) % (21 * 28) / 28;
-                    PLfinal = (uPL - hangeulStartIndex) % 28;
-
-
-                    TPLtemp = naConsonants[PLconsonant].Split(":");
-                    TPLconsonant = TPLtemp[1];
-
-                    TPLtemp = naVowels[PLvowel].Split(":");
-                    TPLvowel = TPLtemp[1];
-                    TPLplainvowel = naPlainVowels[PLvowel];
-
-                    //if (TPLvowel.StartsWith('y')) {TPLsemivowel = 1;} 
-                    //else if (TPLvowel.StartsWith('w')) {TPLsemivowel = 2;}
-                
-                    TPLtemp = naFinals[PLfinal].Split(":");
-                    TPLfinal = TPLtemp[1];
-                    TPLplainfinal = TPLfinal;
-                }
-            }
-
-            // 다음 노트 존재 여부 확인 + 다음 노트 첫번째 글자 확인
-            if (nextNeighbour != null) {
-                firstNL = (nextNeighbour?.lyric)[0];
-                nextExist = true;
-                uNL = (int)firstNL;
-
-                if ((uNL >= hangeulStartIndex) && (uNL <= hangeulEndIndex)) {
-                    nextHangeul = true;
-
-                    NLconsonant = (uNL - hangeulStartIndex) / (21 * 28);
-                    NLvowel = (uNL - hangeulStartIndex) % (21 * 28) / 28;
-                    NLfinal = (uNL - hangeulStartIndex) % 28;
-
-
-                    TNLtemp = naConsonants[NLconsonant].Split(":");
-                    TNLconsonant = TNLtemp[1];
-
-                    TNLtemp = naVowels[NLvowel].Split(":");
-                    TNLvowel = TNLtemp[1];
-                    TNLplainvowel = naPlainVowels[NLvowel];
-
-                    if (TNLvowel.StartsWith('y')) {TNLsemivowel = 1;} 
-                    else if (TNLvowel.StartsWith('w')) {TNLsemivowel = 2;}
-                
-
-                    TNLtemp = naFinals[NLfinal].Split(":");
-                    TNLfinal = TNLtemp[1];
-                }
-            }
-
-            if (currentHangeul) {
-                // 음운규칙 적용
-                if (currentHangeul) {
-
-                    // 1. 연음법칙 
-                    string tempTCLconsonant = "";
-                    string tempTCLfinal = "";
-                    bool yeoneum = false;
-                    bool yeoneum2 = false;
-
-                    if (prevExist && prevHangeul && (CLconsonant == 11) && (TPLfinal != "")) {
-                        int temp = PLfinal;
-                        if (temp == 1) { TCLtemp = naConsonants[0].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 2) { TCLtemp = naConsonants[1].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 3) { TCLtemp = naConsonants[10].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 4) { TCLtemp = naConsonants[2].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 5) { TCLtemp = naConsonants[12].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 6) { TCLtemp = naConsonants[18].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 7) { TCLtemp = naConsonants[3].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 8) { TCLtemp = naConsonants[5].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 9) { TCLtemp = naConsonants[0].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 10) { TCLtemp = naConsonants[6].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 11) { TCLtemp = naConsonants[7].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 12) { TCLtemp = naConsonants[9].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 13) { TCLtemp = naConsonants[16].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 14) { TCLtemp = naConsonants[17].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 15) { TCLtemp = naConsonants[18].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 16) { TCLtemp = naConsonants[6].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 17) { TCLtemp = naConsonants[7].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 18) { TCLtemp = naConsonants[9].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 19) { TCLtemp = naConsonants[9].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 20) { TCLtemp = naConsonants[10].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 21) { tempTCLconsonant = ""; yeoneum = true; }
-                        else if (temp == 22) { TCLtemp = naConsonants[12].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 23) { TCLtemp = naConsonants[14].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 24) { TCLtemp = naConsonants[15].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 25) { TCLtemp = naConsonants[16].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 26) { TCLtemp = naConsonants[17].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                        else if (temp == 27) { TCLtemp = naConsonants[18].Split(":"); tempTCLconsonant = TCLtemp[1]; yeoneum = true; }
-                    }
-
-                    if (nextExist && nextHangeul && (TCLfinal != "") && (TNLconsonant == "")) {
-                        int temp = CLfinal;
-
-                        if (temp == 1) { TCLtemp = naConsonants[0].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                        else if (temp == 2) { TCLtemp = naConsonants[1].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                        else if (temp == 3) { TCLfinal = "k"; yeoneum2 = true; }
-                        else if (temp == 4) { TCLtemp = naConsonants[2].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                        else if (temp == 5) { TCLfinal = "n"; yeoneum2 = true; }
-                        else if (temp == 6) { TCLfinal = "n"; yeoneum2 = true; }
-                        else if (temp == 7) { TCLtemp = naConsonants[3].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                        else if (temp == 8) { TCLtemp = naConsonants[5].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                        else if (temp == 9) { TCLfinal = "l"; yeoneum2 = true; }
-                        else if (temp == 10) { TCLfinal = "l"; yeoneum2 = true; }
-                        else if (temp == 11) { TCLfinal = "l"; yeoneum2 = true; }
-                        else if (temp == 12) { TCLfinal = "l"; yeoneum2 = true; }
-                        else if (temp == 13) { TCLfinal = "l"; yeoneum2 = true; }
-                        else if (temp == 14) { TCLfinal = "l"; yeoneum2 = true; }
-                        else if (temp == 15) { TCLfinal = "l"; yeoneum2 = true; }
-                        else if (temp == 16) { TCLtemp = naConsonants[6].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                        else if (temp == 17) { TCLtemp = naConsonants[7].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                        else if (temp == 18) { TCLfinal = "p"; yeoneum2 = true; }
-                        else if (temp == 19) { TCLtemp = naConsonants[9].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                        else if (temp == 20) { TCLtemp = naConsonants[10].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             //else if (temp == 21) { TCLtemp = naConsonants[11].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             else if (temp == 22) { TCLtemp = naConsonants[12].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; } else if (temp == 23) { TCLtemp = naConsonants[14].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; } else if (temp == 24) { TCLtemp = naConsonants[15].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; } else if (temp == 25) { TCLtemp = naConsonants[16].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; } else if (temp == 26) { TCLtemp = naConsonants[17].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; } else if (temp == 27) { TCLtemp = naConsonants[18].Split(":"); tempTCLfinal = TCLtemp[1]; TCLfinal = ""; yeoneum2 = true; }
-
-                    }
-                    if (yeoneum) { TCLconsonant = tempTCLconsonant; }
-                    if (yeoneum2) { TNLconsonant = tempTCLfinal; }
-
-
-                    // 2. 격음화/유기음화/거센소리되기
-                    if (prevExist && prevHangeul && (TPLfinal != "")) {
-                        if (((PLfinal == 27) && (CLconsonant == 0)) || ((PLfinal == 6) && (CLconsonant == 0)) || ((PLfinal == 15) && (CLconsonant == 0))) { TCLconsonant = "k"; } else if (((PLfinal == 27) && (CLconsonant == 3)) || ((PLfinal == 6) && (CLconsonant == 3)) || ((PLfinal == 15) && (CLconsonant == 3))) { TCLconsonant = "t"; } else if (((PLfinal == 27) && (CLconsonant == 12)) || ((PLfinal == 6) && (CLconsonant == 12)) || ((PLfinal == 15) && (CLconsonant == 12))) { TCLconsonant = "ch"; } else if (((PLfinal == 27) && (CLconsonant == 9)) || ((PLfinal == 6) && (CLconsonant == 9)) || ((PLfinal == 15) && (CLconsonant == 9))) { TCLconsonant = "ss"; }
-
-                        if ((PLfinal == 1) && (CLconsonant == 18)) { TCLconsonant = "k"; } else if ((PLfinal == 7) && (CLconsonant == 18)) { TCLconsonant = "t"; } else if ((PLfinal == 17) && (CLconsonant == 18)) { TCLconsonant = "p"; } else if ((PLfinal == 22) && (CLconsonant == 18)) { TCLconsonant = "ch"; }
-                    }
-                    if (nextExist && nextHangeul && (TCLfinal != "")) {
-                        if ((NLconsonant == 0) && (CLfinal == 27)) { TCLfinal = ""; TNLconsonant = "k"; } else if ((NLconsonant == 0) && (CLfinal == 6)) { TCLfinal = "n"; TNLconsonant = "k"; } else if ((NLconsonant == 0) && (CLfinal == 15)) { TCLfinal = "l"; TNLconsonant = "k"; } else if ((NLconsonant == 3) && (CLfinal == 27)) { TCLfinal = ""; TNLconsonant = "t"; } else if ((NLconsonant == 3) && (CLfinal == 6)) { TCLfinal = "n"; TNLconsonant = "t"; } else if ((NLconsonant == 3) && (CLfinal == 15)) { TCLfinal = "l"; TNLconsonant = "t"; } else if ((NLconsonant == 12) && (CLfinal == 27)) { TCLfinal = ""; TNLconsonant = "ch"; } else if ((NLconsonant == 12) && (CLfinal == 6)) { TCLfinal = "n"; TNLconsonant = "ch"; } else if ((NLconsonant == 12) && (CLfinal == 15)) { TCLfinal = "l"; TNLconsonant = "ch"; } else if ((NLconsonant == 9) && (CLfinal == 27)) { TCLfinal = ""; TNLconsonant = "ss"; } else if ((NLconsonant == 9) && (CLfinal == 6)) { TCLfinal = "n"; TNLconsonant = "ss"; } else if ((NLconsonant == 9) && (CLfinal == 15)) { TCLfinal = "l"; TNLconsonant = "ss"; }
-
-                        if ((NLconsonant == 2) && (CLfinal == 27)) { TCLfinal = "n"; }
-
-                        if ((NLconsonant == 18) && (CLfinal == 1)) { TCLfinal = ""; TNLconsonant = "k"; } else if ((NLconsonant == 18) && (CLfinal == 7)) { TCLfinal = ""; TNLconsonant = "t"; } else if ((NLconsonant == 18) && (CLfinal == 17)) { TCLfinal = ""; TNLconsonant = "p"; } else if ((NLconsonant == 18) && (CLfinal == 22)) { TCLfinal = ""; TNLconsonant = "ch"; }
-                    }
-
-
-                    // 3. 음절의 끝소리 규칙 예외
-                    if (nextExist && nextHangeul) {
-                        /*
-                        // ㄼ + 자음이 있을 때 => ㄼ : p
-                        if ((CLfinal == 11) && (TCLconsonant != "")) { TCLfinal = "p"; }
-                        */
-                        // ㄺ + ㄱ => ㄺ : ㄹ
-                        if ((CLfinal == 9) && (NLconsonant == 0)) { TCLfinal = "l"; }
-                    }
-
-
-                    // 4. 경음화/된소리되기
-                    if (prevExist && prevHangeul && TPLfinal != "") {
-                        // ㄱㄷㅂ + ㄱㄷㅂㅅㅈ = ㄲㄸㅃㅆㅉ
-                        if (((TPLfinal == "k") && (CLconsonant == 0)) || ((TPLfinal == "t") && (CLconsonant == 0)) || ((TPLfinal == "p") && (CLconsonant == 0))) { TCLconsonant = "gg"; } else if (((TPLfinal == "k") && (CLconsonant == 3)) || ((TPLfinal == "t") && (CLconsonant == 3)) || ((TPLfinal == "p") && (CLconsonant == 3))) { TCLconsonant = "dd"; } else if (((TPLfinal == "k") && (CLconsonant == 7)) || ((TPLfinal == "t") && (CLconsonant == 7)) || ((TPLfinal == "p") && (CLconsonant == 7))) { TCLconsonant = "bb"; } else if (((TPLfinal == "k") && (CLconsonant == 9)) || ((TPLfinal == "t") && (CLconsonant == 9)) || ((TPLfinal == "p") && (CLconsonant == 9))) { TCLconsonant = "ss"; } else if (((TPLfinal == "k") && (CLconsonant == 12)) || ((TPLfinal == "t") && (CLconsonant == 12)) || ((TPLfinal == "p") && (CLconsonant == 12))) { TCLconsonant = "jj"; }
-
-                    
-                        // 용언 어간 받침 ㄴㅁ + ㄱㄷㅅㅈ = ㄲㄸㅆㅉ
-                        if(((TPLfinal=="n")&&(CLconsonant==0))|| ((TPLfinal == "m") && (CLconsonant == 0))) { TCLconsonant = "gg"; }
-                        else if (((TPLfinal == "n") && (CLconsonant == 3)) || ((TPLfinal == "m") && (CLconsonant == 3))) { TCLconsonant = "dd"; }
-                        else if (((TPLfinal == "n") && (CLconsonant == 9)) || ((TPLfinal == "m") && (CLconsonant == 9))) { TCLconsonant = "ss"; }
-                        else if (((TPLfinal == "n") && (CLconsonant == 12)) || ((TPLfinal == "m") && (CLconsonant == 12))) { TCLconsonant = "jj"; }
-
-                        // 관형사형 어미ㄹ / 한자어 ㄹ + ㄷㅅㅈ = ㄸㅆㅉ
-                        if ((PLfinal == 8) && (CLconsonant == 3)) { TCLconsonant = "dd"; } else if ((PLfinal == 8) && (CLconsonant == 9)) { TCLconsonant = "ss"; } else if ((PLfinal == 8) && (CLconsonant == 12)) { TCLconsonant = "jj"; }
-
-                        // 어간 받침 ㄼㄾ + ㄱㄷㅅㅈ = ㄲㄸㅆㅉ
-                        if (((PLfinal == 11) && (CLconsonant == 0)) || ((PLfinal == 13) && (CLconsonant == 0))) { TCLconsonant = "gg"; } else if (((PLfinal == 11) && (CLconsonant == 3)) || ((PLfinal == 13) && (CLconsonant == 3))) { TCLconsonant = "dd"; } else if (((PLfinal == 11) && (CLconsonant == 9)) || ((PLfinal == 13) && (CLconsonant == 9))) { TCLconsonant = "ss"; } else if (((PLfinal == 11) && (CLconsonant == 12)) || ((PLfinal == 13) && (CLconsonant == 12))) { TCLconsonant = "jj"; }
-                    }
-
-
-                    // 5. 구개음화 
-                    if (prevExist && prevHangeul && (TPLfinal != "")) {
-                        if ((PLfinal == 7) && (CLconsonant == 11) && (CLvowel == 20)) { TCLconsonant = "j"; } else if ((PLfinal == 25) && (CLconsonant == 11) && (CLvowel == 20)) { TCLconsonant = "ch"; } else if ((PLfinal == 13) && (CLconsonant == 11) && (CLvowel == 20)) { TCLconsonant = "ch"; } else if ((PLfinal == 7) && (CLconsonant == 18) && (CLvowel == 20)) { TCLconsonant = "ch"; }
-                    }
-                    if (nextExist && nextHangeul && (TCLfinal != "")) {
-                        if ((CLfinal == 7) && (NLconsonant == 11) && (NLvowel == 20)) { TCLfinal = ""; } else if ((CLfinal == 25) && (NLconsonant == 11) && (NLvowel == 20)) { TCLfinal = ""; } else if ((CLfinal == 13) && (NLconsonant == 11) && (NLvowel == 20)) { TCLfinal = ""; } else if ((CLfinal == 7) && (NLconsonant == 18) && (NLvowel == 20)) { TCLfinal = ""; }
-
-                    }
-
-
-                    // 6. 비음화
-                    /**
-                    if (prevExist && prevHangeul && (TPLfinal != "")) {
-                        // 한자어 받침 ㅁㅇ + ㄹ = ㄴ
-                        if (((TPLfinal == "m") && (CLconsonant == 5)) || ((TPLfinal == "ng") && (CLconsonant == 5))) { TCLconsonant = "n"; }
-
-                        // 한자어 받침 ㄱㄷㅂ + ㄹ = ㅇㄴㅁ + ㄴ(1)
-                        if (((TPLfinal == "k") && (CLconsonant == 5)) || ((TPLfinal == "t") && (CLconsonant == 5)) || ((TPLfinal == "p") && (CLconsonant == 5))) { TCLconsonant = "n"; }
-                    }
-                    **/
-                    if (nextExist && nextHangeul && (TCLfinal != "")) {
-                        //받침 ㄱㄷㅂ + ㄴㅁ = ㅇㄴㅁ
-                        if (((TCLfinal == "k") && (TNLconsonant == "n")) || ((TCLfinal == "k") && (TNLconsonant == "m"))) { TCLfinal = "ng"; } else if (((TCLfinal == "t") && (TNLconsonant == "n")) || ((TCLfinal == "t") && (TNLconsonant == "m"))) { TCLfinal = "n"; } else if (((TCLfinal == "p") && (TNLconsonant == "n")) || ((TCLfinal == "p") && (TNLconsonant == "m"))) { TCLfinal = "m"; }
-
-                        // 한자어 받침 ㄱㄷㅂ + ㄹ = ㅇㄴㅁ + ㄴ(2)
-                        if ((TCLfinal == "k") && (NLconsonant == 5)) { TCLfinal = "ng"; } else if ((TCLfinal == "t") && (NLconsonant == 5)) { TCLfinal = "n"; } else if ((TCLfinal == "p") && (NLconsonant == 5)) { TCLfinal = "m"; }
-                    }
-
-
-                    // 7. 유음화
-                    /**
-                    if (prevExist && prevHangeul && (TPLfinal != "")) {
-                        if (((PLfinal == 8) && (TCLconsonant == "n")) || ((PLfinal == 13) && (TCLconsonant == "n")) || ((PLfinal == 15) && (TCLconsonant == "n"))) { TCLconsonant = "r"; }
-                    }
-                    if (nextExist && nextHangeul && (TCLfinal != "")) {
-                        if ((TCLfinal == "n") && (TNLconsonant == "r")) { TCLfinal = "l"; }
-                    }
-                    **/
-
-
-
-                    // 8. 받침 + ㄹ = ㄹㄹ
-
-
-
-                    // consonant에 변경 사항이 있을 때
-                    //if (prevExist && prevHangeul) {
-
-
-                        // 비음화
-                        // (1) ㄱ(ㄲㅋㄳㄺ)
-                        //     ㄷ(ㅅ,ㅆ,ㅈ,ㅊ,ㅌ,ㅎ)
-                        //     ㅂ(ㅍ,ㄼ,ㄿ,ㅄ)
-
-
-                    //}
-                    // final에 변경 사항이 있을 때
-
-
-                }
-
-                bool isLastBatchim = false;
-
-                // vowels do not have suffixed phonemes in CBNN, so use suffixed '- h'~ phonemes instead. 
-                if (!prevExist && TCLconsonant == "" && TCLfinal != "" && TCLvowel != "") {
-                    TCLconsonant = "h";
-                }
-                
-                // to make FC's length to 1 if FC comes final (=no next note)
-                if (!nextHangeul && TCLfinal != "" &&TCLvowel != "") {
-                    isLastBatchim = true;
-                }
-
-                // To use semivowels in VC (ex: [- ga][a gy][gya], ** so not [- ga][a g][gya] **)
-                if (TCLsemivowel == 1 && TPLplainvowel != "i" && TPLplainvowel != "eu") {TCLconsonantCBNN = TCLconsonant + 'y';}
-                else if (TCLsemivowel == 2 && TPLplainvowel != "u" && TPLplainvowel != "o" && TPLplainvowel != "eu") {TCLconsonantCBNN = TCLconsonant + 'w';}
-                else {TCLconsonantCBNN = TCLconsonant;}
-
-                if (TNLsemivowel == 1 && TCLplainvowel != "i" && TCLplainvowel != "eu") {TNLconsonantCBNN = TNLconsonant + 'y';}
-                else if (TNLsemivowel == 2 && TCLplainvowel != "u" && TCLplainvowel != "o" && TCLplainvowel != "eu") {TNLconsonantCBNN = TNLconsonant + 'w';}
-                else {TNLconsonantCBNN = TNLconsonant;}
-
-                
-                
-                //To set suffix of CV, according to next-coming batchim.
-                if (TCLfinal == "") {
-                    TCLvowelCBNN = TCLvowel;}
-                else if (TCLfinal == "m" && TCLconsonantCBNN != "" || TCLfinal == "m" && TCLconsonantCBNN == "" && TCLsemivowel != 0) {
-                    TCLvowelCBNN = TCLvowel + '1';}
-                else if (TCLfinal == "n" && TCLconsonantCBNN != ""  || TCLfinal == "n" && TCLconsonantCBNN == "" && TCLsemivowel != 0) {
-                    TCLvowelCBNN = TCLvowel + '2';}
-                else if (TCLfinal == "ng" && TCLconsonantCBNN != "" || TCLfinal == "ng" && TCLconsonantCBNN == "" && TCLsemivowel != 0) {
-                    TCLvowelCBNN = TCLvowel + '3';} 
-                else if (TCLfinal == "l" && TCLconsonantCBNN != "" || TCLfinal == "l" && TCLconsonantCBNN == "" && TCLsemivowel != 0) {
-                    TCLvowelCBNN = TCLvowel + '4';}
-                else if (TCLfinal == "k" && TCLconsonantCBNN != "" || TCLfinal == "k" && TCLconsonantCBNN == "" && TCLsemivowel != 0) {
-                    TCLvowelCBNN = TCLvowel;}
-                else if (TCLfinal == "t" && TCLconsonantCBNN != "" || TCLfinal == "t" && TCLconsonantCBNN == "" && TCLsemivowel != 0) {
-                    TCLvowelCBNN = TCLvowel + '3';}
-                else if (TCLfinal == "p" && TCLconsonantCBNN != "" || TCLfinal == "p" && TCLconsonantCBNN == "" && TCLsemivowel != 0) {
-                    TCLvowelCBNN = TCLvowel + '1';}
-                else {TCLvowelCBNN = TCLvowel;}
-
-
-                string CV = (TCLconsonant + TCLvowelCBNN);
-                string VC = "";
-                bool comesSemivowelWithoutVC = false;
-                
-
-                if (TCLsemivowel != 0 && TCLconsonant == ""){
-                    comesSemivowelWithoutVC = true;
-                }
-                if (nextExist && (TCLfinal == "")) { VC = TCLplainvowel + " " + TNLconsonantCBNN; }
-
-                //for Vowel VCV
-                if (prevExist && TPLfinal == "" && TCLconsonantCBNN == "" && !comesSemivowelWithoutVC) {CV = TPLplainvowel + " " + TCLvowel;}
-
-                
-                string FC = "";
-                if (TCLfinal != "") { FC = TCLplainvowel + TCLfinal; }
-
-
-                // for [- XX] phonemes
-                if (!prevExist || prevIsBreath || TPLfinal != "" && TCLconsonant != "r" && TCLconsonant != "n" && TCLconsonant != "" ) { CV = $"- {CV}"; }
-
-                
-                // 만약 받침이 있다면
-                if (FC != "") {
-                    int totalDuration = notes.Sum(n => n.duration);
-                    int fcLength = totalDuration / 3;
-
-                    if (isLastBatchim) {
-                        fcLength = 1;
-                    }
-                    else if ((TCLfinal == "k") || (TCLfinal == "p") || (TCLfinal == "t")) { 
-                        fcLength = totalDuration / 2;}
-                    else if ((TCLfinal == "l") || (TCLfinal == "ng") || (TCLfinal == "m")) { 
-                        fcLength = totalDuration / 5;}
-                    else if ((TCLfinal == "n")) {
-                        fcLength = totalDuration / 3;
-                    }
-
-                    if (singer.TryGetMappedOto(CV, note.tone + attr0.toneShift, attr0.voiceColor, out var oto1) && singer.TryGetMappedOto(FC, note.tone + attr0.toneShift, attr0.voiceColor, out var oto2)) {
-                        CV = oto1.Alias;
-                        FC = oto2.Alias;
-                        return new Result {
-                            phonemes = new Phoneme[] {
-                                new Phoneme() {
-                                    phoneme = CV,
-                                },
-                                new Phoneme() {
-                                    phoneme = FC,
-                                    position = totalDuration - fcLength,
-                                }
-                            },
-                        };
-                    }
-
-                    
-                    
-                }
-
-
-                // 만약 받침이 없다면
-                if (TCLfinal == "") {
-                    // 뒤에 노트가 있다면
-                    if ((TNLconsonantCBNN != "")) {
-                        int totalDuration = notes.Sum(n => n.duration);
-                        int vcLength = 60;
-                        if ((TNLconsonant == "r") || (TNLconsonant == "g") || (TNLconsonant == "d") || (TNLconsonant == "n")) { vcLength = 33; }
-                        else if (TNLconsonant == "h") {
-                            vcLength = 15;
-                        }
-                        else if ((TNLconsonant == "ch") || (TNLconsonant == "gg")) { vcLength = totalDuration / 2; }
-                        else if ((TNLconsonant == "k") || (TNLconsonant == "t") || (TNLconsonant == "p")  || (TNLconsonant == "dd") || (TNLconsonant == "bb") || (TNLconsonant == "ss") || (TNLconsonant == "jj")) { vcLength = totalDuration / 3; }
-                        vcLength = Math.Min(totalDuration / 2, vcLength);
-
-                        if (singer.TryGetMappedOto(CV, note.tone + attr0.toneShift, attr0.voiceColor, out var oto1) && singer.TryGetMappedOto(VC, note.tone + attr0.toneShift, attr0.voiceColor, out var oto2)) {
-                            CV = oto1.Alias;
-                            VC = oto2.Alias;
-                            return new Result {
-                                phonemes = new Phoneme[] {
-                                    new Phoneme() {
-                                        phoneme = CV,
-                                    },
-                                    new Phoneme() {
-                                        phoneme = VC,
-                                        position = totalDuration - vcLength,
-                                    }
-                                },
-                            };
-                        }
-                        
-                    }
-                }
-
-
-                // 그 외(받침 없는 마지막 노트)
-                if (singer.TryGetMappedOto(CV, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)){
-                        CV = oto.Alias;
-                        return new Result {
-                            phonemes = new Phoneme[] {
-                                new Phoneme() {
-                                    phoneme = CV,
-                            }
-                        },
-                    };
-                }
-            }
-
-            if (prevHangeul) {
-                string endBreath = "-";
-
-                if (prevExist && TPLfinal == "" && endBreath.Contains(currentLyric)) {
-                    endBreath = $"{TPLplainvowel} -";
-                    prevIsBreath = true; // to prevent this→→ case→→, for example... "[사, -, 사 (=notes)]" should be "[- sa,  a -, - sa(=phonemes)]", but it becomes [sa, a -, 사(=phonemes)] in phonemizer, so '사' note becomes *no sound.
-                }
-                else if (prevExist && TPLfinal != "" && endBreath.Contains(currentLyric)) {
-                    endBreath = $"{TPLplainfinal} -";
-                    prevIsBreath = true; // to prevent this→→ case→→, for example... "[사, -, 사 (=notes)]" should be "[- sa,  a -, - sa(=phonemes)]", but it becomes [sa, a -, 사(=phonemes)] in phonemizer, so '사' note becomes *no sound.
-                }
-
-                if (singer.TryGetMappedOto(endBreath, note.tone + attr0.toneShift, attr0.voiceColor, out var oto)){
-                        endBreath = oto.Alias;
-                        return new Result {
-                            phonemes = new Phoneme[] {
-                            new Phoneme() {
-                                phoneme = endBreath,
-                            }
-                        },
-                    };
-                }
-            }
-
-
-
-
-            // ======================================================================================
-/**
-            if (prevNeighbour == null) {
-                // Use "- V" or "- CV" if present in voicebank
-                var initial = $"- {currentLyric}";
-                string[] tests = new string[] {initial, currentLyric};
-                // try [- XX] before trying plain lyric
-                if (checkOtoUntilHit(tests, note, out var oto)){
-                    currentLyric = oto.Alias;
-                }
-            } else if ("-".Contains(currentLyric)) {
-                var prevUnicode = ToUnicodeElements(prevNeighbour?.lyric);
-                prevIsBreath = true;
-                // end breath note
-                if (vowelLookup.TryGetValue(prevUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
-                    var vowel = "";
-                    var prevLyric = string.Join("", prevUnicode);;   
-                    vowel = vow;
-                    
-                    var endBreath = $"{vow} -";
-                    if (prevLyric.EndsWith("eo")) {
-                        endBreath = $"eo -";
-                    } else if (prevLyric.EndsWith("eu")) {
-                        endBreath = $"eu -";
-                    }
-                                        
-                    // try end breath
-                    string[] tests = new string[] {endBreath, currentLyric};
-                    if (checkOtoUntilHit(tests, note, out var oto)){ 
-                        currentLyric = oto.Alias;
-                    }
-                }
-            } else {
-                string[] tests = new string[] {currentLyric};
-                if (checkOtoUntilHit(tests, note, out var oto)){
-                    currentLyric = oto.Alias;
-                }
-            }
-**/
-            if (nextNeighbour != null) { // 다음에 노트가 있으면
-                var nextUnicode = ToUnicodeElements(nextNeighbour?.lyric);
-                var nextLyric = string.Join("", nextUnicode);
-
-                // Check if next note is a vowel and does not require VC
-                if (plainVowels.Contains(nextUnicode.FirstOrDefault() ?? string.Empty)) {
-                    return new Result {
-                        phonemes = new Phoneme[] {
-                            new Phoneme() {
-                                phoneme = currentLyric,
-                            }
-                        },
-                    };
-                }
-
-                // Insert VC before next neighbor
-                // Get vowel from current note
-                var vowel = "";
-
-                if (vowelLookup.TryGetValue(currentUnicode.LastOrDefault() ?? string.Empty, out var vow)) {
-                    vowel = vow;
-
-                    if (currentLyric.Contains("e")) {
-                        vowel = "e" + vowel;
-                        vowel = vowel.Replace("ee", "e");
-                    }
-                }
-
-                // Get consonant from next note
-                var consonant = "";
-                if (consonantLookup.TryGetValue(nextUnicode.FirstOrDefault() ?? string.Empty, out var con)) {
-                    consonant = getConsonant(nextNeighbour?.lyric); //로마자만 가능
-                    if (!(isAlphaCon(consonant))) { consonant = con; }
-                }
-
-                if (consonant == "") {
-                    return new Result {
-                        phonemes = new Phoneme[] {
-                            new Phoneme() {
-                                phoneme = currentLyric,
-                            }
-                        },
-                    };
-                }
-
-                var vcPhoneme = $"{vowel} {consonant}";
-                var vcPhonemes = new string[] {vcPhoneme, ""};
-                if (checkOtoUntilHit(vcPhonemes, note, out var oto1)) {
-                    vcPhoneme = oto1.Alias;
-                } else {
-                    return new Result {
-                        phonemes = new Phoneme[] {
-                            new Phoneme() {
-                                phoneme = currentLyric,
-                            }
-                        },
-                    };
-                }
-
-                int totalDuration = notes.Sum(n => n.duration);
-                int vcLength = 60;
-                var nextAttr = nextNeighbour.Value.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
-                if (singer.TryGetMappedOto(nextLyric, nextNeighbour.Value.tone + nextAttr.toneShift, nextAttr.voiceColor, out var oto)) {
-                    vcLength = MsToTick(oto.Preutter);
-                }
-                vcLength = Math.Min(totalDuration / 2, vcLength);
-
-
-
-                return new Result {
-                    phonemes = new Phoneme[] {
-                        new Phoneme() {
-                            phoneme = currentLyric,
-                        },
-                        new Phoneme() {
-                            phoneme = vcPhoneme,
-                            position = totalDuration - vcLength,
-                        }
-                    },
-                };
-            }
-
-            // No next neighbor
-            return new Result {
-                phonemes = new Phoneme[] {
-                    new Phoneme {
-                        phoneme = currentLyric,
-                    }
-                },
+        static readonly Dictionary<string, string[]> MIDDLE_VOWELS = new Dictionary<string, string[]>(){
+            {"ㅏ", new string[3]{"a", "", "a"}},
+            {"ㅐ", new string[3]{"e", "", "e"}},
+            {"ㅑ", new string[3]{"ya", "y", "a"}},
+            {"ㅒ", new string[3]{"ye", "y", "e"}},
+            {"ㅓ", new string[3]{"eo", "", "eo"}},
+            {"ㅔ", new string[3]{"e", "", "e"}},
+            {"ㅕ", new string[3]{"yeo", "y", "eo"}},
+            {"ㅖ", new string[3]{"ye", "y", "e"}},
+            {"ㅗ", new string[3]{"o", "", "o"}},
+            {"ㅘ", new string[3]{"wa", "w", "a"}},
+            {"ㅙ", new string[3]{"we", "w", "e"}},
+            {"ㅚ", new string[3]{"we", "w", "e"}},
+            {"ㅛ", new string[3]{"yo", "y", "o"}},
+            {"ㅜ", new string[3]{"u", "", "u"}},
+            {"ㅝ", new string[3]{"weo", "w", "eo"}},
+            {"ㅞ", new string[3]{"we", "w", "e"}},
+            {"ㅟ", new string[3]{"wi", "w", "i"}},
+            {"ㅠ", new string[3]{"yu", "y", "u"}},
+            {"ㅡ", new string[3]{"eu", "", "eu"}},
+            {"ㅢ", new string[3]{"i", "", "i"}}, // ㅢ는 ㅣ로 발음
+            {"ㅣ", new string[3]{"i", "", "i"}},
+            {"null", new string[3]{"", "", ""}} // 뒤 글자가 없을 때를 대비
             };
+        static readonly Dictionary<string, string[]> LAST_CONSONANTS = new Dictionary<string, string[]>(){
+             //ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ
+            {"ㄱ", new string[]{"k", ""}},
+            {"ㄲ", new string[]{"k", ""}},
+            {"ㄳ", new string[]{"k", ""}},
+            {"ㄴ", new string[]{"n", "2"}},
+            {"ㄵ", new string[]{"n", "2"}},
+            {"ㄶ", new string[]{"n", "2"}},
+            {"ㄷ", new string[]{"t", "1"}},
+            {"ㄹ", new string[]{"l", "4"}},
+            {"ㄺ", new string[]{"k", ""}},
+            {"ㄻ", new string[]{"m", "1"}},
+            {"ㄼ", new string[]{"l", "4"}},
+            {"ㄽ", new string[]{"l", "4"}},
+            {"ㄾ", new string[]{"l", "4"}},
+            {"ㄿ", new string[]{"p", "1"}},
+            {"ㅀ", new string[]{"l", "4"}},
+            {"ㅁ", new string[]{"m", "1"}},
+            {"ㅂ", new string[]{"p", "1"}},
+            {"ㅄ", new string[]{"p", "1"}},
+            {"ㅅ", new string[]{"t", "1"}},
+            {"ㅆ", new string[]{"t", "1"}},
+            {"ㅇ", new string[]{"ng", "3"}},
+            {"ㅈ", new string[]{"t", "1"}},
+            {"ㅊ", new string[]{"t", "1"}},
+            {"ㅋ", new string[]{"k", ""}},
+            {"ㅌ", new string[]{"t", "1"}},
+            {"ㅍ", new string[]{"p", "1"}},
+            {"ㅎ", new string[]{"t", "1"}},
+            {" ", new string[]{"", ""}}, // no batchim
+            {"null", new string[]{"", ""}} // 뒤 글자가 없을 때를 대비
+            };
+        
+        private Result ConvertForCBNN(Note[] notes, string[] prevLyric, string[] thisLyric, string[] nextLyric, Note? nextNeighbour) {
+            string thisMidVowelHead;
+            string thisMidVowelTail;
+
+            
+            int totalDuration = notes.Sum(n => n.duration);
+            Note note = notes[0];
+
+            string soundBeforeEndSound = thisLyric[2] == " " ? thisLyric[1] : thisLyric[2];
+            string thisMidVowelForEnd;
+
+            thisMidVowelForEnd = MIDDLE_VOWELS.ContainsKey(soundBeforeEndSound) ? MIDDLE_VOWELS[soundBeforeEndSound][2] : LAST_CONSONANTS[soundBeforeEndSound][0];
+            string endSound = $"{thisMidVowelForEnd} -";
+
+            bool isItNeedsFrontCV;
+            bool isRelaxedVC;
+            bool isItNeedsVC;
+            bool isItNeedsVV;
+            bool isItNeedsVSv; // V + Semivowel, example) a y, a w 
+            bool isItNeedsEndSound;
+
+            isItNeedsVV = prevLyric[2] == " " && thisLyric[0] == "ㅇ" && PLAIN_VOWELS.Contains(thisLyric[1]);
+            
+            isItNeedsFrontCV = prevLyric[0] == "null" || prevLyric[1] == "null" || (prevLyric[2] != "null" && HARD_BATCHIMS.Contains(prevLyric[2]) && prevLyric[2] != "ㅁ");
+            isRelaxedVC = nextLyric[0] == "null" || nextLyric[1] == "null" || ((thisLyric[2] == nextLyric[0]) && (KoreanPhonemizerUtil.nasalSounds.ContainsKey(thisLyric[2]) || thisLyric[2] == "ㄹ"));
+            isItNeedsEndSound = (nextLyric[0] == "null" || nextLyric[1] == "null") && nextNeighbour == null;
+            if (thisLyric.All(part => part == null)) {
+                return GenerateResult(FindInOto(note.lyric, note));
+            }
+            else {
+                thisMidVowelHead = $"{MIDDLE_VOWELS[thisLyric[1]][1]}";
+                thisMidVowelTail = $"{MIDDLE_VOWELS[thisLyric[1]][2]}";
+            }
+            
+            string CV = $"{FIRST_CONSONANTS[thisLyric[0]]}{thisMidVowelHead}{thisMidVowelTail}{LAST_CONSONANTS[thisLyric[2]][1]}"; 
+            if (FindInOto(CV, note, true) == null) {
+                CV = CV.Substring(0, CV.Length - 1);
+            }
+            string frontCV;
+            string batchim;
+            string VC = $"{thisMidVowelTail} {FIRST_CONSONANTS[nextLyric[0]]}";
+            string VV = $"{MIDDLE_VOWELS[prevLyric[1]][2]} {thisMidVowelTail}";
+            string VSv = $"{thisMidVowelTail} {MIDDLE_VOWELS[nextLyric[1]][1]}";
+            isItNeedsVSv = thisLyric[2] == " " && nextLyric[0] == "ㅇ" && !PLAIN_VOWELS.Contains(nextLyric[1]) && FindInOto(VSv, note, true) != null;
+            isItNeedsVC = thisLyric[2] == " " && nextLyric[0] != "ㅇ" && nextLyric[0] != "null" && FindInOto(VC, note, true) != null;
+
+            frontCV = $"- {CV}";
+            if (FindInOto(frontCV, note, true) == null) {
+                frontCV = $"-{CV}";
+                if (FindInOto(frontCV, note, true) == null) {
+                    frontCV = CV;
+                }
+            }
+
+            if (isItNeedsVV) {CV = VV;}
+        
+
+            if (thisLyric[2] == " " && isItNeedsVC) { // no batchim, needs VC
+                if (isItNeedsFrontCV){
+                    return GenerateResult(FindInOto(frontCV, note), FindInOto(VC, note), totalDuration, 120, 3);
+                }
+                return GenerateResult(FindInOto(CV, note), FindInOto(VC, note), totalDuration, 120, 3);
+            }
+
+            if (thisLyric[2] == " " && isItNeedsVSv) { // no batchim, needs VSv
+                if (isItNeedsFrontCV){
+                    return GenerateResult(FindInOto(frontCV, note), FindInOto(VSv, note), totalDuration, 120, 3);
+                }
+                return GenerateResult(FindInOto(CV, note), FindInOto(VSv, note), totalDuration, 120, 3);
+            }
+
+            if (thisLyric[2] == " ") { // no batchim, doesn't need VC
+                if (isItNeedsFrontCV){
+                    return isItNeedsEndSound ? 
+                    GenerateResult(FindInOto(frontCV, note), FindInOto(endSound, note), totalDuration, 8)
+                    : GenerateResult(FindInOto(frontCV, note));
+                }
+                return isItNeedsEndSound ? 
+                    GenerateResult(FindInOto(CV, note), FindInOto(endSound, note), totalDuration, 8)
+                    : GenerateResult(FindInOto(CV, note));
+            }
+            
+            batchim = $"{thisMidVowelTail}{LAST_CONSONANTS[thisLyric[2]][0]}";
+            
+            
+            if (thisLyric[2] == "ㅁ" || ! HARD_BATCHIMS.Contains(thisLyric[2])) { // batchim ㅁ + ㄴ ㄹ ㅇ
+                if (isItNeedsFrontCV){
+                    return isRelaxedVC ? 
+                    GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), totalDuration, 120, 8)
+                    : GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), endSound, totalDuration, 120, 2, 3);
+                }
+                return isRelaxedVC ? 
+                GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), totalDuration, 120, 8)
+                : GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), endSound, totalDuration, 120, 2, 3);
+            }
+            else {
+                if (isItNeedsFrontCV){
+                    return isRelaxedVC ? 
+                    GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), totalDuration, 120, 8)
+                    : GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), totalDuration, 120, 5);
+                }
+                return isRelaxedVC ? 
+                GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), totalDuration, 120, 8)
+                : GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), totalDuration, 120, 5);
+            }
+            
+        }
+
+        private string? FindInOto(String phoneme, Note note, bool nullIfNotFound=false){
+            return BaseKoreanPhonemizer.FindInOto(singer, phoneme, note, nullIfNotFound);
+        }
+
+
+        private string HandleEmptyFirstConsonant(string lyric) {
+            return lyric == " " ? "ㅇ" : lyric;
+        }
+
+        public override Result ConvertPhonemes(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
+            Note note = notes[0];
+
+            Hashtable lyrics = KoreanPhonemizerUtil.Variate(prevNeighbour, note, nextNeighbour);
+            string[] prevLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
+                HandleEmptyFirstConsonant((string)lyrics[0]), 
+                (string)lyrics[1], 
+                (string)lyrics[2]
+                };
+            string[] thisLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
+                HandleEmptyFirstConsonant((string)lyrics[3]), 
+                (string)lyrics[4], 
+                (string)lyrics[5]
+                };
+            string[] nextLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
+                HandleEmptyFirstConsonant((string)lyrics[6]), 
+                (string)lyrics[7], 
+                (string)lyrics[8]
+                };
+
+            if (thisLyric[0] == "null") { 
+                return GenerateResult(FindInOto(notes[0].lyric, notes[0]));
+            }
+            
+            return ConvertForCBNN(notes, prevLyric, thisLyric, nextLyric, nextNeighbour);
+
+        }
+        
+
+        public override Result GenerateEndSound(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
+            Note note = notes[0];
+            if (prevNeighbour == null) {
+                return GenerateResult(FindInOto(note.lyric, note));
+            }
+
+            Note prevNeighbour_ = (Note)prevNeighbour;
+            Hashtable lyrics = KoreanPhonemizerUtil.Separate(prevNeighbour_.lyric);
+
+            string[] prevLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
+                HandleEmptyFirstConsonant((string)lyrics[0]), 
+                (string)lyrics[1], 
+                (string)lyrics[2]
+                };
+
+            string soundBeforeEndSound = prevLyric[2] == " " ? prevLyric[1] : prevLyric[2];
+            string endSound = note.lyric;
+            string prevMidVowel;
+
+            prevMidVowel = MIDDLE_VOWELS.ContainsKey(soundBeforeEndSound) ? MIDDLE_VOWELS[soundBeforeEndSound][2] : LAST_CONSONANTS[soundBeforeEndSound][0];
+            
+            if (FindInOto($"{prevMidVowel} {endSound}", note, true) == null) {
+                if (FindInOto($"{prevMidVowel}{endSound}", note, true) == null) {
+                    return GenerateResult(FindInOto($"{endSound}", note));
+                }
+                return GenerateResult(FindInOto($"{prevMidVowel}{endSound}", note, true));
+            }
+            return GenerateResult(FindInOto($"{prevMidVowel} {endSound}", note));            
         }
     }
 }

--- a/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
@@ -190,11 +190,11 @@ namespace OpenUtau.Plugin.Builtin {
                 if (isItNeedsFrontCV){
                     return isRelaxedVC ? 
                     GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), totalDuration, 120, 8)
-                    : GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), endSound, totalDuration, 120, 2, 3);
+                    : GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), FindInOto(endSound, note), totalDuration, 120, 2, 3);
                 }
                 return isRelaxedVC ? 
                 GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), totalDuration, 120, 8)
-                : GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), endSound, totalDuration, 120, 2, 3);
+                : GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), FindInOto(endSound, note), totalDuration, 120, 2, 3);
             }
             else {
                 if (isItNeedsFrontCV){

--- a/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
@@ -30,7 +30,6 @@ namespace OpenUtau.Plugin.Builtin {
                     {"Use rentan", false},
                     {"Use 'shi' for '시'(otherwise 'si')", false},
                     {"Use 'i' for '의'(otherwise 'eui')", false},
-                    {"Use 'aX' instead of 'a X'", false}
                 }},
                 {"BATCHIM", new Hashtable(){
                     {"Use 'aX' instead of 'a X'", false}
@@ -65,788 +64,247 @@ namespace OpenUtau.Plugin.Builtin {
             }
         }
         
-        private class KOCV {
-            /// <summary>
-            /// First Consonant's type.
-            /// </summary>
-            public enum ConsonantType{ 
-                /// <summary>예사소리</summary>
-                NORMAL, 
-                /// <summary>거센소리</summary>
-                ASPIRATE, 
-                /// <summary>된소리</summary>
-                FORTIS, 
-                /// <summary>마찰음</summary>
-                FRICATIVE, 
-                /// <summary>비음</summary>
-                NASAL,
-                /// <summary>유음</summary>
-                LIQUID, 
-                /// <summary>ㅎ</summary>
-                H,
-                /// <summary>자음의 음소값 없음(ㅇ)</summary>
-                NOCONSONANT, 
-                /// <summary>음소 자체가 없음</summary>
-                PHONEME_IS_NULL
+        static readonly Dictionary<string, string> FIRST_CONSONANTS = new Dictionary<string, string>(){
+            {"ㄱ", "g"},
+            {"ㄲ", "gg"},
+            {"ㄴ", "n"},
+            {"ㄷ", "d"},
+            {"ㄸ", "dd"},
+            {"ㄹ", "r"},
+            {"ㅁ", "m"},
+            {"ㅂ", "b"},
+            {"ㅃ", "bb"},
+            {"ㅅ", "s"},
+            {"ㅆ", "ss"},
+            {"ㅇ", ""},
+            {"ㅈ", "j"},
+            {"ㅉ", "jj"},
+            {"ㅊ", "ch"},
+            {"ㅋ", "k"},
+            {"ㅌ", "t"},
+            {"ㅍ", "p"},
+            {"ㅎ", "h"},
+            {"null", ""} // 뒤 글자가 없을 때를 대비
+            };
+        
+        static readonly Dictionary<string, string[]> MIDDLE_VOWELS = new Dictionary<string, string[]>(){
+            {"ㅏ", new string[3]{"a", "", "a"}},
+            {"ㅐ", new string[3]{"e", "", "e"}},
+            {"ㅑ", new string[3]{"ya", "y", "a"}},
+            {"ㅒ", new string[3]{"ye", "y", "e"}},
+            {"ㅓ", new string[3]{"eo", "", "eo"}},
+            {"ㅔ", new string[3]{"e", "", "e"}},
+            {"ㅕ", new string[3]{"yeo", "y", "eo"}},
+            {"ㅖ", new string[3]{"ye", "y", "e"}},
+            {"ㅗ", new string[3]{"o", "", "o"}},
+            {"ㅘ", new string[3]{"wa", "w", "a"}},
+            {"ㅙ", new string[3]{"we", "w", "e"}},
+            {"ㅚ", new string[3]{"we", "w", "e"}},
+            {"ㅛ", new string[3]{"yo", "y", "o"}},
+            {"ㅜ", new string[3]{"u", "", "u"}},
+            {"ㅝ", new string[3]{"weo", "w", "eo"}},
+            {"ㅞ", new string[3]{"we", "w", "e"}},
+            {"ㅟ", new string[3]{"wi", "w", "i"}},
+            {"ㅠ", new string[3]{"yu", "y", "u"}},
+            {"ㅡ", new string[3]{"eu", "", "eu"}},
+            {"ㅢ", new string[3]{"eui", "eu", "i"}}, // ㅢ는 ㅣ로 발음
+            {"ㅣ", new string[3]{"i", "", "i"}},
+            {"null", new string[3]{"", "", ""}} // 뒤 글자가 없을 때를 대비
+            };
+        static readonly Dictionary<string, string[]> LAST_CONSONANTS = new Dictionary<string, string[]>(){
+             //ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ
+            {"ㄱ", new string[]{"k", ""}},
+            {"ㄲ", new string[]{"k", ""}},
+            {"ㄳ", new string[]{"k", ""}},
+            {"ㄴ", new string[]{"n", "2"}},
+            {"ㄵ", new string[]{"n", "2"}},
+            {"ㄶ", new string[]{"n", "2"}},
+            {"ㄷ", new string[]{"t", "1"}},
+            {"ㄹ", new string[]{"l", "4"}},
+            {"ㄺ", new string[]{"k", ""}},
+            {"ㄻ", new string[]{"m", "1"}},
+            {"ㄼ", new string[]{"l", "4"}},
+            {"ㄽ", new string[]{"l", "4"}},
+            {"ㄾ", new string[]{"l", "4"}},
+            {"ㄿ", new string[]{"p", "1"}},
+            {"ㅀ", new string[]{"l", "4"}},
+            {"ㅁ", new string[]{"m", "1"}},
+            {"ㅂ", new string[]{"p", "1"}},
+            {"ㅄ", new string[]{"p", "1"}},
+            {"ㅅ", new string[]{"t", "1"}},
+            {"ㅆ", new string[]{"t", "1"}},
+            {"ㅇ", new string[]{"ng", "3"}},
+            {"ㅈ", new string[]{"t", "1"}},
+            {"ㅊ", new string[]{"t", "1"}},
+            {"ㅋ", new string[]{"k", ""}},
+            {"ㅌ", new string[]{"t", "1"}},
+            {"ㅍ", new string[]{"p", "1"}},
+            {"ㅎ", new string[]{"t", "1"}},
+            {" ", new string[]{""}}, // no batchim
+            {"null", new string[]{"", ""}} // 뒤 글자가 없을 때를 대비
+            };
+        
+        private Result ConvertForCV(Note[] notes, string[] prevLyric, string[] thisLyric, string[] nextLyric) {
+            string thisMidVowelHead;
+            string thisMidVowelTail;
+
+            int totalDuration = notes.Sum(n => n.duration);
+            Note note = notes[0];
+            bool isItNeedsFrontCV;
+            bool isRelaxedVC;
+            isItNeedsFrontCV = prevLyric[0] == "null" || prevLyric[1] == "null" || (prevLyric[2] != "null" && HARD_BATCHIMS.Contains(prevLyric[2]) && prevLyric[2] != "ㅁ");
+            isRelaxedVC = nextLyric[0] == "null" || nextLyric[1] == "null" || ((thisLyric[2] == nextLyric[0]) && (KoreanPhonemizerUtil.nasalSounds.ContainsKey(thisLyric[2]) || thisLyric[2] == "ㄹ"));
+
+            if (thisLyric.All(part => part == null)) {
+                return GenerateResult(FindInOto(note.lyric, note));
             }
-
-            /// <summary>
-            /// Last Consonant's type.
-            /// </summary>
-            public enum BatchimType{ 
-                /// <summary>예사소리 받침</summary>
-                NORMAL_END, 
-                /// <summary>비음 받침</summary>
-                NASAL_END,
-                /// <summary>유음 받침</summary>
-                LIQUID_END, 
-                /// <summary>ㅇ받침</summary>
-                NG_END, 
-                /// <summary>ㅎ받침</summary>
-                H_END,
-                /// <summary>받침이 없음</summary>
-                NO_END,
-                /// <summary>음소 자체가 없음</summary>
-                PHONEME_IS_NULL
-            }
-            
-
-            /// <summary>
-            /// CBNN phoneme table of first consonants. (key "null" is for Handling empty string)
-            /// </summary>
-            static readonly Dictionary<string, string[]> FIRST_CONSONANTS = new Dictionary<string, string[]>(){
-                {"ㄱ", new string[2]{"g", ConsonantType.NORMAL.ToString()}},
-                {"ㄲ", new string[2]{"gg", ConsonantType.FORTIS.ToString()}},
-                {"ㄴ", new string[2]{"n", ConsonantType.NASAL.ToString()}},
-                {"ㄷ", new string[2]{"d", ConsonantType.NORMAL.ToString()}},
-                {"ㄸ", new string[2]{"dd", ConsonantType.FORTIS.ToString()}},
-                {"ㄹ", new string[2]{"r", ConsonantType.LIQUID.ToString()}},
-                {"ㅁ", new string[2]{"m", ConsonantType.NASAL.ToString()}},
-                {"ㅂ", new string[2]{"b", ConsonantType.NORMAL.ToString()}},
-                {"ㅃ", new string[2]{"bb", ConsonantType.FORTIS.ToString()}},
-                {"ㅅ", new string[2]{"s", ConsonantType.NORMAL.ToString()}},
-                {"ㅆ", new string[2]{"ss", ConsonantType.FRICATIVE.ToString()}},
-                {"ㅇ", new string[2]{"", ConsonantType.NOCONSONANT.ToString()}},
-                {"ㅈ", new string[2]{"j", ConsonantType.NORMAL.ToString()}},
-                {"ㅉ", new string[2]{"jj", ConsonantType.FORTIS.ToString()}},
-                {"ㅊ", new string[2]{"ch", ConsonantType.ASPIRATE.ToString()}},
-                {"ㅋ", new string[2]{"k", ConsonantType.ASPIRATE.ToString()}},
-                {"ㅌ", new string[2]{"t", ConsonantType.ASPIRATE.ToString()}},
-                {"ㅍ", new string[2]{"p", ConsonantType.ASPIRATE.ToString()}},
-                {"ㅎ", new string[2]{"h", ConsonantType.H.ToString()}},
-                {" ", new string[2]{"", ConsonantType.NOCONSONANT.ToString()}},
-                {"null", new string[2]{"", ConsonantType.PHONEME_IS_NULL.ToString()}} // 뒤 글자가 없을 때를 대비
-                };
-
-            /// <summary>
-            /// CBNN phoneme table of middle vowels (key "null" is for Handling empty string)
-            /// </summary>
-            static readonly Dictionary<string, string[]> MIDDLE_VOWELS = new Dictionary<string, string[]>(){
-                {"ㅏ", new string[3]{"a", "", "a"}},
-                {"ㅐ", new string[3]{"e", "", "e"}},
-                {"ㅑ", new string[3]{"ya", "y", "a"}},
-                {"ㅒ", new string[3]{"ye", "y", "e"}},
-                {"ㅓ", new string[3]{"eo", "", "eo"}},
-                {"ㅔ", new string[3]{"e", "", "e"}},
-                {"ㅕ", new string[3]{"yeo", "y", "eo"}},
-                {"ㅖ", new string[3]{"ye", "y", "e"}},
-                {"ㅗ", new string[3]{"o", "", "o"}},
-                {"ㅘ", new string[3]{"wa", "w", "a"}},
-                {"ㅙ", new string[3]{"we", "w", "e"}},
-                {"ㅚ", new string[3]{"we", "w", "e"}},
-                {"ㅛ", new string[3]{"yo", "y", "o"}},
-                {"ㅜ", new string[3]{"u", "", "u"}},
-                {"ㅝ", new string[3]{"weo", "w", "eo"}},
-                {"ㅞ", new string[3]{"we", "w", "e"}},
-                {"ㅟ", new string[3]{"wi", "w", "i"}},
-                {"ㅠ", new string[3]{"yu", "y", "u"}},
-                {"ㅡ", new string[3]{"eu", "", "eu"}},
-                {"ㅢ", new string[3]{"i", "", "i"}}, // ㅢ는 ㅣ로 발음
-                {"ㅣ", new string[3]{"i", "", "i"}},
-                {" ", new string[3]{"", "", ""}},
-                {"null", new string[3]{"", "", ""}} // 뒤 글자가 없을 때를 대비
-                };
-
-            /// <summary>
-            /// CBNN phoneme table of last consonants. (key "null" is for Handling empty string)
-            /// </summary>
-            static readonly Dictionary<string, string[]> LAST_CONSONANTS = new Dictionary<string, string[]>(){
-                 //ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ
-                {"ㄱ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
-                {"ㄲ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
-                {"ㄳ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
-                {"ㄴ", new string[3]{"n", "2", BatchimType.NASAL_END.ToString()}},
-                {"ㄵ", new string[3]{"n", "2", BatchimType.NASAL_END.ToString()}},
-                {"ㄶ", new string[3]{"n", "2", BatchimType.NASAL_END.ToString()}},
-                {"ㄷ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㄹ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
-                {"ㄺ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
-                {"ㄻ", new string[3]{"m", "1", BatchimType.NASAL_END.ToString()}},
-                {"ㄼ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
-                {"ㄽ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
-                {"ㄾ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
-                {"ㄿ", new string[3]{"p", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅀ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
-                {"ㅁ", new string[3]{"m", "1", BatchimType.NASAL_END.ToString()}},
-                {"ㅂ", new string[3]{"p", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅄ", new string[3]{"p", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅅ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅆ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅇ", new string[3]{"ng", "3", BatchimType.NG_END.ToString()}},
-                {"ㅈ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅊ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅋ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
-                {"ㅌ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅍ", new string[3]{"p", "1", BatchimType.NORMAL_END.ToString()}},
-                {"ㅎ", new string[3]{"t", "1", BatchimType.H_END.ToString()}},
-                {" ", new string[3]{"", "", BatchimType.NO_END.ToString()}},
-                {"null", new string[3]{"", "", BatchimType.PHONEME_IS_NULL.ToString()}} // 뒤 글자가 없을 때를 대비
-                };
-
-
-            private string thisFirstConsonant, thisVowelHead, thisVowelTail, thisLastConsonant;
-            private string nextFirstConsonant, nextVowelHead, nextLastConsonant;
-            private string prevLastConsonant, prevVowelHead; 
-
-            public string VV, CV, cVC, VC, CV_noSuffix; 
-            public string frontCV, frontCV_noSuffix; // - {CV}
-            public string? endSoundVowel, endSoundLastConsonant; // ng -
-            public int cVCLength, vcLength, vcLengthShort; // 받침 종류에 따라 길이가 달라짐 / 이웃이 있을 때에만 사용
-            private int totalDuration;
-
-            private ConsonantType thisFirstConsonantType, prevFirstConsonantType, nextFirstConsonantType;
-            private BatchimType thisLastConsonantType, prevLastConsonantType, nextLastConsonantType;
-            private Note note;
-            private USinger singer;
-
-            public KOCV(USinger singer, Note note, int totalDuration, int vcLength = 120, int vcLengthShort = 90) {
-                this.totalDuration = totalDuration;
-                this.vcLength = vcLength;
-                this.vcLengthShort = vcLengthShort;
-                this.singer = singer;
-                this.note = note;
-            }
-
-            private string? FindInOto(String phoneme, Note note, bool nullIfNotFound=false){
-                return BaseKoreanPhonemizer.FindInOto(singer, phoneme, note, nullIfNotFound);
-            }
-            
-            private Hashtable ConvertForCV(Hashtable separated, bool[] setting) {
-                // Hangeul.Separate() 함수 등을 사용해 [초성 중성 종성]으로 분리된 결과물을 CV식으로 변경
-                Hashtable cvPhonemes; 
-                bool isUsing_aX, isUsing_i, isRentan;
-
-                isUsing_aX = setting[1];
-                isUsing_i = setting[2];
-                isRentan = setting[3];
-
-                cvPhonemes = new Hashtable() {
-                    [0] = FIRST_CONSONANTS[(string)separated[0]][0],
-                    [1] = MIDDLE_VOWELS[(string)separated[1]][1],
-                    [2] = MIDDLE_VOWELS[(string)separated[1]][2],
-                    [3] = LAST_CONSONANTS[(string)separated[2]][0],
-
-                    [4] = FIRST_CONSONANTS[(string)separated[3]][0],
-                    [5] = MIDDLE_VOWELS[(string)separated[4]][1],
-                    [6] = MIDDLE_VOWELS[(string)separated[4]][2],
-                    [7] = LAST_CONSONANTS[(string)separated[5]][0],
-
-                    [8] = FIRST_CONSONANTS[(string)separated[6]][0],
-                    [9] = MIDDLE_VOWELS[(string)separated[7]][1],
-                    [10] = MIDDLE_VOWELS[(string)separated[7]][2],
-                    [11] = LAST_CONSONANTS[(string)separated[8]][0]
-                };
-
-                if (setting[0] && cvPhonemes[4].Equals("s") && cvPhonemes[6].Equals("i")) {
-                    // [isUsingShi], isUsing_aX, isUsing_i, isRentan
-                    cvPhonemes[4] = "sh"; // si to shi
-                } 
-                else if ((!setting[2]) && separated[4].Equals("ㅢ")) {
-                    // isUsingShi, isUsing_aX, [isUsing_i], isRentan
-                    cvPhonemes[5] = "eu"; // to eui
+            else if (thisLyric[1] == "ㅢ") {
+                if (isUsing_i) {
+                    thisMidVowelHead = $"{MIDDLE_VOWELS["ㅣ"][1]}";
+                    thisMidVowelTail = $"{MIDDLE_VOWELS["ㅣ"][2]}";
                 }
-
-                // ex 냥냐 (nya3 ang nya)
-                thisFirstConsonant = (string)cvPhonemes[4]; // n
-                thisVowelHead = (string)cvPhonemes[5]; // y
-                thisVowelTail = (string)cvPhonemes[6]; // a
-                thisLastConsonant = (string)cvPhonemes[7]; // ng
-
-                nextVowelHead = (string)cvPhonemes[9]; // 다음 노트 모음의 머리 음소 / y
-
-                prevLastConsonant = (string)cvPhonemes[3]; // VV음소 만들 때 쓰는 이전 노트의 받침 음소
-
-                
-                CV = $"{thisFirstConsonant}{thisVowelHead}{thisVowelTail}"; // nya
-
-                endSoundVowel = FindInOto($"{thisVowelTail} -", note, true);
-                endSoundLastConsonant = FindInOto($"{thisLastConsonant} -", note, true);
-
-            
-                if (thisLastConsonant.Equals("l")) {
-                // ㄹ받침
-                    cVCLength = totalDuration / 2;
-                } 
-                else if (thisLastConsonant.Equals("n")) {
-                    // ㄴ받침
-                    cVCLength = 170;
-                } 
-                else if (thisLastConsonant.Equals("ng")) {
-                    // ㅇ받침
-                    cVCLength = 230;
-                } 
-                else if (thisLastConsonant.Equals("m")) {
-                    // ㅁ받침
-                    cVCLength = 280;
-                } 
-                else if (thisLastConsonant.Equals("k")) {
-                    // ㄱ받침
-                    cVCLength = totalDuration / 2;
-                } 
-                else if (thisLastConsonant.Equals("t")) {
-                    // ㄷ받침
-                    cVCLength = totalDuration / 2;
-                } 
-                else if (thisLastConsonant.Equals("p")) {
-                    cVCLength = totalDuration / 2;
-                } 
                 else {
-                    // 나머지
-                    cVCLength = totalDuration / 3;
+                    thisMidVowelHead = $"{MIDDLE_VOWELS["ㅢ"][1]}";
+                    thisMidVowelTail = $"{MIDDLE_VOWELS["ㅢ"][2]}";
                 }
-
-                if (thisVowelTail.Equals("u")) {
-                    cVCLength += 50; // 모음이 u일때엔 cVC의 발음 길이가 더 길어짐
-                    vcLength += 50;
-                }
-
-                cVC = isUsing_aX ? $"{thisVowelTail}{thisLastConsonant}" : $"{thisVowelTail} {thisLastConsonant}";
-
-                // ㅢ를 ㅣ로 대체해서 발음하지 않을 때
-                CV = (!isUsing_i && singer.TryGetMappedOto($"{CV}", note.tone, out UOto oto)) ? $"{CV}" : $"{thisFirstConsonant}{thisVowelTail}";
-
-                if (isRentan) {
-                    frontCV = FindInOto($"- {CV}", note, true);
-                    CV = FindInOto($"{CV}", note);
-                    // 연단음 / 어두 음소(-) 사용 
-                    if (frontCV == null) {
-                        frontCV = FindInOto($"-{CV}", note, true);
-                        CV = FindInOto($"{CV}", note);
-
-                        if (frontCV == null) {frontCV = CV;} 
+            }
+            else {
+                thisMidVowelHead = $"{MIDDLE_VOWELS[thisLyric[1]][1]}";
+                thisMidVowelTail = $"{MIDDLE_VOWELS[thisLyric[1]][2]}";
+            }
+            
+            string CV = $"{FIRST_CONSONANTS[thisLyric[0]]}{thisMidVowelHead}{thisMidVowelTail}"; 
+            string frontCV;
+            string batchim;
+            
+            if (isRentan) {
+                frontCV = $"- {CV}";
+                if (FindInOto(frontCV, note, true) == null) {
+                    frontCV = $"-{CV}";
+                    if (FindInOto(frontCV, note, true) == null) {
+                        frontCV = CV;
                     }
                 }
-
-                cVC = FindInOto(cVC, note);
-
-                if (endSoundVowel == null) {endSoundVowel = "";}
-                if (endSoundLastConsonant == null) {endSoundLastConsonant = "";}
-                if (frontCV == null) {frontCV = CV;}
-
-                return cvPhonemes;
             }
-
-            private Hashtable ConvertForCVSingle(Hashtable separated, bool[] setting) {
-                // Hangeul.Separate() 함수 등을 사용해 [초성 중성 종성]으로 분리된 결과물을 CV식으로 변경
-                // 한 글자짜리 노트 받아서 반환함 (숨소리 생성용)
-                Hashtable separatedConvertedForCV;
-
-                separatedConvertedForCV = new Hashtable() {
-                    [0] = FIRST_CONSONANTS[(string)separated[0]][0], // n
-                    [1] = MIDDLE_VOWELS[(string)separated[1]][1], // y
-                    [2] = MIDDLE_VOWELS[(string)separated[1]][2], // a
-                    [3] = LAST_CONSONANTS[(string)separated[2]][0], // ng
-
-                };
-
-                if ((setting[0]) && (separatedConvertedForCV[0].Equals("s")) && (separatedConvertedForCV[2].Equals("i"))) {
-                    // [isUsingShi], isUsing_aX, isUsing_i, isRentan
-                    separatedConvertedForCV[0] = "sh"; // si to shi
-                } else if ((!setting[2]) && (separated[1].Equals("ㅢ"))) {
-                    // isUsingShi, isUsing_aX, [isUsing_i], isRentan
-                    separatedConvertedForCV[2] = "eu"; // to eui
+            else {
+                frontCV = CV;
+            }
+        
+            if (thisLyric[2] == " ") { // no batchim
+                if (isItNeedsFrontCV){
+                    return GenerateResult(FindInOto(frontCV, note));
                 }
-
-                return separatedConvertedForCV;
-            }
-
-            public Hashtable ConvertForCV(Note? prevNeighbour, Note note, Note? nextNeighbour, bool[] setting) {
-                // Hangeul.Separate() 함수 등을 사용해 [초성 중성 종성]으로 분리된 결과물을 CV식으로 변경
-                Hashtable variated = KoreanPhonemizerUtil.Variate(prevNeighbour, note, nextNeighbour);
-
-                thisFirstConsonantType = Enum.Parse<ConsonantType>(FIRST_CONSONANTS[(string)variated[3]][1]);
-                thisLastConsonantType = Enum.Parse<BatchimType>(LAST_CONSONANTS[(string)variated[5]][2]);
-                prevFirstConsonantType = Enum.Parse<ConsonantType>(FIRST_CONSONANTS[(string)variated[0]][1]);
-                prevLastConsonantType = Enum.Parse<BatchimType>(LAST_CONSONANTS[(string)variated[2]][2]);
-                nextFirstConsonantType = Enum.Parse<ConsonantType>(FIRST_CONSONANTS[(string)variated[6]][1]);
-                nextLastConsonantType = Enum.Parse<BatchimType>(LAST_CONSONANTS[(string)variated[8]][2]);
-                
-                return ConvertForCV(variated, setting);
-            }
-
-            public Hashtable ConvertForCV(Note? prevNeighbour, bool[] setting) {
-                return ConvertForCVSingle(KoreanPhonemizerUtil.Variate(prevNeighbour?.lyric), setting);
-            }
-
-            /// <summary>
-            /// true when current Target has Batchim, otherwise false.
-            /// </summary>
-            public bool ThisHasBatchim(){
-                return (!thisLastConsonant.Equals("")) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous Target has Batchim, otherwise false.
-            /// </summary>
-            public bool PrevHasBatchim(){
-                return (!prevLastConsonant.Equals("")) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next Target has Batchim, otherwise false.
-            /// </summary>
-            public bool NextHasBatchim(){
-                return (!nextLastConsonant.Equals("")) ? true : false;
-            }
-            /// <summary>
-            /// true when current FirstConsonant is Normal(ㄱ, ㄷ, ㅂ, ㅅ, ㅈ), otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantIsNormal(){
-                return (thisFirstConsonantType == ConsonantType.NORMAL) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next FirstConsonant is Normal(ㄱ, ㄷ, ㅂ, ㅅ, ㅈ), otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantIsNormal(){
-                return (nextFirstConsonantType == ConsonantType.NORMAL) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous FirstConsonant is Normal(ㄱ, ㄷ, ㅂ, ㅅ, ㅈ), otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantIsNormal(){
-                return (prevFirstConsonantType == ConsonantType.NORMAL) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current FirstConsonant is Fortis(ㄲ, ㄸ, ㅃ, ㅉ), otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantIsFortis(){
-                return (thisFirstConsonantType == ConsonantType.FORTIS) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next FirstConsonant is Fortis(ㄲ, ㄸ, ㅃ, ㅉ), otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantIsFortis(){
-                return (nextFirstConsonantType == ConsonantType.FORTIS) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous FirstConsonant is Fortis(ㄲ, ㄸ, ㅃ, ㅉ), otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantIsFortis(){
-                return (prevFirstConsonantType == ConsonantType.FORTIS) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current FirstConsonant is Aspirate(ㅋ, ㅌ, ㅍ, ㅊ), otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantIsAspirate(){
-                return (thisFirstConsonantType == ConsonantType.ASPIRATE) ? true : false;
+                return GenerateResult(FindInOto(CV, note));
             }
             
-            /// <summary>
-            /// true when next FirstConsonant is Aspirate(ㅋ, ㅌ, ㅍ, ㅊ), otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantIsAspirate(){
-                return (nextFirstConsonantType == ConsonantType.ASPIRATE) ? true : false;
+            if (isUsing_aX) {
+                batchim = $"{thisMidVowelTail}{LAST_CONSONANTS[thisLyric[2]][0]}";
             }
+            else {
+                batchim = $"{thisMidVowelTail} {LAST_CONSONANTS[thisLyric[2]][0]}";
+            }
+            
+            if (thisLyric[2] == "ㅁ" || ! HARD_BATCHIMS.Contains(thisLyric[2])) { // batchim ㅁ + ㄴ ㄹ ㅇ
+                if (isItNeedsFrontCV){
+                    return isRelaxedVC ? 
+                    GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), totalDuration, 120, 8)
+                    : GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), "", totalDuration, 120, 3, 5);
+                }
+                return isRelaxedVC ? 
+                GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), totalDuration, 120, 8)
+                : GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), "", totalDuration, 120, 3, 5);
+            }
+            else {
+                if (isItNeedsFrontCV){
+                    return isRelaxedVC ? 
+                    GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), totalDuration, 120, 8)
+                    : GenerateResult(FindInOto(frontCV, note), FindInOto(batchim, note), totalDuration, 120, 5);
+                }
+                return isRelaxedVC ? 
+                GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), totalDuration, 120, 8)
+                : GenerateResult(FindInOto(CV, note), FindInOto(batchim, note), totalDuration, 120, 5);
+            }
+            
+        }
 
-            /// <summary>
-            /// true when previous FirstConsonant is Aspirate(ㅋ, ㅌ, ㅍ, ㅊ), otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantIsAspirate(){
-                return (prevFirstConsonantType == ConsonantType.ASPIRATE) ? true : false;
-            }
-            /// <summary>
-            /// true when current FirstConsonant is Fricative(ㅆ), otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantIsFricative(){
-                return (thisFirstConsonantType == ConsonantType.FRICATIVE) ? true : false;
-            }
+        private string? FindInOto(String phoneme, Note note, bool nullIfNotFound=false){
+            return BaseKoreanPhonemizer.FindInOto(singer, phoneme, note, nullIfNotFound);
+        }
 
-            /// <summary>
-            /// true when next FirstConsonant is Fricative(ㅆ), otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantIsFricative(){
-                return (nextFirstConsonantType == ConsonantType.FRICATIVE) ? true : false;
-            }
 
-            /// <summary>
-            /// true when previous FirstConsonant is Fricative(ㅆ), otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantIsFricative(){
-                return (prevFirstConsonantType == ConsonantType.FRICATIVE) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current FirstConsonant is ㅇ, otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantIsNone(){
-                return (thisFirstConsonantType == ConsonantType.NOCONSONANT) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next FirstConsonant is ㅇ, otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantIsNone(){
-                return (nextFirstConsonantType == ConsonantType.NOCONSONANT) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous FirstConsonant is ㅇ, otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantIsNone(){
-                return (prevFirstConsonantType == ConsonantType.NOCONSONANT) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current FirstConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantIsNasal(){
-                return (thisFirstConsonantType == ConsonantType.NASAL) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next FirstConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantIsNasal(){
-                return (nextFirstConsonantType == ConsonantType.NASAL) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous FirstConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantIsNasal(){
-                return (prevFirstConsonantType == ConsonantType.NASAL) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current FirstConsonant is Liquid(ㄹ), otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantIsLiquid(){
-                return (thisFirstConsonantType == ConsonantType.LIQUID) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next FirstConsonant is Liquid(ㄹ), otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantIsLiquid(){
-                return (nextFirstConsonantType == ConsonantType.LIQUID) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous FirstConsonant is Liquid(ㄹ), otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantIsLiquid(){
-                return (prevFirstConsonantType == ConsonantType.LIQUID) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current FirstConsonant is ㅎ, otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantIsH(){
-                return (thisFirstConsonantType == ConsonantType.H) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next FirstConsonant is ㅎ, otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantIsH(){
-                return (thisFirstConsonantType == ConsonantType.H) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous FirstConsonant is ㅎ, otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantIsH(){
-                return (prevFirstConsonantType == ConsonantType.H) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current Target is Plain vowel(ㅏ, ㅣ, ㅜ, ㅔ, ㅗ, ㅡ, ㅓ), otherwise false.
-            /// </summary>
-            public bool ThisIsPlainVowel(){
-                return (ThisFirstConsonantIsNone() && thisVowelHead.Equals("")) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next Target is Plain vowel(ㅏ, ㅣ, ㅜ, ㅔ, ㅗ, ㅡ, ㅓ), otherwise false.
-            /// </summary>
-            public bool NextIsPlainVowel(){
-                return (NextFirstConsonantIsNone() && nextVowelHead.Equals("")) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous Target is Plain vowel(ㅏ, ㅣ, ㅜ, ㅔ, ㅗ, ㅡ, ㅓ), otherwise false.
-            /// </summary>
-            public bool PrevIsPlainVowel(){
-                return (PrevFirstConsonantIsNone() && prevVowelHead.Equals("")) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current LastConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
-            /// </summary>
-            public bool ThisLastConsonantIsNasal(){
-                return (thisLastConsonantType == BatchimType.NASAL_END || thisLastConsonantType == BatchimType.NG_END) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next LastConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
-            /// </summary>
-            public bool NextLastConsonantIsNasal(){
-                return (nextLastConsonantType == BatchimType.NASAL_END || nextLastConsonantType == BatchimType.NG_END) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous LastConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
-            /// </summary>
-            public bool PrevLastConsonantIsNasal(){
-                return (prevLastConsonantType == BatchimType.NASAL_END || prevLastConsonantType == BatchimType.NG_END) ? true : false;
-            }
-
-            /// <summary>
-            /// true when current LastConsonant is Liquid(ㄹ), otherwise false.
-            /// </summary>
-            public bool ThisLastConsonantIsLiquid(){
-                return (thisLastConsonantType == BatchimType.LIQUID_END) ? true : false;
-            }
-
-            /// <summary>
-            /// true when next LastConsonant is Liquid(ㄹ), otherwise false.
-            /// </summary>
-            public bool NextLastConsonantIsLiquid(){
-                return (nextLastConsonantType == BatchimType.LIQUID_END) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous LastConsonant is Liquid.(ㄹ), otherwise false.
-            /// </summary>
-            public bool PrevLastConsonantIsLiquid(){
-                return (prevLastConsonantType == BatchimType.LIQUID_END) ? true : false;
-            }
-
-            /// <summary>
-            /// true when previous FirstConsonant is Aspirate or Fortis or Fricative (ㅋ, ㅌ, ㅍ, ㅊ, ㄲ, ㄸ, ㅃ, ㅆ, ㅉ), otherwise false.
-            /// </summary>
-            public bool PrevFirstConsonantNeedsPause(){
-                return (PrevFirstConsonantIsAspirate() || PrevFirstConsonantIsFortis() || PrevFirstConsonantIsFricative());
-            }
-
-            /// <summary>
-            /// true when current FirstConsonant is Aspirate or Fortis or Fricative (ㅋ, ㅌ, ㅍ, ㅊ, ㄲ, ㄸ, ㅃ, ㅆ, ㅉ), otherwise false.
-            /// </summary>
-            public bool ThisFirstConsonantNeedsPause(){
-                return (ThisFirstConsonantIsAspirate() || ThisFirstConsonantIsFortis() || ThisFirstConsonantIsFricative());
-            }
-
-            /// <summary>
-            /// true when next FirstConsonant is Aspirate or Fortis or Fricative (ㅋ, ㅌ, ㅍ, ㅊ, ㄲ, ㄸ, ㅃ, ㅆ, ㅉ), otherwise false.
-            /// </summary>
-            public bool NextFirstConsonantNeedsPause(){
-                return (NextFirstConsonantIsAspirate() || NextFirstConsonantIsFortis() || NextFirstConsonantIsFricative());
-            }
-
-            /// <summary>
-            /// true when current LastConsonant is Nasal or Liquid (ㄴ, ㅇ, ㅁ, ㄹ), otherwise false.
-            /// </summary>
-            public bool ThisLastConsonantIsNasalOrLiquid(){
-                return (ThisLastConsonantIsNasal() || ThisLastConsonantIsLiquid());
-            }
-
-            /// <summary>
-            /// true when next LastConsonant is Nasal or Liquid (ㄴ, ㅇ, ㅁ, ㄹ), otherwise false.
-            /// </summary>
-            public bool NextLastConsonantIsNasalOrLiquid(){
-                return (NextLastConsonantIsNasal() || NextLastConsonantIsLiquid());
-            }
-
-            /// <summary>
-            /// true when previous LastConsonant is Nasal or Liquid (ㄴ, ㅇ, ㅁ, ㄹ), otherwise false.
-            /// </summary>
-            public bool PrevLastConsonantIsNasalOrLiquid(){
-                return (PrevLastConsonantIsNasal() || PrevLastConsonantIsLiquid());
-            }
-
-            /// <summary>
-            /// true when current Target needs VV for Vowel Phoneme(Example: a i, u eo...), otherwise false.
-            /// </summary>
-            public bool ThisVowelNeedsVV(){
-                return ((! PrevHasBatchim()) && ThisIsPlainVowel());
-            }
-
-            /// <summary>
-            /// true when current Target needs CV for Vowel Phoneme(Example: a, ya...), otherwise false.
-            /// </summary>
-            public bool ThisVowelNeedsCV(){
-                return ((ThisFirstConsonantIsNone() && PrevHasBatchim()) || (PrevHasBatchim() && ThisIsPlainVowel()));
-            }
-
-            /// <summary>
-            /// true when current Target needs frontCV for CV Phoneme(Example: - ka), otherwise false.
-            /// </summary>
-            public bool ThisNeedsFrontCV(){
-                return (PrevHasBatchim() && ThisFirstConsonantNeedsPause());
-            }
+        private string HandleEmptyFirstConsonant(string lyric) {
+            return lyric == " " ? "ㅇ" : lyric;
         }
 
         public override Result ConvertPhonemes(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
-            Hashtable cvPhonemes;
-
             Note note = notes[0];
-            string lyric = note.lyric;
-            string phoneticHint = note.phoneticHint;
 
-            Note? prevNote = prevNeighbour; // null or Note
-            Note thisNote = note;
-            Note? nextNote = nextNeighbour; // null or Note
+            Hashtable lyrics = KoreanPhonemizerUtil.Variate(prevNeighbour, note, nextNeighbour);
+            string[] prevLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
+                HandleEmptyFirstConsonant((string)lyrics[0]), 
+                (string)lyrics[1], 
+                (string)lyrics[2]
+                };
+            string[] thisLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
+                HandleEmptyFirstConsonant((string)lyrics[3]), 
+                (string)lyrics[4], 
+                (string)lyrics[5]
+                };
+            string[] nextLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
+                HandleEmptyFirstConsonant((string)lyrics[6]), 
+                (string)lyrics[7], 
+                (string)lyrics[8]
+                };
 
-            int totalDuration = notes.Sum(n => n.duration);
-            int vcLength = 120;
-            int vcLengthShort = 30;
-
-            KOCV cv = new KOCV(singer, thisNote, totalDuration, vcLength, vcLengthShort);
-
-            try{
-                // change lyric to CV phonemes, with phoneme variation.
-                cvPhonemes = cv.ConvertForCV(prevNote, thisNote, nextNote, 
-                        new bool[] {isUsingShi, isUsing_aX, isUsing_i, isRentan});
-            
+            if (thisLyric[0] == "null") { 
+                return GenerateResult(FindInOto(notes[0].lyric, notes[0]));
             }
-            catch {
-                return GenerateResult(lyric);
-            }
             
+            return ConvertForCV(notes, prevLyric, thisLyric, nextLyric);
 
-            // return phonemes
-            if ((prevNeighbour == null) && (nextNeighbour == null)) { // 이웃이 없음 / 냥
-                return (! cv.ThisHasBatchim()) ? GenerateResult(cv.frontCV, cv.endSoundVowel, totalDuration, vcLengthShort, 8) : GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.cVCLength, 8);
-            } 
-            
-            else if ((prevNeighbour != null) && (nextNeighbour == null)) {
-                // 앞에 이웃 있고 뒤에 이웃 없음 / 냥[냥]
-                if (! cv.ThisHasBatchim()) { // 둘다 이웃 있고 받침 없음 / 냥[냐]냥
-                    return cv.ThisNeedsFrontCV() ? GenerateResult(cv.frontCV) : GenerateResult(cv.CV);
-                }
-                else{
-                    return cv.ThisNeedsFrontCV() ? GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.vcLength, 8) : GenerateResult(cv.CV, cv.cVC, totalDuration, cv.vcLength, 8);
-                }
-            }   
-
-            else if ((prevNeighbour == null) && (nextNeighbour != null)) {
-                if (KoreanPhonemizerUtil.IsHangeul(nextNeighbour?.lyric)) {// 뒤 글자가 한글임
-                    if (! cv.ThisHasBatchim()) { // 앞이웃만 없고 받침 없음 / [냐]냥
-                        return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.frontCV, "", totalDuration, vcLength) : GenerateResult(cv.frontCV);
-                    } 
-                    else {
-                        return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.frontCV, cv.cVC, "", totalDuration, cv.cVCLength, 2, 8) : GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.vcLength);
-                    }
-                } 
-                else {
-                    return (! cv.ThisHasBatchim()) ? GenerateResult(cv.frontCV) : GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.vcLength);
-                }
-            } 
-
-            else if ((prevNeighbour != null) && (nextNeighbour != null)) {// 둘다 이웃 있음
-                if (KoreanPhonemizerUtil.IsHangeul(nextNeighbour?.lyric)) {// 뒤의 이웃이 한국어임
-                    if (! cv.ThisHasBatchim()) { // 둘다 이웃 있고 받침 없음 / 냥[냐]냥
-                        if (cv.ThisNeedsFrontCV()) {
-                            return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.frontCV, "", totalDuration, cv.vcLength, 2) : GenerateResult(cv.frontCV);
-                        }
-                        else{// 뒤 음소가 파열음 혹은 된소리일 때엔 VC로 공백을 준다 ))
-                            return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.CV, "", totalDuration, cv.vcLength, 2) : GenerateResult(cv.CV);
-                        }   
-                    }
-                    else{
-                        if (cv.ThisNeedsFrontCV()) {
-                            return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.frontCV, cv.cVC, "", totalDuration, cv.cVCLength, 2, 8) : GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.cVCLength, 2);
-                        }
-                        else{// 뒤 음소가 파열음 혹은 된소리일 때엔 VC로 공백을 준다 ))
-                            return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.CV, cv.cVC, "", totalDuration, cv.cVCLength, 2, 8) : GenerateResult(cv.CV, cv.cVC, totalDuration, cv.cVCLength, 2);
-                        }   
-                    }
-                } 
-                else if ((bool)(nextNeighbour?.lyric.Equals("-")) || (bool)(nextNeighbour?.lyric.Equals("R"))) {
-                    // 둘다 이웃 있고 뒤에 -가 옴
-                    return (! cv.ThisHasBatchim())  ? GenerateResult(cv.CV) : GenerateResult(cv.CV, cv.cVC, totalDuration, cv.cVCLength, 3);
-                } 
-                else {
-                    return (! cv.ThisHasBatchim()) ? GenerateResult(cv.CV) : GenerateResult(cv.CV, cv.cVC, totalDuration, cv.cVCLength, 3);
-                }
-            } 
-            else {
-                return GenerateResult(cv.CV);
-            }
         }
         
 
         public override Result GenerateEndSound(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
-            Hashtable cvPhonemes;
-
             Note note = notes[0];
-            string lyric = note.lyric;
-            string phoneticHint = note.phoneticHint;
-
-            Note? prevNote = prevNeighbour; // null or Note
-            Note thisNote = note;
-            Note? nextNote = nextNeighbour; // null or Note
-
-            int totalDuration = notes.Sum(n => n.duration);
-
-            KOCV cv = new KOCV(singer, thisNote, totalDuration, vcLength, vcLengthShort);
-            string phonemeToReturn = lyric; // 아래에서 아무것도 안 걸리면 그냥 가사 반환
-            string prevLyric = prevNote?.lyric;
-
-            if (phonemeToReturn.Equals("-")) {
-                if (KoreanPhonemizerUtil.IsHangeul(prevLyric)) {
-                    cvPhonemes = cv.ConvertForCV(prevNote, 
-                                new bool[] { isUsingShi, isUsing_aX, isUsing_i, isRentan }); 
-
-                    string prevVowelTail = (string)cvPhonemes[2]; // V이전 노트의 모음 음소 
-                    string prevLastConsonant = (string)cvPhonemes[3]; // 이전 노트의 받침 음소
-
-                    // 앞 노트가 한글
-                    if (!prevLastConsonant.Equals("")) {
-                        phonemeToReturn = $"{prevLastConsonant} -";
-                    } 
-                    else if (!prevVowelTail.Equals("")) {
-                        phonemeToReturn = $"{prevVowelTail} -";
-                    }
-                }
-                return GenerateResult(phonemeToReturn);
-            } 
-            else if (phonemeToReturn.Equals("R")) {
-                if (KoreanPhonemizerUtil.IsHangeul(prevLyric)) {
-                    cvPhonemes = cv.ConvertForCV(prevNote, 
-                                new bool[] { isUsingShi, isUsing_aX, isUsing_i, isRentan }); // [isUsingShi], isUsing_aX, isUsing_i, isRentan
-
-                    string prevVowelTail = (string)cvPhonemes[2]; // V이전 노트의 모음 음소 
-                    string prevLastConsonant = (string)cvPhonemes[3]; // 이전 노트의 받침 음소
-
-                    // 앞 노트가 한글
-                    if (!prevLastConsonant.Equals("")) {
-                        phonemeToReturn = $"{prevLastConsonant} R";
-                    } else if (!prevVowelTail.Equals("")) {
-                        phonemeToReturn = $"{prevVowelTail} R";
-                    }
-
-                }
-                return GenerateResult(phonemeToReturn);
-            } else {
-                return GenerateResult(phonemeToReturn);
+            if (prevNeighbour == null) {
+                return GenerateResult(FindInOto(note.lyric, note));
             }
+
+            Note prevNeighbour_ = (Note)prevNeighbour;
+            Hashtable lyrics = KoreanPhonemizerUtil.Separate(prevNeighbour_.lyric);
+
+            string[] prevLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
+                HandleEmptyFirstConsonant((string)lyrics[0]), 
+                (string)lyrics[1], 
+                (string)lyrics[2]
+                };
+
+            string soundBeforeEndSound = prevLyric[2] == " " ? prevLyric[1] : prevLyric[2];
+            string endSound = note.lyric;
+            string prevMidVowel;
+
+            
+
+            if (prevLyric[1] == "ㅢ") {
+                if (isUsing_i) {
+                    prevMidVowel = $"{MIDDLE_VOWELS["ㅣ"][0]}";
+                }
+                else {
+                    prevMidVowel = $"{MIDDLE_VOWELS["ㅢ"][0]}";
+                }
+            }
+            else{
+                prevMidVowel = MIDDLE_VOWELS.ContainsKey(soundBeforeEndSound) ? MIDDLE_VOWELS[soundBeforeEndSound][2] : LAST_CONSONANTS[soundBeforeEndSound][0];
+            }
+            
+            if (FindInOto($"{prevMidVowel} {endSound}", note, true) == null) {
+                if (FindInOto($"{prevMidVowel}{endSound}", note, true) == null) {
+                    return GenerateResult(FindInOto($"{endSound}", note));
+                }
+                return GenerateResult(FindInOto($"{prevMidVowel}{endSound}", note, true));
+            }
+            return GenerateResult(FindInOto($"{prevMidVowel} {endSound}", note));            
         }
     }
 }

--- a/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
@@ -22,48 +22,49 @@ namespace OpenUtau.Plugin.Builtin {
             this.singer = singer;
             if (this.singer == null) {return;}
 
+            if (this.singer.SingerType != USingerType.Classic){return;}
+
             koreanCVIniSetting = new KoreanCVIniSetting();
-            koreanCVIniSetting.Initialize(singer, "ko-CV.ini");
+            koreanCVIniSetting.Initialize(singer, "ko-CV.ini", new Hashtable(){
+                {"CV", new Hashtable(){
+                    {"Use rentan", false},
+                    {"Use 'shi' for '시'(otherwise 'si')", false},
+                    {"Use 'i' for '의'(otherwise 'eui')", false},
+                    {"Use 'aX' instead of 'a X'", false}
+                }},
+                {"BATCHIM", new Hashtable(){
+                    {"Use 'aX' instead of 'a X'", false}
+                }}
+            });
 
-            isUsingShi = koreanCVIniSetting.IsUsingShi();
-            isUsing_aX = koreanCVIniSetting.IsUsing_aX();
-            isUsing_i = koreanCVIniSetting.IsUsing_i();
-            isRentan = koreanCVIniSetting.IsRentan();
+            isUsingShi = koreanCVIniSetting.isUsingShi;
+            isUsing_aX = koreanCVIniSetting.isUsing_aX;
+            isUsing_i = koreanCVIniSetting.isUsing_i;
+            isRentan = koreanCVIniSetting.isRentan;
         }
-
-
-
 
         private class KoreanCVIniSetting : BaseIniManager{
-            protected override void IniSetUp(IniFile iniFile) {
+            public bool isRentan;
+            public bool isUsingShi;
+            public bool isUsing_aX;
+            public bool isUsing_i;
+
+            protected override void IniSetUp(Hashtable iniSetting) {
                 // ko-CV.ini
-                SetOrReadThisValue("CV", "Use rentan", false); // 연단음 사용 유무 - 기본값 false
-                SetOrReadThisValue("CV", "Use 'shi' for '시'(otherwise 'si')", false); // 시를 [shi]로 표기할 지 유무 - 기본값 false
-                SetOrReadThisValue("CV", "Use 'i' for '의'(otherwise 'eui')", false); // 의를 [i]로 표기할 지 유무 - 기본값 false
-                SetOrReadThisValue("BATCHIM", "Use 'aX' instead of 'a X'", false); // 받침 표기를 a n 처럼 할 지 an 처럼 할지 유무 - 기본값 false(=a n 사용)
-            }
+                SetOrReadThisValue("CV", "Use rentan", false, out var resultValue); // 연단음 사용 유무 - 기본값 false
+                isRentan = resultValue;
+                
+                SetOrReadThisValue("CV", "Use 'shi' for '시'(otherwise 'si')", false, out resultValue); // 시를 [shi]로 표기할 지 유무 - 기본값 false
+                isUsingShi = resultValue;
 
-            public bool IsRentan() {
-                bool isRentan = iniFile["CV"]["Use rentan"].ToBool();
-                return isRentan;
-            }
+                SetOrReadThisValue("CV", "Use 'i' for '의'(otherwise 'eui')", false, out resultValue); // 의를 [i]로 표기할 지 유무 - 기본값 false
+                isUsing_i = resultValue;
 
-            public bool IsUsingShi() {
-                bool isUsingShi = iniFile["CV"]["Use 'shi' for '시'(otherwise 'si')"].ToBool();
-                return isUsingShi;
+                SetOrReadThisValue("BATCHIM", "Use 'aX' instead of 'a X'", false, out resultValue); // 받침 표기를 a n 처럼 할 지 an 처럼 할지 유무 - 기본값 false(=a n 사용)
+                isUsing_aX = resultValue;
             }
-
-            public bool IsUsing_aX() {
-                bool isUsing_aX = iniFile["BATCHIM"]["Use 'aX' instead of 'a X'"].ToBool();
-                return isUsing_aX;
-            }
-
-            public bool IsUsing_i() {
-                bool isUsing_i = iniFile["CV"]["Use 'i' for '의'(otherwise 'eui')"].ToBool();
-                return isUsing_i;
-            }
-
         }
+        
         private class KOCV {
             /// <summary>
             /// First Consonant's type.

--- a/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
@@ -1,0 +1,851 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using OpenUtau.Api;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core;
+
+namespace OpenUtau.Plugin.Builtin {
+    /// Phonemizer for 'KOR CV' ///
+    [Phonemizer("Korean CV Phonemizer", "KO CV", "EX3", language: "KO")]
+
+    public class KoreanCVPhonemizer : BaseKoreanPhonemizer {
+
+        // 1. Load Singer and Settings
+        private KoreanCVIniSetting koreanCVIniSetting; // Manages Setting
+
+        public bool isUsingShi, isUsing_aX, isUsing_i, isRentan;
+
+        public override void SetSinger(USinger singer) {
+            if (this.singer == singer) {return;}
+            this.singer = singer;
+            if (this.singer == null) {return;}
+
+            koreanCVIniSetting = new KoreanCVIniSetting();
+            koreanCVIniSetting.Initialize(singer, "ko-CV.ini");
+
+            isUsingShi = koreanCVIniSetting.IsUsingShi();
+            isUsing_aX = koreanCVIniSetting.IsUsing_aX();
+            isUsing_i = koreanCVIniSetting.IsUsing_i();
+            isRentan = koreanCVIniSetting.IsRentan();
+        }
+
+
+
+
+        private class KoreanCVIniSetting : BaseIniManager{
+            protected override void IniSetUp(IniFile iniFile) {
+                // ko-CV.ini
+                SetOrReadThisValue("CV", "Use rentan", false); // 연단음 사용 유무 - 기본값 false
+                SetOrReadThisValue("CV", "Use 'shi' for '시'(otherwise 'si')", false); // 시를 [shi]로 표기할 지 유무 - 기본값 false
+                SetOrReadThisValue("CV", "Use 'i' for '의'(otherwise 'eui')", false); // 의를 [i]로 표기할 지 유무 - 기본값 false
+                SetOrReadThisValue("BATCHIM", "Use 'aX' instead of 'a X'", false); // 받침 표기를 a n 처럼 할 지 an 처럼 할지 유무 - 기본값 false(=a n 사용)
+            }
+
+            public bool IsRentan() {
+                bool isRentan = iniFile["CV"]["Use rentan"].ToBool();
+                return isRentan;
+            }
+
+            public bool IsUsingShi() {
+                bool isUsingShi = iniFile["CV"]["Use 'shi' for '시'(otherwise 'si')"].ToBool();
+                return isUsingShi;
+            }
+
+            public bool IsUsing_aX() {
+                bool isUsing_aX = iniFile["BATCHIM"]["Use 'aX' instead of 'a X'"].ToBool();
+                return isUsing_aX;
+            }
+
+            public bool IsUsing_i() {
+                bool isUsing_i = iniFile["CV"]["Use 'i' for '의'(otherwise 'eui')"].ToBool();
+                return isUsing_i;
+            }
+
+        }
+        private class KOCV {
+            /// <summary>
+            /// First Consonant's type.
+            /// </summary>
+            public enum ConsonantType{ 
+                /// <summary>예사소리</summary>
+                NORMAL, 
+                /// <summary>거센소리</summary>
+                ASPIRATE, 
+                /// <summary>된소리</summary>
+                FORTIS, 
+                /// <summary>마찰음</summary>
+                FRICATIVE, 
+                /// <summary>비음</summary>
+                NASAL,
+                /// <summary>유음</summary>
+                LIQUID, 
+                /// <summary>ㅎ</summary>
+                H,
+                /// <summary>자음의 음소값 없음(ㅇ)</summary>
+                NOCONSONANT, 
+                /// <summary>음소 자체가 없음</summary>
+                PHONEME_IS_NULL
+            }
+
+            /// <summary>
+            /// Last Consonant's type.
+            /// </summary>
+            public enum BatchimType{ 
+                /// <summary>예사소리 받침</summary>
+                NORMAL_END, 
+                /// <summary>비음 받침</summary>
+                NASAL_END,
+                /// <summary>유음 받침</summary>
+                LIQUID_END, 
+                /// <summary>ㅇ받침</summary>
+                NG_END, 
+                /// <summary>ㅎ받침</summary>
+                H_END,
+                /// <summary>받침이 없음</summary>
+                NO_END,
+                /// <summary>음소 자체가 없음</summary>
+                PHONEME_IS_NULL
+            }
+            
+
+            /// <summary>
+            /// CBNN phoneme table of first consonants. (key "null" is for Handling empty string)
+            /// </summary>
+            static readonly Dictionary<string, string[]> FIRST_CONSONANTS = new Dictionary<string, string[]>(){
+                {"ㄱ", new string[2]{"g", ConsonantType.NORMAL.ToString()}},
+                {"ㄲ", new string[2]{"gg", ConsonantType.FORTIS.ToString()}},
+                {"ㄴ", new string[2]{"n", ConsonantType.NASAL.ToString()}},
+                {"ㄷ", new string[2]{"d", ConsonantType.NORMAL.ToString()}},
+                {"ㄸ", new string[2]{"dd", ConsonantType.FORTIS.ToString()}},
+                {"ㄹ", new string[2]{"r", ConsonantType.LIQUID.ToString()}},
+                {"ㅁ", new string[2]{"m", ConsonantType.NASAL.ToString()}},
+                {"ㅂ", new string[2]{"b", ConsonantType.NORMAL.ToString()}},
+                {"ㅃ", new string[2]{"bb", ConsonantType.FORTIS.ToString()}},
+                {"ㅅ", new string[2]{"s", ConsonantType.NORMAL.ToString()}},
+                {"ㅆ", new string[2]{"ss", ConsonantType.FRICATIVE.ToString()}},
+                {"ㅇ", new string[2]{"", ConsonantType.NOCONSONANT.ToString()}},
+                {"ㅈ", new string[2]{"j", ConsonantType.NORMAL.ToString()}},
+                {"ㅉ", new string[2]{"jj", ConsonantType.FORTIS.ToString()}},
+                {"ㅊ", new string[2]{"ch", ConsonantType.ASPIRATE.ToString()}},
+                {"ㅋ", new string[2]{"k", ConsonantType.ASPIRATE.ToString()}},
+                {"ㅌ", new string[2]{"t", ConsonantType.ASPIRATE.ToString()}},
+                {"ㅍ", new string[2]{"p", ConsonantType.ASPIRATE.ToString()}},
+                {"ㅎ", new string[2]{"h", ConsonantType.H.ToString()}},
+                {" ", new string[2]{"", ConsonantType.NOCONSONANT.ToString()}},
+                {"null", new string[2]{"", ConsonantType.PHONEME_IS_NULL.ToString()}} // 뒤 글자가 없을 때를 대비
+                };
+
+            /// <summary>
+            /// CBNN phoneme table of middle vowels (key "null" is for Handling empty string)
+            /// </summary>
+            static readonly Dictionary<string, string[]> MIDDLE_VOWELS = new Dictionary<string, string[]>(){
+                {"ㅏ", new string[3]{"a", "", "a"}},
+                {"ㅐ", new string[3]{"e", "", "e"}},
+                {"ㅑ", new string[3]{"ya", "y", "a"}},
+                {"ㅒ", new string[3]{"ye", "y", "e"}},
+                {"ㅓ", new string[3]{"eo", "", "eo"}},
+                {"ㅔ", new string[3]{"e", "", "e"}},
+                {"ㅕ", new string[3]{"yeo", "y", "eo"}},
+                {"ㅖ", new string[3]{"ye", "y", "e"}},
+                {"ㅗ", new string[3]{"o", "", "o"}},
+                {"ㅘ", new string[3]{"wa", "w", "a"}},
+                {"ㅙ", new string[3]{"we", "w", "e"}},
+                {"ㅚ", new string[3]{"we", "w", "e"}},
+                {"ㅛ", new string[3]{"yo", "y", "o"}},
+                {"ㅜ", new string[3]{"u", "", "u"}},
+                {"ㅝ", new string[3]{"weo", "w", "eo"}},
+                {"ㅞ", new string[3]{"we", "w", "e"}},
+                {"ㅟ", new string[3]{"wi", "w", "i"}},
+                {"ㅠ", new string[3]{"yu", "y", "u"}},
+                {"ㅡ", new string[3]{"eu", "", "eu"}},
+                {"ㅢ", new string[3]{"i", "", "i"}}, // ㅢ는 ㅣ로 발음
+                {"ㅣ", new string[3]{"i", "", "i"}},
+                {" ", new string[3]{"", "", ""}},
+                {"null", new string[3]{"", "", ""}} // 뒤 글자가 없을 때를 대비
+                };
+
+            /// <summary>
+            /// CBNN phoneme table of last consonants. (key "null" is for Handling empty string)
+            /// </summary>
+            static readonly Dictionary<string, string[]> LAST_CONSONANTS = new Dictionary<string, string[]>(){
+                 //ㄱㄲㄳㄴㄵㄶㄷㄹㄺㄻㄼㄽㄾㄿㅀㅁㅂㅄㅅㅆㅇㅈㅊㅋㅌㅍㅎ
+                {"ㄱ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
+                {"ㄲ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
+                {"ㄳ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
+                {"ㄴ", new string[3]{"n", "2", BatchimType.NASAL_END.ToString()}},
+                {"ㄵ", new string[3]{"n", "2", BatchimType.NASAL_END.ToString()}},
+                {"ㄶ", new string[3]{"n", "2", BatchimType.NASAL_END.ToString()}},
+                {"ㄷ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㄹ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
+                {"ㄺ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
+                {"ㄻ", new string[3]{"m", "1", BatchimType.NASAL_END.ToString()}},
+                {"ㄼ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
+                {"ㄽ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
+                {"ㄾ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
+                {"ㄿ", new string[3]{"p", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅀ", new string[3]{"l", "4", BatchimType.LIQUID_END.ToString()}},
+                {"ㅁ", new string[3]{"m", "1", BatchimType.NASAL_END.ToString()}},
+                {"ㅂ", new string[3]{"p", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅄ", new string[3]{"p", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅅ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅆ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅇ", new string[3]{"ng", "3", BatchimType.NG_END.ToString()}},
+                {"ㅈ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅊ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅋ", new string[3]{"k", "", BatchimType.NORMAL_END.ToString()}},
+                {"ㅌ", new string[3]{"t", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅍ", new string[3]{"p", "1", BatchimType.NORMAL_END.ToString()}},
+                {"ㅎ", new string[3]{"t", "1", BatchimType.H_END.ToString()}},
+                {" ", new string[3]{"", "", BatchimType.NO_END.ToString()}},
+                {"null", new string[3]{"", "", BatchimType.PHONEME_IS_NULL.ToString()}} // 뒤 글자가 없을 때를 대비
+                };
+
+
+            private string thisFirstConsonant, thisVowelHead, thisVowelTail, thisLastConsonant;
+            private string nextFirstConsonant, nextVowelHead, nextLastConsonant;
+            private string prevLastConsonant, prevVowelHead; 
+
+            public string VV, CV, cVC, VC, CV_noSuffix; 
+            public string frontCV, frontCV_noSuffix; // - {CV}
+            public string? endSoundVowel, endSoundLastConsonant; // ng -
+            public int cVCLength, vcLength, vcLengthShort; // 받침 종류에 따라 길이가 달라짐 / 이웃이 있을 때에만 사용
+            private int totalDuration;
+
+            private ConsonantType thisFirstConsonantType, prevFirstConsonantType, nextFirstConsonantType;
+            private BatchimType thisLastConsonantType, prevLastConsonantType, nextLastConsonantType;
+            private Note note;
+            private USinger singer;
+
+            public KOCV(USinger singer, Note note, int totalDuration, int vcLength = 120, int vcLengthShort = 90) {
+                this.totalDuration = totalDuration;
+                this.vcLength = vcLength;
+                this.vcLengthShort = vcLengthShort;
+                this.singer = singer;
+                this.note = note;
+            }
+
+            private string? FindInOto(String phoneme, Note note, bool nullIfNotFound=false){
+                return BaseKoreanPhonemizer.FindInOto(singer, phoneme, note, nullIfNotFound);
+            }
+            
+            private Hashtable ConvertForCV(Hashtable separated, bool[] setting) {
+                // Hangeul.Separate() 함수 등을 사용해 [초성 중성 종성]으로 분리된 결과물을 CV식으로 변경
+                Hashtable cvPhonemes; 
+                bool isUsing_aX, isUsing_i, isRentan;
+
+                isUsing_aX = setting[1];
+                isUsing_i = setting[2];
+                isRentan = setting[3];
+
+                cvPhonemes = new Hashtable() {
+                    [0] = FIRST_CONSONANTS[(string)separated[0]][0],
+                    [1] = MIDDLE_VOWELS[(string)separated[1]][1],
+                    [2] = MIDDLE_VOWELS[(string)separated[1]][2],
+                    [3] = LAST_CONSONANTS[(string)separated[2]][0],
+
+                    [4] = FIRST_CONSONANTS[(string)separated[3]][0],
+                    [5] = MIDDLE_VOWELS[(string)separated[4]][1],
+                    [6] = MIDDLE_VOWELS[(string)separated[4]][2],
+                    [7] = LAST_CONSONANTS[(string)separated[5]][0],
+
+                    [8] = FIRST_CONSONANTS[(string)separated[6]][0],
+                    [9] = MIDDLE_VOWELS[(string)separated[7]][1],
+                    [10] = MIDDLE_VOWELS[(string)separated[7]][2],
+                    [11] = LAST_CONSONANTS[(string)separated[8]][0]
+                };
+
+                if (setting[0] && cvPhonemes[4].Equals("s") && cvPhonemes[6].Equals("i")) {
+                    // [isUsingShi], isUsing_aX, isUsing_i, isRentan
+                    cvPhonemes[4] = "sh"; // si to shi
+                } 
+                else if ((!setting[2]) && separated[4].Equals("ㅢ")) {
+                    // isUsingShi, isUsing_aX, [isUsing_i], isRentan
+                    cvPhonemes[5] = "eu"; // to eui
+                }
+
+                // ex 냥냐 (nya3 ang nya)
+                thisFirstConsonant = (string)cvPhonemes[4]; // n
+                thisVowelHead = (string)cvPhonemes[5]; // y
+                thisVowelTail = (string)cvPhonemes[6]; // a
+                thisLastConsonant = (string)cvPhonemes[7]; // ng
+
+                nextVowelHead = (string)cvPhonemes[9]; // 다음 노트 모음의 머리 음소 / y
+
+                prevLastConsonant = (string)cvPhonemes[3]; // VV음소 만들 때 쓰는 이전 노트의 받침 음소
+
+                
+                CV = $"{thisFirstConsonant}{thisVowelHead}{thisVowelTail}"; // nya
+
+                endSoundVowel = FindInOto($"{thisVowelTail} -", note, true);
+                endSoundLastConsonant = FindInOto($"{thisLastConsonant} -", note, true);
+
+            
+                if (thisLastConsonant.Equals("l")) {
+                // ㄹ받침
+                    cVCLength = totalDuration / 2;
+                } 
+                else if (thisLastConsonant.Equals("n")) {
+                    // ㄴ받침
+                    cVCLength = 170;
+                } 
+                else if (thisLastConsonant.Equals("ng")) {
+                    // ㅇ받침
+                    cVCLength = 230;
+                } 
+                else if (thisLastConsonant.Equals("m")) {
+                    // ㅁ받침
+                    cVCLength = 280;
+                } 
+                else if (thisLastConsonant.Equals("k")) {
+                    // ㄱ받침
+                    cVCLength = totalDuration / 2;
+                } 
+                else if (thisLastConsonant.Equals("t")) {
+                    // ㄷ받침
+                    cVCLength = totalDuration / 2;
+                } 
+                else if (thisLastConsonant.Equals("p")) {
+                    cVCLength = totalDuration / 2;
+                } 
+                else {
+                    // 나머지
+                    cVCLength = totalDuration / 3;
+                }
+
+                if (thisVowelTail.Equals("u")) {
+                    cVCLength += 50; // 모음이 u일때엔 cVC의 발음 길이가 더 길어짐
+                    vcLength += 50;
+                }
+
+                cVC = isUsing_aX ? $"{thisVowelTail}{thisLastConsonant}" : $"{thisVowelTail} {thisLastConsonant}";
+
+                // ㅢ를 ㅣ로 대체해서 발음하지 않을 때
+                CV = (!isUsing_i && singer.TryGetMappedOto($"{CV}", note.tone, out UOto oto)) ? $"{CV}" : $"{thisFirstConsonant}{thisVowelTail}";
+
+                if (isRentan) {
+                    frontCV = FindInOto($"- {CV}", note, true);
+                    CV = FindInOto($"{CV}", note);
+                    // 연단음 / 어두 음소(-) 사용 
+                    if (frontCV == null) {
+                        frontCV = FindInOto($"-{CV}", note, true);
+                        CV = FindInOto($"{CV}", note);
+
+                        if (frontCV == null) {frontCV = CV;} 
+                    }
+                }
+
+                cVC = FindInOto(cVC, note);
+
+                if (endSoundVowel == null) {endSoundVowel = "";}
+                if (endSoundLastConsonant == null) {endSoundLastConsonant = "";}
+                if (frontCV == null) {frontCV = CV;}
+
+                return cvPhonemes;
+            }
+
+            private Hashtable ConvertForCVSingle(Hashtable separated, bool[] setting) {
+                // Hangeul.Separate() 함수 등을 사용해 [초성 중성 종성]으로 분리된 결과물을 CV식으로 변경
+                // 한 글자짜리 노트 받아서 반환함 (숨소리 생성용)
+                Hashtable separatedConvertedForCV;
+
+                separatedConvertedForCV = new Hashtable() {
+                    [0] = FIRST_CONSONANTS[(string)separated[0]][0], // n
+                    [1] = MIDDLE_VOWELS[(string)separated[1]][1], // y
+                    [2] = MIDDLE_VOWELS[(string)separated[1]][2], // a
+                    [3] = LAST_CONSONANTS[(string)separated[2]][0], // ng
+
+                };
+
+                if ((setting[0]) && (separatedConvertedForCV[0].Equals("s")) && (separatedConvertedForCV[2].Equals("i"))) {
+                    // [isUsingShi], isUsing_aX, isUsing_i, isRentan
+                    separatedConvertedForCV[0] = "sh"; // si to shi
+                } else if ((!setting[2]) && (separated[1].Equals("ㅢ"))) {
+                    // isUsingShi, isUsing_aX, [isUsing_i], isRentan
+                    separatedConvertedForCV[2] = "eu"; // to eui
+                }
+
+                return separatedConvertedForCV;
+            }
+
+            public Hashtable ConvertForCV(Note? prevNeighbour, Note note, Note? nextNeighbour, bool[] setting) {
+                // Hangeul.Separate() 함수 등을 사용해 [초성 중성 종성]으로 분리된 결과물을 CV식으로 변경
+                Hashtable variated = KoreanPhonemizerUtil.Variate(prevNeighbour, note, nextNeighbour);
+
+                thisFirstConsonantType = Enum.Parse<ConsonantType>(FIRST_CONSONANTS[(string)variated[3]][1]);
+                thisLastConsonantType = Enum.Parse<BatchimType>(LAST_CONSONANTS[(string)variated[5]][2]);
+                prevFirstConsonantType = Enum.Parse<ConsonantType>(FIRST_CONSONANTS[(string)variated[0]][1]);
+                prevLastConsonantType = Enum.Parse<BatchimType>(LAST_CONSONANTS[(string)variated[2]][2]);
+                nextFirstConsonantType = Enum.Parse<ConsonantType>(FIRST_CONSONANTS[(string)variated[6]][1]);
+                nextLastConsonantType = Enum.Parse<BatchimType>(LAST_CONSONANTS[(string)variated[8]][2]);
+                
+                return ConvertForCV(variated, setting);
+            }
+
+            public Hashtable ConvertForCV(Note? prevNeighbour, bool[] setting) {
+                return ConvertForCVSingle(KoreanPhonemizerUtil.Variate(prevNeighbour?.lyric), setting);
+            }
+
+            /// <summary>
+            /// true when current Target has Batchim, otherwise false.
+            /// </summary>
+            public bool ThisHasBatchim(){
+                return (!thisLastConsonant.Equals("")) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous Target has Batchim, otherwise false.
+            /// </summary>
+            public bool PrevHasBatchim(){
+                return (!prevLastConsonant.Equals("")) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next Target has Batchim, otherwise false.
+            /// </summary>
+            public bool NextHasBatchim(){
+                return (!nextLastConsonant.Equals("")) ? true : false;
+            }
+            /// <summary>
+            /// true when current FirstConsonant is Normal(ㄱ, ㄷ, ㅂ, ㅅ, ㅈ), otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantIsNormal(){
+                return (thisFirstConsonantType == ConsonantType.NORMAL) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next FirstConsonant is Normal(ㄱ, ㄷ, ㅂ, ㅅ, ㅈ), otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantIsNormal(){
+                return (nextFirstConsonantType == ConsonantType.NORMAL) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is Normal(ㄱ, ㄷ, ㅂ, ㅅ, ㅈ), otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantIsNormal(){
+                return (prevFirstConsonantType == ConsonantType.NORMAL) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current FirstConsonant is Fortis(ㄲ, ㄸ, ㅃ, ㅉ), otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantIsFortis(){
+                return (thisFirstConsonantType == ConsonantType.FORTIS) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next FirstConsonant is Fortis(ㄲ, ㄸ, ㅃ, ㅉ), otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantIsFortis(){
+                return (nextFirstConsonantType == ConsonantType.FORTIS) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is Fortis(ㄲ, ㄸ, ㅃ, ㅉ), otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantIsFortis(){
+                return (prevFirstConsonantType == ConsonantType.FORTIS) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current FirstConsonant is Aspirate(ㅋ, ㅌ, ㅍ, ㅊ), otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantIsAspirate(){
+                return (thisFirstConsonantType == ConsonantType.ASPIRATE) ? true : false;
+            }
+            
+            /// <summary>
+            /// true when next FirstConsonant is Aspirate(ㅋ, ㅌ, ㅍ, ㅊ), otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantIsAspirate(){
+                return (nextFirstConsonantType == ConsonantType.ASPIRATE) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is Aspirate(ㅋ, ㅌ, ㅍ, ㅊ), otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantIsAspirate(){
+                return (prevFirstConsonantType == ConsonantType.ASPIRATE) ? true : false;
+            }
+            /// <summary>
+            /// true when current FirstConsonant is Fricative(ㅆ), otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantIsFricative(){
+                return (thisFirstConsonantType == ConsonantType.FRICATIVE) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next FirstConsonant is Fricative(ㅆ), otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantIsFricative(){
+                return (nextFirstConsonantType == ConsonantType.FRICATIVE) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is Fricative(ㅆ), otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantIsFricative(){
+                return (prevFirstConsonantType == ConsonantType.FRICATIVE) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current FirstConsonant is ㅇ, otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantIsNone(){
+                return (thisFirstConsonantType == ConsonantType.NOCONSONANT) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next FirstConsonant is ㅇ, otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantIsNone(){
+                return (nextFirstConsonantType == ConsonantType.NOCONSONANT) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is ㅇ, otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantIsNone(){
+                return (prevFirstConsonantType == ConsonantType.NOCONSONANT) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current FirstConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantIsNasal(){
+                return (thisFirstConsonantType == ConsonantType.NASAL) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next FirstConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantIsNasal(){
+                return (nextFirstConsonantType == ConsonantType.NASAL) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantIsNasal(){
+                return (prevFirstConsonantType == ConsonantType.NASAL) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current FirstConsonant is Liquid(ㄹ), otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantIsLiquid(){
+                return (thisFirstConsonantType == ConsonantType.LIQUID) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next FirstConsonant is Liquid(ㄹ), otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantIsLiquid(){
+                return (nextFirstConsonantType == ConsonantType.LIQUID) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is Liquid(ㄹ), otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantIsLiquid(){
+                return (prevFirstConsonantType == ConsonantType.LIQUID) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current FirstConsonant is ㅎ, otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantIsH(){
+                return (thisFirstConsonantType == ConsonantType.H) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next FirstConsonant is ㅎ, otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantIsH(){
+                return (thisFirstConsonantType == ConsonantType.H) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is ㅎ, otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantIsH(){
+                return (prevFirstConsonantType == ConsonantType.H) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current Target is Plain vowel(ㅏ, ㅣ, ㅜ, ㅔ, ㅗ, ㅡ, ㅓ), otherwise false.
+            /// </summary>
+            public bool ThisIsPlainVowel(){
+                return (ThisFirstConsonantIsNone() && thisVowelHead.Equals("")) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next Target is Plain vowel(ㅏ, ㅣ, ㅜ, ㅔ, ㅗ, ㅡ, ㅓ), otherwise false.
+            /// </summary>
+            public bool NextIsPlainVowel(){
+                return (NextFirstConsonantIsNone() && nextVowelHead.Equals("")) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous Target is Plain vowel(ㅏ, ㅣ, ㅜ, ㅔ, ㅗ, ㅡ, ㅓ), otherwise false.
+            /// </summary>
+            public bool PrevIsPlainVowel(){
+                return (PrevFirstConsonantIsNone() && prevVowelHead.Equals("")) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current LastConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
+            /// </summary>
+            public bool ThisLastConsonantIsNasal(){
+                return (thisLastConsonantType == BatchimType.NASAL_END || thisLastConsonantType == BatchimType.NG_END) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next LastConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
+            /// </summary>
+            public bool NextLastConsonantIsNasal(){
+                return (nextLastConsonantType == BatchimType.NASAL_END || nextLastConsonantType == BatchimType.NG_END) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous LastConsonant is Nasal(ㄴ, ㅇ, ㅁ), otherwise false.
+            /// </summary>
+            public bool PrevLastConsonantIsNasal(){
+                return (prevLastConsonantType == BatchimType.NASAL_END || prevLastConsonantType == BatchimType.NG_END) ? true : false;
+            }
+
+            /// <summary>
+            /// true when current LastConsonant is Liquid(ㄹ), otherwise false.
+            /// </summary>
+            public bool ThisLastConsonantIsLiquid(){
+                return (thisLastConsonantType == BatchimType.LIQUID_END) ? true : false;
+            }
+
+            /// <summary>
+            /// true when next LastConsonant is Liquid(ㄹ), otherwise false.
+            /// </summary>
+            public bool NextLastConsonantIsLiquid(){
+                return (nextLastConsonantType == BatchimType.LIQUID_END) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous LastConsonant is Liquid.(ㄹ), otherwise false.
+            /// </summary>
+            public bool PrevLastConsonantIsLiquid(){
+                return (prevLastConsonantType == BatchimType.LIQUID_END) ? true : false;
+            }
+
+            /// <summary>
+            /// true when previous FirstConsonant is Aspirate or Fortis or Fricative (ㅋ, ㅌ, ㅍ, ㅊ, ㄲ, ㄸ, ㅃ, ㅆ, ㅉ), otherwise false.
+            /// </summary>
+            public bool PrevFirstConsonantNeedsPause(){
+                return (PrevFirstConsonantIsAspirate() || PrevFirstConsonantIsFortis() || PrevFirstConsonantIsFricative());
+            }
+
+            /// <summary>
+            /// true when current FirstConsonant is Aspirate or Fortis or Fricative (ㅋ, ㅌ, ㅍ, ㅊ, ㄲ, ㄸ, ㅃ, ㅆ, ㅉ), otherwise false.
+            /// </summary>
+            public bool ThisFirstConsonantNeedsPause(){
+                return (ThisFirstConsonantIsAspirate() || ThisFirstConsonantIsFortis() || ThisFirstConsonantIsFricative());
+            }
+
+            /// <summary>
+            /// true when next FirstConsonant is Aspirate or Fortis or Fricative (ㅋ, ㅌ, ㅍ, ㅊ, ㄲ, ㄸ, ㅃ, ㅆ, ㅉ), otherwise false.
+            /// </summary>
+            public bool NextFirstConsonantNeedsPause(){
+                return (NextFirstConsonantIsAspirate() || NextFirstConsonantIsFortis() || NextFirstConsonantIsFricative());
+            }
+
+            /// <summary>
+            /// true when current LastConsonant is Nasal or Liquid (ㄴ, ㅇ, ㅁ, ㄹ), otherwise false.
+            /// </summary>
+            public bool ThisLastConsonantIsNasalOrLiquid(){
+                return (ThisLastConsonantIsNasal() || ThisLastConsonantIsLiquid());
+            }
+
+            /// <summary>
+            /// true when next LastConsonant is Nasal or Liquid (ㄴ, ㅇ, ㅁ, ㄹ), otherwise false.
+            /// </summary>
+            public bool NextLastConsonantIsNasalOrLiquid(){
+                return (NextLastConsonantIsNasal() || NextLastConsonantIsLiquid());
+            }
+
+            /// <summary>
+            /// true when previous LastConsonant is Nasal or Liquid (ㄴ, ㅇ, ㅁ, ㄹ), otherwise false.
+            /// </summary>
+            public bool PrevLastConsonantIsNasalOrLiquid(){
+                return (PrevLastConsonantIsNasal() || PrevLastConsonantIsLiquid());
+            }
+
+            /// <summary>
+            /// true when current Target needs VV for Vowel Phoneme(Example: a i, u eo...), otherwise false.
+            /// </summary>
+            public bool ThisVowelNeedsVV(){
+                return ((! PrevHasBatchim()) && ThisIsPlainVowel());
+            }
+
+            /// <summary>
+            /// true when current Target needs CV for Vowel Phoneme(Example: a, ya...), otherwise false.
+            /// </summary>
+            public bool ThisVowelNeedsCV(){
+                return ((ThisFirstConsonantIsNone() && PrevHasBatchim()) || (PrevHasBatchim() && ThisIsPlainVowel()));
+            }
+
+            /// <summary>
+            /// true when current Target needs frontCV for CV Phoneme(Example: - ka), otherwise false.
+            /// </summary>
+            public bool ThisNeedsFrontCV(){
+                return (PrevHasBatchim() && ThisFirstConsonantNeedsPause());
+            }
+        }
+
+        public override Result ConvertPhonemes(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
+            Hashtable cvPhonemes;
+
+            Note note = notes[0];
+            string lyric = note.lyric;
+            string phoneticHint = note.phoneticHint;
+
+            Note? prevNote = prevNeighbour; // null or Note
+            Note thisNote = note;
+            Note? nextNote = nextNeighbour; // null or Note
+
+            int totalDuration = notes.Sum(n => n.duration);
+            int vcLength = 120;
+            int vcLengthShort = 30;
+
+            KOCV cv = new KOCV(singer, thisNote, totalDuration, vcLength, vcLengthShort);
+
+            try{
+                // change lyric to CV phonemes, with phoneme variation.
+                cvPhonemes = cv.ConvertForCV(prevNote, thisNote, nextNote, 
+                        new bool[] {isUsingShi, isUsing_aX, isUsing_i, isRentan});
+            
+            }
+            catch {
+                return GenerateResult(lyric);
+            }
+            
+
+            // return phonemes
+            if ((prevNeighbour == null) && (nextNeighbour == null)) { // 이웃이 없음 / 냥
+                return (! cv.ThisHasBatchim()) ? GenerateResult(cv.frontCV, cv.endSoundVowel, totalDuration, vcLengthShort, 8) : GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.cVCLength, 8);
+            } 
+            
+            else if ((prevNeighbour != null) && (nextNeighbour == null)) {
+                // 앞에 이웃 있고 뒤에 이웃 없음 / 냥[냥]
+                if (! cv.ThisHasBatchim()) { // 둘다 이웃 있고 받침 없음 / 냥[냐]냥
+                    return cv.ThisNeedsFrontCV() ? GenerateResult(cv.frontCV) : GenerateResult(cv.CV);
+                }
+                else{
+                    return cv.ThisNeedsFrontCV() ? GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.vcLength, 8) : GenerateResult(cv.CV, cv.cVC, totalDuration, cv.vcLength, 8);
+                }
+            }   
+
+            else if ((prevNeighbour == null) && (nextNeighbour != null)) {
+                if (KoreanPhonemizerUtil.IsHangeul(nextNeighbour?.lyric)) {// 뒤 글자가 한글임
+                    if (! cv.ThisHasBatchim()) { // 앞이웃만 없고 받침 없음 / [냐]냥
+                        return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.frontCV, "", totalDuration, vcLength) : GenerateResult(cv.frontCV);
+                    } 
+                    else {
+                        return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.frontCV, cv.cVC, "", totalDuration, cv.cVCLength, 2, 8) : GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.vcLength);
+                    }
+                } 
+                else {
+                    return (! cv.ThisHasBatchim()) ? GenerateResult(cv.frontCV) : GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.vcLength);
+                }
+            } 
+
+            else if ((prevNeighbour != null) && (nextNeighbour != null)) {// 둘다 이웃 있음
+                if (KoreanPhonemizerUtil.IsHangeul(nextNeighbour?.lyric)) {// 뒤의 이웃이 한국어임
+                    if (! cv.ThisHasBatchim()) { // 둘다 이웃 있고 받침 없음 / 냥[냐]냥
+                        if (cv.ThisNeedsFrontCV()) {
+                            return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.frontCV, "", totalDuration, cv.vcLength, 2) : GenerateResult(cv.frontCV);
+                        }
+                        else{// 뒤 음소가 파열음 혹은 된소리일 때엔 VC로 공백을 준다 ))
+                            return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.CV, "", totalDuration, cv.vcLength, 2) : GenerateResult(cv.CV);
+                        }   
+                    }
+                    else{
+                        if (cv.ThisNeedsFrontCV()) {
+                            return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.frontCV, cv.cVC, "", totalDuration, cv.cVCLength, 2, 8) : GenerateResult(cv.frontCV, cv.cVC, totalDuration, cv.cVCLength, 2);
+                        }
+                        else{// 뒤 음소가 파열음 혹은 된소리일 때엔 VC로 공백을 준다 ))
+                            return cv.NextFirstConsonantNeedsPause() ? GenerateResult(cv.CV, cv.cVC, "", totalDuration, cv.cVCLength, 2, 8) : GenerateResult(cv.CV, cv.cVC, totalDuration, cv.cVCLength, 2);
+                        }   
+                    }
+                } 
+                else if ((bool)(nextNeighbour?.lyric.Equals("-")) || (bool)(nextNeighbour?.lyric.Equals("R"))) {
+                    // 둘다 이웃 있고 뒤에 -가 옴
+                    return (! cv.ThisHasBatchim())  ? GenerateResult(cv.CV) : GenerateResult(cv.CV, cv.cVC, totalDuration, cv.cVCLength, 3);
+                } 
+                else {
+                    return (! cv.ThisHasBatchim()) ? GenerateResult(cv.CV) : GenerateResult(cv.CV, cv.cVC, totalDuration, cv.cVCLength, 3);
+                }
+            } 
+            else {
+                return GenerateResult(cv.CV);
+            }
+        }
+        
+
+        public override Result GenerateEndSound(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
+            Hashtable cvPhonemes;
+
+            Note note = notes[0];
+            string lyric = note.lyric;
+            string phoneticHint = note.phoneticHint;
+
+            Note? prevNote = prevNeighbour; // null or Note
+            Note thisNote = note;
+            Note? nextNote = nextNeighbour; // null or Note
+
+            int totalDuration = notes.Sum(n => n.duration);
+
+            KOCV cv = new KOCV(singer, thisNote, totalDuration, vcLength, vcLengthShort);
+            string phonemeToReturn = lyric; // 아래에서 아무것도 안 걸리면 그냥 가사 반환
+            string prevLyric = prevNote?.lyric;
+
+            if (phonemeToReturn.Equals("-")) {
+                if (KoreanPhonemizerUtil.IsHangeul(prevLyric)) {
+                    cvPhonemes = cv.ConvertForCV(prevNote, 
+                                new bool[] { isUsingShi, isUsing_aX, isUsing_i, isRentan }); 
+
+                    string prevVowelTail = (string)cvPhonemes[2]; // V이전 노트의 모음 음소 
+                    string prevLastConsonant = (string)cvPhonemes[3]; // 이전 노트의 받침 음소
+
+                    // 앞 노트가 한글
+                    if (!prevLastConsonant.Equals("")) {
+                        phonemeToReturn = $"{prevLastConsonant} -";
+                    } 
+                    else if (!prevVowelTail.Equals("")) {
+                        phonemeToReturn = $"{prevVowelTail} -";
+                    }
+                }
+                return GenerateResult(phonemeToReturn);
+            } 
+            else if (phonemeToReturn.Equals("R")) {
+                if (KoreanPhonemizerUtil.IsHangeul(prevLyric)) {
+                    cvPhonemes = cv.ConvertForCV(prevNote, 
+                                new bool[] { isUsingShi, isUsing_aX, isUsing_i, isRentan }); // [isUsingShi], isUsing_aX, isUsing_i, isRentan
+
+                    string prevVowelTail = (string)cvPhonemes[2]; // V이전 노트의 모음 음소 
+                    string prevLastConsonant = (string)cvPhonemes[3]; // 이전 노트의 받침 음소
+
+                    // 앞 노트가 한글
+                    if (!prevLastConsonant.Equals("")) {
+                        phonemeToReturn = $"{prevLastConsonant} R";
+                    } else if (!prevVowelTail.Equals("")) {
+                        phonemeToReturn = $"{prevVowelTail} R";
+                    }
+
+                }
+                return GenerateResult(phonemeToReturn);
+            } else {
+                return GenerateResult(phonemeToReturn);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added Korean CV Phonemizer(CLASSIC).
- Since Korean CV Voicebanks have many variations in Alias, It uses `Ko-CV.ini` to Handle Various CV voicebanks.
(for example, 시 is used as "shi" in some VBs and "si" in others, Batchim 아-ㄴ is used as "an" in some VBs and "a n" in others... so on. We are calling ALL of them as "Korean CV Voicebanks", but They are commonly using Similar, but Different phoneme symbols in some part.) 
- Supports Phoneme hints input(like 냥[nya, a ng]), Detailed phoneme position adjustments(Especially at end consonants) for better synthesize quality, and Korean Phoneme Variation.
- This is Branch after (Should be merged after) #991