### PR TITLE
[EN X-SAMPA] Distinguish between current word CC and previous word CC

### DIFF
--- a/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
@@ -331,7 +331,7 @@ namespace OpenUtau.Plugin.Builtin {
                             if (HasOto(vr, syllable.tone) || HasOto(ValidateAlias(vr), syllable.tone)) {
                                 phonemes.Add(vr);
                             }
-                        } else if (HasOto(vcc, syllable.tone) || HasOto(ValidateAlias(vcc), syllable.tone)) {
+                        } else if ((HasOto(vcc, syllable.tone) || HasOto(ValidateAlias(vcc), syllable.tone)) && !affricates.Contains(string.Join("", cc.Take(2)))) {
                             phonemes.Add(vcc);
                             firstC = 1;
                             break;

--- a/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
@@ -4,21 +4,24 @@ using System.IO;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core.G2p;
-using OpenUtau.Core.Ustx;
 using Serilog;
 
 namespace OpenUtau.Plugin.Builtin {
+    /// <summary>
+    /// General English phonemizer for X-SAMPA voicebanks.
+    /// The difference between this phonemizer and the Teto English phonemizer is that this one was made to support all X-SAMPA-based banks.
+    /// However, it should be fully compatible with Kasane Teto's English voicebank regardless.
+    /// <br></br>
+    /// <br></br>
+    /// It supports Delta-style English banks, as well as other English X-SAMPA voicebank styles.
+    /// There is also support for extended English phonemes, which can be included in a custom dictionary and/or phonetic input.
+    /// Due to the flexibility of X-SAMPA, it was easy to add the custom sounds. More suggestions for this are always welcome.
+    /// <br></br>
+    /// <br></br>
+    /// Read more about X-SAMPA <a href="https://www.wikipedia.org/wiki/X-SAMPA">here</a>.
+    /// </summary>
     [Phonemizer("English X-SAMPA phonemizer", "EN X-SAMPA", "Lotte V", language: "EN")]
     public class EnXSampaPhonemizer : SyllableBasedPhonemizer {
-        /// <summary>
-        /// General English phonemizer for X-SAMPA voicebanks.
-        /// The difference between this phonemizer and the Teto English phonemizer is that this one was made to support all X-SAMPA-based banks.
-        /// However, it should be fully compatible with Kasane Teto's English voicebank regardless.
-        /// It supports Delta-style English banks, as well as other English X-SAMPA voicebank styles.
-        /// There is also support for extended English phonemes, which can be included in a custom dictionary and/or phonetic input.
-        /// Due to the flexibility of X-SAMPA, it was easy to add the custom sounds. More suggestions for this are always welcome.
-        ///</summary>
-
         private readonly string[] vowels = "a,A,@,{,V,O,aU,aI,E,3,eI,I,i,oU,OI,U,u,Q,Ol,Ql,aUn,e@,eN,IN,e,o,Ar,Qr,Er,Ir,Or,Ur,ir,ur,aIr,aUr,A@,Q@,E@,I@,O@,U@,i@,u@,aI@,aU@,@r,@l,@m,@n,@N,1,e@m,e@n,y,I\\,M,U\\,Y,@\\,@`,3`,A`,Q`,E`,I`,O`,U`,i`,u`,aI`,aU`,},2,3\\,6,7,8,9,&,{~,I~,aU~,VI,VU,@U,ai,ei,Oi,au,ou,Ou,@u,i:,u:,O:,e@0,E~,e~,3r,ar,or,{l,Al,al,El,Il,il,ul,Ul,mm,nn,ll,NN".Split(',');
         private readonly string[] consonants = "b,tS,d,D,4,f,g,h,dZ,k,l,m,n,N,p,r,s,S,t,T,v,w,W,j,z,Z,t_},・,_".Split(',');
         private readonly string[] affricates = "tS,dZ".Split(',');
@@ -160,6 +163,10 @@ namespace OpenUtau.Plugin.Builtin {
             string[] cc = syllable.cc;
             string v = syllable.v;
 
+            string[] CurrentWordCc = syllable.CurrentWordCc;
+            string[] PreviousWordCc = syllable.PreviousWordCc;
+            int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
+
             string basePhoneme;
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
@@ -276,11 +283,21 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             } else { // VCV
                 var vcv = $"{prevV} {cc[0]}{v}";
+                var vcvEnd = $"{prevV}{cc[0]} {v}";
                 var vccv = $"{prevV} {string.Join("", cc)}{v}";
                 var crv = $"{cc.Last()} {v}";
-                if (syllable.IsVCVWithOneConsonant && (HasOto(vcv, syllable.vowelTone) || HasOto(ValidateAlias(vcv), syllable.vowelTone))) {
+                // Use regular VCV if the current word starts with one consonant and the previous word ends with none
+                if (syllable.IsVCVWithOneConsonant && (HasOto(vcv, syllable.vowelTone) || HasOto(ValidateAlias(vcv), syllable.vowelTone)) && prevWordConsonantsCount == 0 && CurrentWordCc.Length == 1) {
                     basePhoneme = vcv;
-                } else if (syllable.IsVCVWithMoreThanOneConsonant && (HasOto(vccv, syllable.vowelTone) || HasOto(ValidateAlias(vccv), syllable.vowelTone))) {
+                    // Use end VCV if current word does not start with a consonant but the previous word does end with one
+                } else if (syllable.IsVCVWithOneConsonant && prevWordConsonantsCount == 1 && CurrentWordCc.Length == 0 && (HasOto(vcvEnd, syllable.vowelTone) || HasOto(ValidateAlias(vcvEnd), syllable.vowelTone))) {
+                    basePhoneme = vcvEnd;
+                    // Use regular VCV if end VCV does not exist
+                } else if (syllable.IsVCVWithOneConsonant && !HasOto(vcvEnd, syllable.vowelTone) && !HasOto(ValidateAlias(vcvEnd), syllable.vowelTone) && (HasOto(vcv, syllable.vowelTone) || HasOto(ValidateAlias(vcv), syllable.vowelTone))) {
+                    basePhoneme = vcv;
+                    // VCV with multiple consonants, only for current word onset and null previous word ending
+                    // TODO: multi-VCV for words ending with one or more consonants?
+                } else if (syllable.IsVCVWithMoreThanOneConsonant && (HasOto(vccv, syllable.vowelTone) || HasOto(ValidateAlias(vccv), syllable.vowelTone)) && prevWordConsonantsCount == 0) {
                     basePhoneme = vccv;
                     lastC = 0;
                 } else {
@@ -293,11 +310,11 @@ namespace OpenUtau.Plugin.Builtin {
                         for (var i = firstC; i < cc.Length; i++) {
                             var ccv = $"{string.Join("", cc.Skip(i))}{v}";
                             var rccv = $"- {string.Join("", cc.Skip(i))}{v}";
-                            if (HasOto(ccv, syllable.vowelTone) || HasOto(ValidateAlias(ccv), syllable.vowelTone)) {
+                            if ((HasOto(ccv, syllable.vowelTone) || HasOto(ValidateAlias(ccv), syllable.vowelTone)) && CurrentWordCc.Length >= 2) {
                                 lastC = i;
                                 basePhoneme = ccv;
                                 break;
-                            } else if ((HasOto(rccv, syllable.vowelTone) || HasOto(ValidateAlias(rccv), syllable.vowelTone)) && (!HasOto(ccv, syllable.vowelTone) && !HasOto(ValidateAlias(ccv), syllable.vowelTone))) {
+                            } else if ((HasOto(rccv, syllable.vowelTone) || HasOto(ValidateAlias(rccv), syllable.vowelTone)) && (!HasOto(ccv, syllable.vowelTone) && !HasOto(ValidateAlias(ccv), syllable.vowelTone)) && CurrentWordCc.Length >= 2) {
                                 lastC = i;
                                 basePhoneme = rccv;
                                 break;
@@ -331,63 +348,71 @@ namespace OpenUtau.Plugin.Builtin {
                     }
                 }
             }
+
             for (var i = firstC; i < lastC; i++) {
                 // we could use some CCV, so lastC is used
                 // we could use -CC so firstC is used
                 var cc1 = $"{string.Join("", cc.Skip(i))}";
                 var ccv = string.Join("", cc.Skip(i)) + v;
-                var ucv = $"_{cc.Last()}{v}"; ;
+                var ucv = $"_{cc.Last()}{v}";
+                // Use [C1C2...] when current word starts with 2 consonants or more
+                if (CurrentWordCc.Length >= 2) {
+                    cc1 = $"{string.Join("", cc.Skip(i))}";
+                }
                 if (!HasOto(cc1, syllable.tone)) {
                     cc1 = ValidateAlias(cc1);
                 }
-                if (!HasOto(cc1, syllable.tone)) {
+                // Use [C1C2] when current word has 2 consonants or more and [C1C2C3...] does not exist
+                if (!HasOto(cc1, syllable.tone) && CurrentWordCc.Length >= 2) {
                     cc1 = $"{cc[i]}{cc[i + 1]}";
                 }
                 if (!HasOto(cc1, syllable.tone)) {
                     cc1 = ValidateAlias(cc1);
                 }
-                if (!HasOto(cc1, syllable.tone)) {
+                // Use [C1 C2] when either [C1C2] does not exist, or current word has 1 consonant or less and previous word has 1 consonant or more
+                if (!HasOto(cc1, syllable.tone) || (prevWordConsonantsCount >= 1 && CurrentWordCc.Length <= 1)) {
                     cc1 = $"{cc[i]} {cc[i + 1]}";
                 }
                 if (!HasOto(cc1, syllable.tone)) {
                     cc1 = ValidateAlias(cc1);
                 }
-                if (!HasOto(cc1, syllable.tone)) {
-                    cc1 = ValidateAlias(cc1);
-                }
-                if (HasOto(ccv, syllable.vowelTone) || HasOto(ValidateAlias(ccv), syllable.vowelTone)) {
+                // Use CCV if it exists
+                if ((HasOto(ccv, syllable.vowelTone) || HasOto(ValidateAlias(ccv), syllable.vowelTone)) && CurrentWordCc.Length >= 2) {
                     basePhoneme = ccv;
                     lastC = i;
+                    // Use _CV if it exists
                 } else if ((HasOto(ucv, syllable.vowelTone) || HasOto(ValidateAlias(ucv), syllable.vowelTone)) && HasOto(cc1, syllable.vowelTone) && !cc1.Contains($"{cc[i]} {cc[i + 1]}")) {
                     basePhoneme = ucv;
                 }
                 if (i + 1 < lastC) {
                     var cc2 = $"{string.Join("", cc.Skip(i))}";
-                    if (!HasOto(cc2, syllable.tone)) {
-                        cc2 = ValidateAlias(cc2);
+                    // Use [C2C3...] when current word starts with 2 consonants or more
+                    if (CurrentWordCc.Length >= 2) {
+                        cc2 = $"{string.Join("", cc.Skip(i))}";
                     }
                     if (!HasOto(cc2, syllable.tone)) {
                         cc2 = ValidateAlias(cc2);
                     }
-                    if (!HasOto(cc2, syllable.tone)) {
+                    // Use [C2C3] when current word has 2 consonants or more and [C2C3C4...] does not exist
+                    if (!HasOto(cc2, syllable.tone) && CurrentWordCc.Length >= 2) {
                         cc2 = $"{cc[i + 1]}{cc[i + 2]}";
                     }
                     if (!HasOto(cc2, syllable.tone)) {
                         cc2 = ValidateAlias(cc2);
                     }
-                    if (!HasOto(cc2, syllable.tone)) {
+                    // Use [C2 C3] when either [C2C3] does not exist, or current word has 1 consonant or less and previous word has 2 consonants or more
+                    if (!HasOto(cc2, syllable.tone) || (prevWordConsonantsCount >= 2 && CurrentWordCc.Length <= 1 && !CurrentWordCc.Contains(cc2))) {
                         cc2 = $"{cc[i + 1]} {cc[i + 2]}";
                     }
                     if (!HasOto(cc2, syllable.tone)) {
                         cc2 = ValidateAlias(cc2);
                     }
-                    if (!HasOto(cc2, syllable.tone)) {
-                        cc2 = ValidateAlias(cc2);
-                    }
-                    if (HasOto(ccv, syllable.vowelTone) || HasOto(ValidateAlias(ccv), syllable.vowelTone)) {
+                    // Use CCV if it exists
+                    if ((HasOto(ccv, syllable.vowelTone) || HasOto(ValidateAlias(ccv), syllable.vowelTone)) && CurrentWordCc.Length >= 2) {
                         basePhoneme = ccv;
                         lastC = i;
-                    } else if ((HasOto(ucv, syllable.vowelTone) || HasOto(ValidateAlias(ucv), syllable.vowelTone)) && (HasOto(cc2, syllable.vowelTone) || HasOto(ValidateAlias(cc2), syllable.vowelTone)) && !cc2.Contains($"{cc[i + 1]} {cc[i + 2]}")) {
+                        // Use _CV if it exists
+                    } else if ((HasOto(ucv, syllable.vowelTone) || HasOto(ValidateAlias(ucv), syllable.vowelTone)) && (HasOto(cc2, syllable.vowelTone) || HasOto(ValidateAlias(cc2), syllable.vowelTone)) && !cc2.Contains($"{cc[i + 1]} {cc[i + 2]}") && !PreviousWordCc.Contains(ucv)) {
                         basePhoneme = ucv;
                     }
                     if (HasOto(cc1, syllable.tone) && HasOto(cc2, syllable.tone) && !cc1.Contains($"{string.Join("", cc.Skip(i))}")) {
@@ -399,6 +424,7 @@ namespace OpenUtau.Plugin.Builtin {
                             i++;
                         }
                     } else {
+                        /// Add single consonant if no CC cluster
                         // like [V C1] [C1] [C2 ..]
                         TryAddPhoneme(phonemes, syllable.tone, cc[i], ValidateAlias(cc[i]));
                     }


### PR DESCRIPTION
This will distinguish between beginning consonants of the current word and ending consonants of the previous word. Fallbacks are supported. I decided to implement this since in English, starting and ending consonants can sound quite different.

Some visual examples:

#### Consonant clusters
Current word CCV vs previous word spaced CC. The current word CC can still fall back to spaced CC (after non-spaced CC).

![Current word CCV vs previous word spaced CC](https://i.ibb.co/k0TpGL9/Start-Cc-Vs-End-Cc.png)

#### VCV
VCV with consonant from previous word vs. CVVC with consonant from current word. Falls back to regular VCV first, then CVVC.

![VCV with consonant from previous word vs. CVVC with consonant from current word](https://i.ibb.co/JHZbSbf/End-Vs-Start-Vcv.png)

**TODO:** Do something similar with VCV that contain multiple ending consonants? This is a bit more complicated which is why I'm waiting to implement it. Right now, only start consonants are supported, otherwise it falls back to CVVC with CC.