### PR TITLE
Add an option to import tempo when importing tracks

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -179,6 +179,7 @@ namespace OpenUtau.Core.Util {
             public bool RememberMid = false;
             public bool RememberUst = true;
             public bool RememberVsqx = true;
+            public int ImportTempo = 0;
             public string PhoneticAssistant = string.Empty;
         }
     }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -35,6 +35,8 @@
   <system:String x:Key="dialogs.exitsave.message">The current project contains unsaved changes. Do you want to save it?</system:String>
   <system:String x:Key="dialogs.export.caption">Export</system:String>
   <system:String x:Key="dialogs.export.savefirst">Save project file first</system:String>
+  <system:String x:Key="dialogs.importtracks.caption">Import tracks</system:String>
+  <system:String x:Key="dialogs.importtracks.importtempo">The imported project contains the following tempo markers. Do you want to use them?</system:String>
   <system:String x:Key="dialogs.installdependency.caption">Installing dependency</system:String>
   <system:String x:Key="dialogs.installdependency.message">Installing </system:String>
   <system:String x:Key="dialogs.installdll.caption">Installing phonemizer</system:String>
@@ -285,6 +287,10 @@ Warning: this option removes custom presets.</system:String>
 
   <system:String x:Key="prefs.advanced">Advanced</system:String>
   <system:String x:Key="prefs.advanced.beta">Beta</system:String>
+  <system:String x:Key="prefs.advanced.importtempo">When importing tracks, use the tempos of the imported project</system:String>
+  <system:String x:Key="prefs.advanced.importtempo.always">Always</system:String>
+  <system:String x:Key="prefs.advanced.importtempo.ask">Ask me each time</system:String>
+  <system:String x:Key="prefs.advanced.importtempo.never">Never</system:String>
   <system:String x:Key="prefs.advanced.lyricshelper">Lyrics Helper</system:String>
   <system:String x:Key="prefs.advanced.lyricshelper.brackets">Lyrics Helper Adds Brackets</system:String>
   <system:String x:Key="prefs.advanced.rememberfiletypes">Remember these file types in "Open Recent"</system:String>

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -137,12 +137,19 @@ namespace OpenUtau.App.ViewModels {
             DocManager.Inst.ExecuteCmd(new SaveProjectNotification(file));
             this.RaisePropertyChanged(nameof(Title));
         }
+        
+        public void ImportTracks(UProject[] loadedProjects, bool importTempo){
+            if (loadedProjects == null || loadedProjects.Length < 1) {
+                return;
+            }
+            Core.Format.Formats.ImportTracks(DocManager.Inst.Project, loadedProjects, importTempo);
+        }
 
-        public void ImportTracks(string[] files) {
+        public void ImportTracks(string[] files, bool importTempo) {
             if (files == null) {
                 return;
             }
-            Core.Format.Formats.ImportTracks(DocManager.Inst.Project, files);
+            Core.Format.Formats.ImportTracks(DocManager.Inst.Project, files, importTempo);
         }
 
         public void ImportAudio(string file) {

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -90,6 +90,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public bool RememberMid{ get; set; }
         [Reactive] public bool RememberUst{ get; set; }
         [Reactive] public bool RememberVsqx{ get; set; }
+        [Reactive] public int ImportTempo{ get; set; }
 
         private List<AudioOutputDevice>? audioOutputDevices;
         private AudioOutputDevice? audioOutputDevice;
@@ -150,6 +151,7 @@ namespace OpenUtau.App.ViewModels {
             RememberMid = Preferences.Default.RememberMid;
             RememberUst = Preferences.Default.RememberUst;
             RememberVsqx = Preferences.Default.RememberVsqx;
+            ImportTempo = Preferences.Default.ImportTempo;
             ClearCacheOnQuit = Preferences.Default.ClearCacheOnQuit;
 
             this.WhenAnyValue(vm => vm.AudioOutputDevice)
@@ -296,6 +298,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.RememberVsqx)
                 .Subscribe(index => {
                     Preferences.Default.RememberVsqx = index;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.ImportTempo)
+                .Subscribe(index => {
+                    Preferences.Default.ImportTempo = index;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.ClearCacheOnQuit)

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -231,6 +231,12 @@
               <CheckBox IsChecked="{Binding RememberVsqx}" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center"/>
               <TextBlock Text=" .vsqx" Grid.Column="1" Grid.Row="2" VerticalAlignment="Center"/>
             </Grid>
+            <TextBlock Text="{DynamicResource prefs.advanced.importtempo}" Margin="0,10,0,0"/>
+            <ComboBox SelectedIndex="{Binding ImportTempo}">
+              <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.always}"/>
+              <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.never}"/>
+              <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.ask}"/>
+            </ComboBox>
           </StackPanel>
         </HeaderedContentControl>
       </StackPanel>


### PR DESCRIPTION
When importing tracks, sometimes the user wants to keep their original timeaxis. This PR let the user to choose the behaviour when importing. The user can choose "Always", "Never", or "Ask me each time".

If "Ask me each time" is selected, openutau will show a dialog with the tempo list when importing tracks:
![image](https://github.com/stakira/OpenUtau/assets/54425948/2bd8a804-ddd4-4492-a9b3-1f634e3ae929)
