### PR TITLE
G2p: add IsGlide method; EN ARPA: support glide phonemes.

### DIFF
--- a/OpenUtau.Core/Api/G2pFallbacks.cs
+++ b/OpenUtau.Core/Api/G2pFallbacks.cs
@@ -25,6 +25,15 @@ namespace OpenUtau.Api {
             return false;
         }
 
+        public bool IsGlide(string symbol) {
+            foreach (var dict in dictionaries) {
+                if (dict.IsValidSymbol(symbol)) {
+                    return dict.IsGlide(symbol);
+                }
+            }
+            return false;
+        }
+
         public string[] Query(string grapheme) {
             foreach (var dict in dictionaries) {
                 var result = dict.Query(grapheme);

--- a/OpenUtau.Core/Api/G2pPack.cs
+++ b/OpenUtau.Core/Api/G2pPack.cs
@@ -59,6 +59,10 @@ namespace OpenUtau.Api {
             return Dict.IsVowel(symbol);
         }
 
+        public bool IsGlide(string symbol) {
+            return Dict.IsGlide(symbol);
+        }
+
         public string[] Query(string grapheme) {
             if (grapheme.Length == 0 || kAllPunct.IsMatch(grapheme)) {
                 return null;

--- a/OpenUtau.Core/Api/G2pRemapper.cs
+++ b/OpenUtau.Core/Api/G2pRemapper.cs
@@ -5,14 +5,17 @@ namespace OpenUtau.Api {
     public class G2pRemapper : IG2p {
         private IG2p mapped;
         private Dictionary<string, bool> phonemeSymbols; // (phoneme, isVowel)
+        private HashSet<string> glideSymbols;
         private Dictionary<string, string> replacements;
 
         public G2pRemapper(IG2p mapped,
             Dictionary<string, bool> phonemeSymbols,
-            Dictionary<string, string> replacements) {
+            Dictionary<string, string> replacements,
+            HashSet<string> glideSymbols = null) {
             this.mapped = mapped;
             this.phonemeSymbols = phonemeSymbols;
             this.replacements = replacements;
+            this.glideSymbols = glideSymbols ?? new HashSet<string>();
         }
 
         public bool IsValidSymbol(string symbol) {
@@ -21,6 +24,10 @@ namespace OpenUtau.Api {
 
         public bool IsVowel(string symbol) {
             return phonemeSymbols.TryGetValue(symbol, out var isVowel) && isVowel;
+        }
+
+        public bool IsGlide(string symbol) {
+            return glideSymbols.Contains(symbol);
         }
 
         public string[] Query(string grapheme) {

--- a/OpenUtau.Core/Api/IG2p.cs
+++ b/OpenUtau.Core/Api/IG2p.cs
@@ -4,6 +4,11 @@
         bool IsVowel(string symbol);
 
         /// <summary>
+        /// Returns true if the symbol is a semivowel or liquid phoneme, like y, w, l, r in English.
+        /// </summary>
+        bool IsGlide(string symbol);
+
+        /// <summary>
         /// Produces a list of phonemes from grapheme.
         /// </summary>
         string[] Query(string grapheme);

--- a/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
@@ -84,6 +84,10 @@ namespace OpenUtau.Plugin.Builtin
             return !phoneme.StartsWith("_");
         }
 
+        public bool IsGlide(string phoneme){
+            return false;
+        }
+
         public string[] Query(string lyric){
             // The overall logic is:
             // 1. Remove consonant: "duang" -> "uang".


### PR DESCRIPTION
This PR adds an IsGlide method to IG2p that tells whether a phoneme is a semivowel or liquid sound, like `y`, `w`, `l`, `r` in English. 

In "Consonant - Glide - Vowel" syllables such as "grass", glide phoneme should be put after the start position of the note.

I've tested some external dll phonemizers released before this change. They work successfully as before.