### PR TITLE
[ES SYL] Phonemizer refactor + custom dictionary support

### DIFF
--- a/OpenUtau.Plugin.Builtin/SpanishSyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SpanishSyllableBasedPhonemizer.cs
@@ -1,42 +1,85 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using OpenUtau.Api;
 using OpenUtau.Core.G2p;
 using System.Linq;
 using Serilog;
+using System.IO;
 
 namespace OpenUtau.Plugin.Builtin {
+    /// <summary>
+    /// Spanish syllable-based phonemizer.
+    /// I tried to make this phonemizer as compatible with many different methods as possible.
+    /// Supports both CVVC and VCV if the voicebank has it.
+    /// Supports seseo ("s" instead of "z" if the voicebank doesn't have the latter).
+    /// It also substitutes "nh" for "ny" if the voicebank doesn't have the first.
+    /// Ít now also uses "i" instead of "y" and "u" instead of "w" depending on what the voicebank supports.
+    /// Now with full VCV support, including "consonant VCV" if the voicebank has either of them (ex. "l ba", "n da" but also "m bra" etc.).
+    /// </summary>
     [Phonemizer("Spanish Syllable-Based Phonemizer", "ES SYL", "Lotte V", language: "ES")]
     public class SpanishSyllableBasedPhonemizer : SyllableBasedPhonemizer {
 
-        /// <summary>
-        /// Spanish syllable-based phonemizer.
-        /// I tried to make this phonemizer as compatible with many different methods as possible.
-        /// Supports both CVVC and VCV if the voicebank has it.
-        /// Supports seseo ("s" instead of "z" if the voicebank doesn't have the latter).
-        /// It also substitutes "nh" for "ny" if the voicebank doesn't have the first.
-        /// Ít now also uses "i" instead of "y" and "u" instead of "w" depending on what the voicebank supports.
-        /// Now with full VCV support, including "consonant VCV" if the voicebank has either of them (ex. "l ba", "n da" but also "m bra" etc.).
-        ///</summary>
-
         private readonly string[] vowels = "a,e,i,o,u".Split(',');
-        private readonly string[] consonants = "b,ch,d,dz,f,g,h,hh,j,k,l,ll,m,n,nh,p,r,rr,s,sh,t,ts,w,y,z,zz,zh".Split(',');
-        private readonly Dictionary<string, string> dictionaryReplacements = ("a=a;e=e;i=i;o=o;u=u;" +
-                "b=b;ch=ch;d=d;dz=dz;f=f;g=g;gn=nh;k=k;l=l;ll=j;m=m;n=n;p=p;r=r;rr=rr;s=s;sh=sh;t=t;ts=ts;w=w;x=h;y=y;z=z;zz=zz;zh=zh;I=i;U=u;B=b;D=d;G=g;Y=y").Split(';')
+        private readonly string[] consonants = "b,ch,d,dz,f,g,h,hh,j,k,l,ll,m,n,nh,p,r,rr,s,sh,t,ts,w,y,z,zz,zh,I,U".Split(',');
+        private readonly Dictionary<string, string> dictionaryReplacements = ("a=a;e=e;i=i;o=o;u=u;" + "b=b;ch=ch;d=d;f=f;g=g;gn=nh;k=k;l=l;ll=j;m=m;n=n;p=p;r=r;rr=rr;s=s;t=t;w=w;x=h;y=y;z=z;I=I;U=U;B=b;D=d;G=g;Y=y").Split(';')
                 .Select(entry => entry.Split('='))
                 .Where(parts => parts.Length == 2)
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
 
         private readonly string[] longConsonants = "ch,dz,h,s,sh,k,p,rr,t,ts,z".Split(',');
-        private readonly string[] notClusters = "dz,hh,ll,nh,sh,zz,zh".Split(',');
-        private readonly string[] specialClusters = "by,dy,fy,gy,hy,jy,ky,ly,my,py,ry,rry,sy,ty,vy,zy,bw,chw,dw,fw,gw,hw,jw,kw,lw,llw,mw,nw,pw,rw,rrw,sw,tw,vw,zw,bl,fl,gl,kl,pl,br,dr,fr,gr,kr,pr,tr".Split(',');
+        private readonly string[] initialCC = "bl,bly,blw,br,bry,brw,by,bw,dr,dry,drw,dy,dw,fl,fly,flw,fr,fry,frw,fy,fw,gl,gly,glw,gr,gry,grw,gy,gw,kl,kly,klw,kr,kry,krw,ky,kw,pl,ply,plw,pr,pry,prw,py,pw,tl,tly,tlw,tr,try,trw,ty,tw,chy,chw,hy,hw,jy,jw,ly,lw,my,mw,ny,nw,ry,rw,sy,sw,vy,vw,zy,zw,nhy,nhw,rry,rrw,ts".Split(',');
+        private readonly string[] notClusters = "dz,hh,ll,nh,sh,zz,zh,th,ng".Split(',');
+        private readonly string[] burstConsonants = "ch,dz,j,k,p,t,ts,r".Split(',');
+
+        // For banks with a seseo accent
+        private readonly Dictionary<string, string> seseo = "z=s".Split(';')
+                .Select(entry => entry.Split('='))
+                .Where(parts => parts.Length == 2)
+                .Where(parts => parts[0] != parts[1])
+                .ToDictionary(parts => parts[0], parts => parts[1]);
+
+        private bool isSeseo = false;
+
+        // For banks with alternate semivowel aliases
+        private readonly Dictionary<string, string> semiVowelFallback = "jya=ja;jye=je;jyo=jo;jyu=ju;chya=cha;chye=che;chyo=cho;chyu=chu;nhya=nha;nhye=nhe;nhyo=nho;nhyu=nhu;nhwa=nua;nhwe=nue;nhwi=nui;nhwo=nuo;ya=ia;ye=ie;yo=io;yu=iu;wa=ua;we=ue;wi=ui;wo=uo".Split(';')
+                .Select(entry => entry.Split('='))
+                .Where(parts => parts.Length == 2)
+                .Where(parts => parts[0] != parts[1])
+                .ToDictionary(parts => parts[0], parts => parts[1]);
+
+        private bool isSemiVowelFallback = false;
+
+        // For banks with alternate alias for "ñ"
+        private readonly Dictionary<string, string> eñeFallback = "nhya=nya;nhye=nye;nhyo=nyo;nhyu=nyu;nhwa=nwa;nhwe=nwe;nhwi=nwi;nhwo=nwo;nha=nya;nhe=nye;nyi=ni;nhi=nyi;nho=nyo;nhu=nyu;a nh=a n;e nh=e n;i nh=i n;o nh=o n;u nh=u n;n nh=n n;l nh=l n;m nh=m n".Split(';')
+                .Select(entry => entry.Split('='))
+                .Where(parts => parts.Length == 2)
+                .Where(parts => parts[0] != parts[1])
+                .ToDictionary(parts => parts[0], parts => parts[1]);
+
+        private bool isEñeFallback = false;
 
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "cmudict_es.txt";
-        protected override IG2p LoadBaseDictionary() => new SpanishG2p();
+
+        protected override IG2p LoadBaseDictionary() {
+            var g2ps = new List<IG2p>();
+
+            // Load dictionary from singer folder.
+            if (singer != null && singer.Found && singer.Loaded) {
+                string file = Path.Combine(singer.Location, "es-syl.yaml");
+                if (File.Exists(file)) {
+                    try {
+                        g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
+                    } catch (Exception e) {
+                        Log.Error(e, $"Failed to load {file}");
+                    }
+                }
+            }
+            g2ps.Add(new SpanishG2p());
+            return new G2pFallbacks(g2ps.ToArray());
+        }
         protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
@@ -46,14 +89,28 @@ namespace OpenUtau.Plugin.Builtin {
 
             string basePhoneme;
             var phonemes = new List<string>();
+
             var lastC = cc.Length - 1;
             var firstC = 0;
-            var rcv = $"- {v}";
+
+            var rv = $"- {v}";
             var vv1 = $"{prevV} {v}";
             var vv2 = $"{prevV}{v}";
+
+            // Switch between phonetic systems, depending on certain aliases in the bank
+            if (!HasOto($"z{v}", syllable.tone) && !HasOto($"- z{v}", syllable.tone)) {
+                isSeseo = true;
+            }
+            if (!HasOto($"{cc.Length}y{v}", syllable.vowelTone) && !HasOto($"- {cc.Length}y{v}", syllable.vowelTone)) {
+                isSemiVowelFallback = true;
+            }
+            if (!HasOto($"nh{v}", syllable.vowelTone) && !HasOto($"- nh{v}", syllable.vowelTone)) {
+                isEñeFallback = true;
+            }
+
             if (syllable.IsStartingV) {
-                basePhoneme = rcv;
-                if (!HasOto(rcv, syllable.vowelTone)) {
+                basePhoneme = rv;
+                if (!HasOto(rv, syllable.vowelTone)) {
                     basePhoneme = $"{v}";
                 }
             } else if (syllable.IsVV) {
@@ -71,275 +128,151 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             } else if (syllable.IsStartingCVWithOneConsonant) {
                 // TODO: move to config -CV or -C CV
-                var rc = $"- {cc[0]}{v}";
-                var src = $"- s{v}";
-                if (HasOto(rc, syllable.vowelTone)) {
-                    basePhoneme = rc;
-                } else if (cc[0] == "z"
-                    && !HasOto(cc[0], syllable.vowelTone)
-                    && HasOto(src, syllable.vowelTone)) {
-                    basePhoneme = src;
+                var rcv = $"- {cc[0]}{v}";
+                if (HasOto(rcv, syllable.vowelTone) || HasOto(ValidateAlias(rcv), syllable.vowelTone)) {
+                    basePhoneme = rcv;
                 } else {
                     basePhoneme = $"{cc[0]}{v}";
                 }
             } else if (syllable.IsStartingCVWithMoreThanOneConsonant) {
                 // try RCCV
-                var rvvc = $"- {string.Join("", cc)}{v}";
-                var vvc = string.Join("", cc) + v;
-                if (HasOto(rvvc, syllable.vowelTone)) {
-                    basePhoneme = rvvc;
-                } else if (!HasOto(rvvc, syllable.vowelTone) && HasOto(ValidateAlias(rvvc), syllable.vowelTone)) {
-                    basePhoneme = ValidateAlias(rvvc);
-                } else if (!HasOto(ValidateAlias(rvvc), syllable.vowelTone) && HasOto(vvc, syllable.vowelTone)) {
-                    basePhoneme = vvc;
-                } else if (!HasOto(vvc, syllable.vowelTone) && HasOto(ValidateAlias(vvc), syllable.vowelTone)) {
-                    basePhoneme = ValidateAlias(vvc);
+                var rccv = $"- {string.Join("", cc)}{v}";
+                var ccv = string.Join("", cc) + v;
+                var crv = $"{cc.Last()} {v}";
+                if ((HasOto(rccv, syllable.vowelTone) || HasOto(ValidateAlias(rccv), syllable.vowelTone)) && (initialCC.Contains(string.Join("", cc)) || initialCC.Contains(ValidateAlias(string.Join("", cc))))) {
+                    basePhoneme = rccv;
+                    lastC = 0;
+                } else if (!HasOto(rccv, syllable.vowelTone) && !HasOto(ValidateAlias(rccv), syllable.vowelTone) && (HasOto(ccv, syllable.vowelTone) || HasOto(ValidateAlias(ccv), syllable.vowelTone)) && (initialCC.Contains(string.Join("", cc)) || initialCC.Contains(ValidateAlias(string.Join("", cc))))) {
+                    basePhoneme = ccv;
+                    lastC = 0;
                 } else {
-                    basePhoneme = $"{cc.Last()}{v}";
+                    basePhoneme = ValidateAlias(crv);
+                    if (!HasOto(ValidateAlias(crv), syllable.vowelTone)) {
+                        basePhoneme = $"{cc.Last()}{v}";
+                    }
                     // try RCC
                     for (var i = cc.Length; i > 1; i--) {
-                        if (TryAddPhoneme(phonemes, syllable.tone, $"- {string.Join("", cc.Take(i))}", ValidateAlias($"- {string.Join("", cc.Take(i))}"), string.Join("", cc.Take(i)), ValidateAlias(string.Join("", cc.Take(i))))) {
-                            firstC = i;
-                            break;
+                        var rcc = $"- {string.Join("", cc.Take(i))}";
+                        var cc1 = string.Join("", cc.Take(i));
+                        if (initialCC.Contains(string.Join("", cc.Take(i))) || initialCC.Contains(ValidateAlias(string.Join("", cc.Take(i))))) {
+                            if (TryAddPhoneme(phonemes, syllable.tone, rcc, ValidateAlias(rcc), cc1, ValidateAlias(cc1))) {
+                                firstC = i - 1;
+                                break;
+                            }
                         }
                     }
                     if (phonemes.Count == 0) {
                         TryAddPhoneme(phonemes, syllable.tone, $"- {cc[0]}", ValidateAlias($"- {cc[0]}"));
                     }
-                    // try CCV
-                    for (var i = firstC; i < cc.Length - 1; i++) {
-                        var ccv = string.Join("", cc.Skip(i)) + v;
-                        if (HasOto(ccv, syllable.tone)) {
-                            basePhoneme = ccv;
-                            lastC = i;
-                            if (!HasOto(ccv, syllable.tone)) {
-                                ccv = ValidateAlias(ccv);
-                                basePhoneme = ccv;
-                                lastC = i;
-                                break;
-                            }
-                            break;
-                        }
-                    }
                 }
             } else { // VCV
                 var vcv = $"{prevV} {cc[0]}{v}";
                 var vccv = $"{prevV} {string.Join("", cc)}{v}";
-                var nyvcv = $"{prevV} ny{v}";
-                var svcv = $"{prevV} s{v}";
-                var syvccv = $"{prevV} sy{v}";
-                var swvccv = $"{prevV} sw{v}";
-                if (HasOto(vcv, syllable.vowelTone)
+                if ((HasOto(vcv, syllable.vowelTone) || HasOto(ValidateAlias(vcv), syllable.vowelTone))
                     && (syllable.IsVCVWithOneConsonant)) {
                     basePhoneme = vcv;
-                } else if (cc[0] == "nh"
-                    && !HasOto(cc[0], syllable.vowelTone)
-                    && HasOto(nyvcv, syllable.vowelTone)
-                    && syllable.IsVCVWithOneConsonant) {
-                    basePhoneme = nyvcv;
-                } else if (cc[0] == "z"
-                    && !HasOto(cc[0], syllable.vowelTone)
-                    && HasOto(svcv, syllable.vowelTone)
-                    && syllable.IsVCVWithOneConsonant) {
-                    basePhoneme = svcv;
-                } else if (string.Join("", cc) == "zy"
-                    && !HasOto(string.Join("", cc), syllable.vowelTone)
-                    && HasOto(syvccv, syllable.vowelTone)
-                    && syllable.IsVCVWithMoreThanOneConsonant) {
-                    basePhoneme = syvccv;
-                } else if (string.Join("", cc) == "zw"
-                    && !HasOto(string.Join("", cc), syllable.vowelTone)
-                    && HasOto(swvccv, syllable.vowelTone)
-                    && syllable.IsVCVWithMoreThanOneConsonant) {
-                    basePhoneme = swvccv;
-                } else if (HasOto(vccv, syllable.vowelTone)
+                } else if ((HasOto(vccv, syllable.vowelTone) || HasOto(ValidateAlias(vccv), syllable.vowelTone))
                     && syllable.IsVCVWithMoreThanOneConsonant
-                    && !notClusters.Contains(string.Join("", cc))) {
+                    && (initialCC.Contains(string.Join("", cc)) || initialCC.Contains(ValidateAlias(string.Join("", cc))))) {
                     basePhoneme = vccv;
-                } else { 
-                    basePhoneme = cc.Last() + v;
+                    lastC = 0;
+                } else {
+                    var cv = cc.Last() + v;
+                    var crv = $"{cc.Last()} {v}";
+                    basePhoneme = cv;
+                    if (!HasOto(cv, syllable.vowelTone) && !HasOto(ValidateAlias(cv), syllable.vowelTone)) {
+                        basePhoneme = crv;
+                    }
+
                     // try CCV
                     if (cc.Length - firstC > 1) {
-                        for (var i = firstC; i < cc.Length; i++) {
+                        for (var i = firstC; i < lastC; i++) {
                             var ccv = $"{string.Join("", cc.Skip(i))}{v}";
                             var ccv2 = $"{string.Join(" ", cc.Skip(i))}{v}";
                             var ccv3 = $"{cc[0]} {string.Join("", cc.Skip(i))}{v}";
-                            if (HasOto(ccv, syllable.vowelTone) && !notClusters.Contains(string.Join("", cc.Skip(i)))) {
+                            if ((HasOto(ccv, syllable.vowelTone) || HasOto(ValidateAlias(ccv), syllable.vowelTone)) && (initialCC.Contains(string.Join("", cc.Skip(i))) || initialCC.Contains(ValidateAlias(string.Join("", cc.Skip(i)))))) {
                                 lastC = i;
                                 basePhoneme = ccv;
-                                if (!HasOto(ccv, syllable.vowelTone)) {
-                                    ccv = ValidateAlias(ccv);
-                                    lastC = i;
-                                    basePhoneme = ccv;
-                                    break;
-                                }
                                 break;
-                            } else if (HasOto(ccv2, syllable.vowelTone)) {
+                            } else if (HasOto(ccv2, syllable.vowelTone) || HasOto(ValidateAlias(ccv2), syllable.vowelTone)) {
                                 lastC = i;
                                 basePhoneme = ccv2;
-                                if (!HasOto(ccv2, syllable.vowelTone)) {
-                                    ccv2 = ValidateAlias(ccv);
-                                    lastC = i;
-                                    basePhoneme = ccv2;
-                                    break;
-                                }
                                 break;
-                            } else if (HasOto(ccv3, syllable.vowelTone) && !notClusters.Contains(string.Join("", cc.Skip(i)))) {
+                            } else if ((HasOto(ccv3, syllable.vowelTone) || HasOto(ValidateAlias(ccv3), syllable.vowelTone)) && (initialCC.Contains(string.Join("", cc.Skip(i))) || initialCC.Contains(ValidateAlias(string.Join("", cc.Skip(i)))))) {
                                 lastC = i;
                                 basePhoneme = ccv3;
-                                if (!HasOto(ccv3, syllable.vowelTone)) {
-                                    ccv3 = ValidateAlias(ccv3);
-                                    lastC = i;
-                                    basePhoneme = ccv3;
-                                    break;
-                                }
                                 break;
+                            } else {
+                                continue;
                             }
                         }
                     }
-                    // try vc
+                    // try vcc or vc
                     for (var i = lastC + 1; i >= 0; i--) {
                         var vc1 = $"{prevV} {cc[0]}";
                         var vc2 = $"{prevV}{cc[0]}";
-                        // try vcc
-                        var vcc = $"{prevV} {string.Join("", cc.Take(i))}";
-                        var vcc2 = $"{prevV}{string.Join("", cc.Take(i))}";
-                        if (i == 0 && HasOto(vc1, syllable.tone)) {
-                            phonemes.Add(vc1);
-                            if (!HasOto(vc1, syllable.tone)) {
-                                vc1 = ValidateAlias(vc1);
-                                phonemes.Add(vc1);
-                                break;
-                            }
-                            break;
-                        } else if (HasOto(vcc, syllable.tone) && !notClusters.Contains(string.Join("", cc.Take(i)))) {
+                        var vcc = $"{prevV} {string.Join("", cc.Take(2))}";
+                        var vcc2 = $"{prevV}{string.Join("", cc.Take(2))}";
+                        if ((HasOto(ValidateAlias(vcc), syllable.tone) || HasOto(ValidateAlias(vcc), syllable.tone)) && (!notClusters.Contains(string.Join("", cc.Take(2))) && !notClusters.Contains(ValidateAlias(string.Join("", cc.Take(2)))))) {
                             phonemes.Add(vcc);
-                            firstC = i - 1;
-                            if (!HasOto(vcc, syllable.tone)) {
-                                vcc = ValidateAlias(vcc);
-                                phonemes.Add(vcc);
-                                firstC = i - 1;
-                                break;
-                            }
+                            firstC = 1;
                             break;
-                        } else if (HasOto(vcc2, syllable.tone) && !notClusters.Contains(string.Join("", cc.Take(i)))) {
+                        } else if ((HasOto(vcc2, syllable.tone) || HasOto(ValidateAlias(vcc2), syllable.tone)) && (!notClusters.Contains(string.Join("", cc.Take(2))) && !notClusters.Contains(ValidateAlias(string.Join("", cc.Take(2)))))) {
                             phonemes.Add(vcc2);
-                            firstC = i - 1;
-                            if (!HasOto(vcc2, syllable.tone)) {
-                                vcc2 = ValidateAlias(vcc2);
-                                phonemes.Add(vcc2);
-                                firstC = i - 1;
-                                break;
-                            }
+                            firstC = 1;
                             break;
-                        } else if (!HasOto(vc1, syllable.tone) && HasOto(vc2, syllable.tone)) {
+                        } else if ((HasOto(vc1, syllable.tone) || HasOto(ValidateAlias(vc1), syllable.tone))) {
+                            phonemes.Add(vc1);
+                            break;
+                        } else if (HasOto(vc2, syllable.tone) || HasOto(ValidateAlias(vc2), syllable.tone)) {
                             phonemes.Add(vc2);
-                            if (!HasOto(vc2, syllable.tone)) {
-                                vc2 = ValidateAlias(vc1);
-                                phonemes.Add(vc2);
-                                break;
-                            }
                             break;
-                        } else if (!HasOto(vc1, syllable.tone) && !HasOto(vc2, syllable.tone)) {
-                            continue;
                         }
                     }
-                    if (cc.Length - firstC > 1) {
-                        for (var i = firstC; i < cc.Length; i++) {
-                            var spccv = $"{string.Join("", cc.Skip(i))}{v}";
-                            var ccv3 = $"{cc[0]} {string.Join("", cc.Skip(i))}{v}";
-                            var syccv = $"{cc[0]} sy{v}";
-                            var swccv = $"{cc[0]} sw{v}";
-                            if (specialClusters.Contains(string.Join("", cc.Skip(i)))) {
-                                lastC = i;
-                                basePhoneme = spccv;
-                                if (!HasOto(spccv, syllable.vowelTone)) {
-                                    spccv = ValidateAlias(spccv);
-                                    lastC = i;
-                                    basePhoneme = spccv;
-                                }
-                            }
-                            if (specialClusters.Contains(string.Join("", cc.Skip(i))) && HasOto(ccv3, syllable.vowelTone)) {
-                                lastC = i;
-                                basePhoneme = ccv3;
-                                if (!HasOto(ccv3, syllable.vowelTone)) {
-                                    ccv3 = ValidateAlias(ccv3);
-                                    lastC = i;
-                                    basePhoneme = ccv3;
-                                }
-                            }
-                            if (string.Join("", cc) == "zy"
-                                && !HasOto(string.Join("", cc), syllable.vowelTone)
-                                && HasOto(syccv, syllable.vowelTone)) {
-                                lastC = i;
-                                basePhoneme = syccv;
-                            }
-                            if (string.Join("", cc) == "zw"
-                                && !HasOto(string.Join("", cc), syllable.vowelTone)
-                                && HasOto(swccv, syllable.vowelTone)) {
-                                lastC = i;
-                                basePhoneme = swccv;
-                            }
-                        }
-                    }
-
                 }
             }
-            var rccv = $"- {string.Join("", cc)}{v}";
-            if (!HasOto(rccv, syllable.vowelTone) && !HasOto(ValidateAlias(rccv), syllable.vowelTone)) {
-                for (var i = firstC; i < lastC; i++) {
-                    // we could use some CCV, so lastC is used
-                    // we could use -CC so firstC is used
-                    var cc1 = $"{cc[i]} {cc[i + 1]}";
-                    var ncc1 = $"{cc[i]} n";
-                    if (!HasOto(cc1, syllable.tone)) {
-                        cc1 = ValidateAlias(cc1);
+            for (var i = firstC; i < lastC; i++) {
+                // we could use some CCV, so lastC is used
+                // we could use -CC so firstC is used
+                var cc1 = $"{cc[i]}{cc[i + 1]}";
+
+                // Use [C1C2]
+                if (!HasOto(cc1, syllable.tone)) {
+                    cc1 = ValidateAlias(cc1);
+                }
+                // Use [C1 C2]
+                if (!HasOto(cc1, syllable.tone)) {
+                    cc1 = $"{cc[i]} {cc[i + 1]}";
+                }
+                if (!HasOto(cc1, syllable.tone)) {
+                    cc1 = ValidateAlias(cc1);
+                }
+                if (i + 1 < lastC) {
+                    var cc2 = $"{cc[i + 1]}{cc[i + 2]}";
+
+                    // Use [C2C3]
+                    if (!HasOto(cc2, syllable.tone)) {
+                        cc2 = ValidateAlias(cc2);
                     }
-                    if (!HasOto(cc1, syllable.tone)) {
-                        cc1 = $"{cc[i]}{cc[i + 1]}";
+                    // Use [C2 C3]
+                    if (!HasOto(cc2, syllable.tone)) {
+                        cc2 = $"{cc[i + 1]} {cc[i + 2]}";
                     }
-                    if (!HasOto(cc1, syllable.tone)) {
-                        cc1 = ValidateAlias(cc1);
+                    if (!HasOto(cc2, syllable.tone)) {
+                        cc2 = ValidateAlias(cc2);
                     }
-                    if (i + 1 < lastC) {
-                        var cc2 = $"{cc[i + 1]} {cc[i + 2]}";
-                        var ncc2 = $"{cc[i + 1]} n";
-                        if (!HasOto(cc2, syllable.tone)) {
-                            cc2 = ValidateAlias(cc2);
-                        }
-                        if (!HasOto(cc2, syllable.tone)) {
-                            cc2 = $"{cc[i + 1]}{cc[i + 2]}";
-                        }
-                        if (!HasOto(cc2, syllable.tone)) {
-                            cc2 = ValidateAlias(cc2);
-                        }
-                        if (HasOto(cc1, syllable.tone) && HasOto(cc2, syllable.tone)) {
-                            // like [V C1] [C1 C2] [C2 C3] [C3 ..]
-                            phonemes.Add(cc1);
-                        } else if (TryAddPhoneme(phonemes, syllable.tone, $"{cc[i]} {cc[i + 1]}-", ValidateAlias($"{cc[i]} {cc[i + 1]}-"))) {
-                            // like [V C1] [C1 C2-] [C3 ..]
-                            i++;
-                        } else if (TryAddPhoneme(phonemes, syllable.tone, cc1, ValidateAlias(cc1))) {
-                            if (cc[i + 2] == "nh" && !HasOto(cc[i + 2], syllable.tone)) {
-                                TryAddPhoneme(phonemes, syllable.tone, ncc2, ValidateAlias(ncc2)); ;
-                            }
-                            // like [V C1] [C1 C2] [C2 ..]
-                        } else if (!HasOto(cc1, syllable.tone) && firstC == i - 1 && cc[i] != cc[0]) {
-                            TryAddPhoneme(phonemes, syllable.tone, cc[i], ValidateAlias(cc[i]));
-                        }
-                        if (!HasOto(cc2, syllable.tone) && firstC == i - 1 && cc[i + 1] != cc[1]) {
-                            TryAddPhoneme(phonemes, syllable.tone, cc[i + 1], ValidateAlias(cc[i + 1]));
-                        }
+                    if ((HasOto(cc1, syllable.tone) || HasOto(ValidateAlias(cc1), syllable.tone)) && (HasOto(cc2, syllable.tone) || HasOto(ValidateAlias(cc2), syllable.tone))) {
+                        // like [V C1] [C1 C2] [C2 C3] [C3 ..]
+                        phonemes.Add(cc1);
+                    } else if (TryAddPhoneme(phonemes, syllable.tone, cc1, ValidateAlias(cc1))) {
+                        // like [V C1] [C1 C2] [C2 ..]
                     } else {
-                        // like [V C1] [C1 C2]  [C2 ..] or like [V C1] [C1 -] [C3 ..]
-                        TryAddPhoneme(phonemes, syllable.tone, cc1);
-                        if (cc[i + 1] == "nh" && !HasOto(cc[i + 1], syllable.tone)) {
-                            TryAddPhoneme(phonemes, syllable.tone, ncc1, ValidateAlias(ncc1));
-                        }
-                        if (!HasOto(cc1, syllable.tone) && firstC == i - 1 && cc[i] != cc[0]) {
-                            TryAddPhoneme(phonemes, syllable.tone, cc[i], ValidateAlias(cc[i]));
-                        }
+                        // like[V C1][C1][C2..]
+                        TryAddPhoneme(phonemes, syllable.tone, cc[i], ValidateAlias(cc[i]));
                     }
+                } else {
+                    // like [V C1] [C1 C2]  [C2 ..] or like [V C1] [C1 -] [C3 ..]
+                    TryAddPhoneme(phonemes, syllable.tone, cc1, cc[i], ValidateAlias(cc[i]));
                 }
             }
 
@@ -352,56 +285,138 @@ namespace OpenUtau.Plugin.Builtin {
             string v = ending.prevV;
 
             var phonemes = new List<string>();
-            if (ending.IsEndingV) {   // ending V
-                TryAddPhoneme(phonemes, ending.tone, $"{v} R", $"{v} -", $"{v}-");
-            } else if (ending.IsEndingVCWithOneConsonant) {   // ending VC
-                TryAddPhoneme(phonemes, ending.tone, $"{v} {cc[0]}-", ValidateAlias($"{v} {cc[0]}-"), $"{v}{cc[0]}-", ValidateAlias($"{v}{cc[0]}-"), $"{v} {cc[0]}", ValidateAlias($"{v} {cc[0]}"), $"{v}{cc[0]}", ValidateAlias($"{v}{cc[0]}"), cc[0], ValidateAlias(cc[0]));
-            } else if (ending.IsEndingVCWithMoreThanOneConsonant) {   // ending VCC (very rare, usually only occurs in words ending with "x")
-                var vcc = $"{v} {string.Join("", cc)}";
-                var vcc2 = $"{v}{string.Join("", cc)}";
+
+            var lastC = cc.Length - 1;
+            var firstC = 0;
+
+            if (ending.IsEndingV) { // ending V
+                TryAddPhoneme(phonemes, ending.tone, $"{v} -", $"{v}-", $"{v} R");
+            } else if (ending.IsEndingVCWithOneConsonant) { // ending VC
+                var vcr = $"{v} {cc[0]}-";
+                var vcr2 = $"{v}{cc[0]}-";
                 var vc = $"{v} {cc[0]}";
                 var vc2 = $"{v}{cc[0]}";
-                var cc1 = $"{cc[0]} {cc[1]}";
-                var cc2 = $"{cc[0]}{cc[1]}";
-                TryAddPhoneme(phonemes, ending.tone, vcc, vcc2);
-                if (!HasOto(vcc, ending.tone) && !HasOto(vcc2, ending.tone) && HasOto(vc, ending.tone)) {
-                    phonemes.Add(vc);
-                    if (!HasOto(vc, ending.tone)) {
-                        vc = ValidateAlias(vc);
+                if (HasOto(vcr, ending.tone) || HasOto(ValidateAlias(vcr), ending.tone)) {
+                    phonemes.Add(vcr);
+                } else if (HasOto(vcr2, ending.tone) || HasOto(ValidateAlias(vcr2), ending.tone)) {
+                    phonemes.Add(vcr2);
+                } else {
+                    if (HasOto(vc, ending.tone) || HasOto(ValidateAlias(vc), ending.tone)) {
                         phonemes.Add(vc);
-                    }
-                    TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1));
-                    if (!HasOto(cc1, ending.tone)) {
-                        TryAddPhoneme(phonemes, ending.tone, cc2, ValidateAlias(cc2));
-                    }
-                    if (!HasOto(cc1, ending.tone) && !HasOto(cc2, ending.tone)) {
-                        TryAddPhoneme(phonemes, ending.tone, cc[0] + cc[1], ValidateAlias(cc[0] + cc[1]));
-                    }
-                }
-                if (!HasOto(vcc, ending.tone) && !HasOto(vcc2, ending.tone) && !HasOto(vc, ending.tone) && HasOto(vc2, ending.tone)) {
-                    phonemes.Add(vc2);
-                    if (!HasOto(vc2, ending.tone)) {
-                        vc2 = ValidateAlias(vc2);
+                    } else if (HasOto(vc2, ending.tone) || HasOto(ValidateAlias(vc2), ending.tone)) {
                         phonemes.Add(vc2);
                     }
-                    TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1));
-                    if (!HasOto(cc1, ending.tone)) {
-                        TryAddPhoneme(phonemes, ending.tone, cc2, ValidateAlias(cc2));
-                    } else if (!HasOto(cc1, ending.tone) && !HasOto(cc2, ending.tone)) {
-                        TryAddPhoneme(phonemes, ending.tone, cc[0] + cc[1], ValidateAlias(cc[0] + cc[1]));
+                    if (burstConsonants.Contains(cc[0]) || burstConsonants.Contains(ValidateAlias(cc[0]))) {
+                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", $"{ValidateAlias(cc[0])} -", cc[0], ValidateAlias(cc[0]));
+                    } else {
+                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", $"{ValidateAlias(cc[0])} -", $"{cc[0]}-", $"{ValidateAlias(cc[0])}-", $"{cc[0]} R", $"{ValidateAlias(cc[0])} R");
                     }
                 }
-                if (!HasOto(vcc, ending.tone) && !HasOto(vcc2, ending.tone) && !HasOto(vc, ending.tone) && !HasOto(vc2, ending.tone)) {
-                    phonemes.Add(cc[0]);
-                    if (!HasOto(cc[0], ending.tone)) {
-                        cc[0] = ValidateAlias(cc[0]);
-                        phonemes.Add(cc[0]);
+            } else { // ending VCC (very rare, usually only occurs in words ending with "x")
+                for (var i = lastC; i >= 0; i--) {
+                    var vcc = $"{v} {string.Join("", cc.Take(2))}-";
+                    var vcc3 = $"{v}{string.Join("", cc.Take(2))}";
+                    var vcc2 = $"{v} {string.Join("", cc.Take(2))}";
+                    var vcc4 = $"{v}{string.Join(" ", cc.Take(2))}-";
+                    var vc = $"{v} {cc[0]}";
+                    var vc2 = $"{v}{cc[0]}";
+                    if ((HasOto(vcc, ending.tone) || HasOto(ValidateAlias(vcc), ending.tone)) && lastC == 1 && !notClusters.Contains(string.Join("", cc.Take(2))) && !notClusters.Contains(ValidateAlias(string.Join("", cc.Take(2))))) {
+                        phonemes.Add(vcc);
+                        firstC = 1;
+                        break;
+                    } else if ((HasOto(vcc2, ending.tone) || HasOto(ValidateAlias(vcc2), ending.tone)) && !notClusters.Contains(string.Join("", cc.Take(2))) && !notClusters.Contains(ValidateAlias(string.Join("", cc.Take(2))))) {
+                        phonemes.Add(vcc2);
+                        firstC = 1;
+                        break;
+                    } else if ((HasOto(vcc3, ending.tone) || HasOto(ValidateAlias(vcc3), ending.tone)) && !notClusters.Contains(string.Join("", cc.Take(2))) && !notClusters.Contains(ValidateAlias(string.Join("", cc.Take(2))))) {
+                        phonemes.Add(vcc3);
+                        firstC = 1;
+                        break;
+                    } else if ((HasOto(vcc4, ending.tone) || HasOto(ValidateAlias(vcc4), ending.tone)) && lastC == 1 && !notClusters.Contains(string.Join("", cc.Take(2))) && !notClusters.Contains(ValidateAlias(string.Join("", cc.Take(2))))) {
+                        phonemes.Add(vcc4);
+                        firstC = 1;
+                        break;
+                    } else
+                    if (HasOto(vc, ending.tone) || HasOto(ValidateAlias(vc), ending.tone)) {
+                        phonemes.Add(vc);
+                        break;
+                    } else {
+                        TryAddPhoneme(phonemes, ending.tone, vc2, ValidateAlias(vc2));
+                        break;
                     }
-                    TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1));
-                    if (!HasOto(cc1, ending.tone)) {
-                        TryAddPhoneme(phonemes, ending.tone, cc2, ValidateAlias(cc2));
-                    } else if (!HasOto(cc1, ending.tone) && !HasOto(cc2, ending.tone)) {
-                        TryAddPhoneme(phonemes, ending.tone, cc[1], ValidateAlias(cc[1]));
+                }
+
+                for (var i = firstC; i < lastC; i++) {
+                    // all CCs except the first one are /C1C2/, the last one is /C1 C2-/
+                    // but if there is no /C1C2/, we try /C1 C2-/, vise versa for the last one
+                    var cc1 = $"{cc[i]} {cc[i + 1]}";
+                    if (i < cc.Length - 2) {
+                        var cc2 = $"{cc[i + 1]} {cc[i + 2]}";
+                        if (!HasOto(cc1, ending.tone)) {
+                            cc1 = ValidateAlias(cc1);
+                        }
+                        if (!HasOto(cc1, ending.tone) && !notClusters.Contains($"{cc[i]}{cc[i + 1]}") && !notClusters.Contains(ValidateAlias($"{cc[i]}{cc[i + 1]}"))) {
+                            cc1 = $"{cc[i]}{cc[i + 1]}";
+                        }
+                        if (!HasOto(cc1, ending.tone)) {
+                            cc1 = ValidateAlias(cc1);
+                        }
+                        if (!HasOto(cc2, ending.tone)) {
+                            cc2 = ValidateAlias(cc2);
+                        }
+                        if (!HasOto(cc2, ending.tone)) {
+                            cc2 = $"{cc[i + 1]}{cc[i + 2]}";
+                        }
+                        if (!HasOto(cc2, ending.tone)) {
+                            cc2 = ValidateAlias(cc2);
+                        }
+                        if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone)) || HasOto($"{cc[i + 1]}{cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]}{cc[i + 2]}-"), ending.tone)) {
+                            // like [C1 C2][C2 ...]
+                            phonemes.Add(cc1);
+                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone) || HasOto($"{cc[i + 1]}{cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]}{cc[i + 2]}-"), ending.tone)))) {
+                            // like [C1 C2-][C3 ...]
+                            phonemes.Add(cc[i]);
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}-", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), $"{cc[i + 1]}{cc[i + 2]}-", ValidateAlias($"{cc[i + 1]}{cc[i + 2]}-"))) {
+                            // like [C1 C2-][C3 ...]
+                            i++;
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]}{cc[i + 2]}", ValidateAlias($"{cc[i + 1]}{cc[i + 2]}"))) {
+                            // like [C1C2][C2 ...]
+                            i++;
+                        } else if (TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1))) {
+                            i++;
+                        } else {
+                            // like [C1][C2 ...]
+                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} -", ValidateAlias($"{cc[i]} -"));
+                            TryAddPhoneme(phonemes, ending.tone, cc[i + 1], ValidateAlias(cc[i + 1]), $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"));
+                            i++;
+                        }
+                    } else {
+                        if (!HasOto(cc1, ending.tone)) {
+                            cc1 = ValidateAlias(cc1);
+                        }
+                        if (!HasOto(cc1, ending.tone)) {
+                            cc1 = $"{cc[i]}{cc[i + 1]}";
+                        }
+                        if (!HasOto(cc1, ending.tone)) {
+                            cc1 = ValidateAlias(cc1);
+                        }
+                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}-", ValidateAlias($"{cc[i]} {cc[i + 1]}-"), $"{cc[i]}{cc[i + 1]}-", ValidateAlias($"{cc[i]}{cc[i + 1]}-"))) {
+                            // like [C1 C2-]
+                            i++;
+                        } else if (TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1))) {
+                            // like [C1 C2][C2 -]
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"), cc[i + 1], ValidateAlias(cc[i + 1]));
+                            i++;
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}", ValidateAlias($"{cc[i]}{cc[i + 1]}"))) {
+                            // like [C1C2][C2 -]
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"), cc[i + 1], ValidateAlias(cc[i + 1]));
+                            i++;
+                        } else {
+                            // like [C1][C2 -]
+                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} -", ValidateAlias($"{cc[i]} -"));
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"), cc[i + 1], ValidateAlias(cc[i + 1]));
+                            i++;
+                        }
                     }
                 }
             }
@@ -409,43 +424,38 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override string ValidateAlias(string alias) {
-            foreach (var consonant in new[] { "j" }) {
-                alias = alias.Replace(consonant, "ll");
-            }
-            foreach (var consonant in specialClusters) {
-                alias = alias.Replace("w", "u");
-            }
-            foreach (var consonant in new[] { "z" }) {
-                alias = alias.Replace(consonant, "s");
-            }
-            foreach (var consonant in specialClusters) {
-                alias = alias.Replace("y", "i");
-            }
-            foreach (var consonant in new[] { "nh" }) {
-                alias = alias.Replace(consonant, "ny");
-            }
-            foreach (var consonant in new[] { " nh" }) {
-                alias = alias.Replace(consonant, " n");
-            }
-            foreach (var vowel in vowels) {
-                foreach (var consonant in new[] { " ny" }) {
-                    return alias.Replace(vowel + consonant, vowel + " n");
+            // Validate alias depending on method
+            if (isSeseo) {
+                foreach (var syllable in seseo) {
+                    alias = alias.Replace(syllable.Key, syllable.Value);
                 }
             }
-            foreach (var consonant1 in consonants) {
-                foreach (var consonant2 in new[] { " ny" }) {
-                    return alias.Replace(consonant1 + consonant2, consonant1 + " n");
+            if (isSemiVowelFallback) {
+                foreach (var syllable in semiVowelFallback) {
+                    alias = alias.Replace(syllable.Key, syllable.Value);
                 }
             }
-            foreach (var vowel in vowels) {
-                foreach (var consonant in new[] { " nh" }) {
-                    return alias.Replace(vowel + consonant, vowel + " n");
+            if (isEñeFallback) {
+                foreach (var syllable in eñeFallback) {
+                    alias = alias.Replace(syllable.Key, syllable.Value);
                 }
             }
-            foreach (var consonant1 in consonants) {
-                foreach (var consonant2 in new[] { " nh" }) {
-                    return alias.Replace(consonant1 + consonant2, consonant1 + " n");
-                }
+
+            // Other validations
+            if (alias.Contains("I")) {
+                alias = alias.Replace("I", "i");
+            }
+            if (alias.Contains("U")) {
+                alias = alias.Replace("U", "u");
+            }
+            foreach (var cc in new[] { "ks" }) {
+                alias = alias.Replace("ks", "x");
+            }
+            if (alias == "r") {
+                alias = alias.Replace("r", "rr");
+            }
+            if (alias == "ch") {
+                alias = alias.Replace("ch", "tch");
             }
             return alias;
         }


### PR DESCRIPTION
This is an important refactor that has been long overdue.

- Fixes several bugs, mostly related to ``ValidateAlias()`` as well as some others.
- Adds custom dictionary support (``es-syl.yaml``). No dictionary template has been added; I might do this if there's demand.

I might take a look at the other Spanish phonemizers as well at some point, though this one was arguably the most outdated.