### PR TITLE
Enable IME input on X11 platforms such as Linux

### DIFF
--- a/OpenUtau/Program.cs
+++ b/OpenUtau/Program.cs
@@ -70,7 +70,8 @@ namespace OpenUtau.App {
                 .UsePlatformDetect()
                 .LogToTrace()
                 .UseReactiveUI()
-                .With(fontOptions);
+                .With(fontOptions)
+                .With(new X11PlatformOptions {EnableIme = true});
         }
 
         public static void Run(string[] args)


### PR DESCRIPTION
![image](https://github.com/stakira/OpenUtau/assets/155589502/6006b9e1-3569-4330-8290-9003b9dc8e1f)

This PR enables support for IME input methods that does not appear to be supported when OpenUtau is compiled for Linux.

Tested working using IBus w/ Anthy. Built and tested on windows as well, the option does not appear to affect other platforms

Reference: https://github.com/AvaloniaUI/Avalonia/issues/6155