### PR TITLE
language name localization

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -46,13 +46,13 @@
   <system:String x:Key="dialogs.messagebox.yes">Yes</system:String>
   <system:String x:Key="dialogs.noresampler.caption">No resampler</system:String>
   <system:String x:Key="dialogs.noresampler.message">No resampler! Put your favourite resampler exe or dll in the Resamplers folder and choose it in Preferences!</system:String>
-  <system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>
-  <system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>
   <system:String x:Key="dialogs.timesig.caption">Time Signature</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">Track Settings</system:String>
   <system:String x:Key="dialogs.tracksettings.location">Location</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>
+  <system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>
+  <system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>
   <system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>
 
@@ -74,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Curve</system:String>
   <system:String x:Key="exps.type.numerical">Numerical</system:String>
   <system:String x:Key="exps.type.options">Options</system:String>
+
+  <system:String x:Key="languages.de">German</system:String>
+  <system:String x:Key="languages.en">English</system:String>
+  <system:String x:Key="languages.es">Spanish</system:String>
+  <system:String x:Key="languages.fr">French</system:String>
+  <system:String x:Key="languages.it">Italian</system:String>
+  <system:String x:Key="languages.ja">Japanese</system:String>
+  <system:String x:Key="languages.ko">Korean</system:String>
+  <system:String x:Key="languages.pl">Polish</system:String>
+  <system:String x:Key="languages.pt">Portuguese</system:String>
+  <system:String x:Key="languages.ru">Russian</system:String>
+  <system:String x:Key="languages.vi">Vietnamese</system:String>
+  <system:String x:Key="languages.zh">Chinese</system:String>
+  <system:String x:Key="languages.zh-yue">Cantonese</system:String>
 
   <system:String x:Key="lyrics.apply">Apply</system:String>
   <system:String x:Key="lyrics.cancel">Cancel</system:String>

--- a/OpenUtau/Strings/Strings.de-DE.axaml
+++ b/OpenUtau/Strings/Strings.de-DE.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Position</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Als Standard festlegen</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Kurve</system:String>
   <system:String x:Key="exps.type.numerical">Numerisch</system:String>
   <system:String x:Key="exps.type.options">Optionen</system:String>
+
+  <system:String x:Key="languages.de">Deutsch</system:String>
+  <system:String x:Key="languages.en">Englisch</system:String>
+  <system:String x:Key="languages.es">Spanisch</system:String>
+  <system:String x:Key="languages.fr">Französisch</system:String>
+  <system:String x:Key="languages.it">Italienisch</system:String>
+  <system:String x:Key="languages.ja">Japanisch</system:String>
+  <system:String x:Key="languages.ko">Koreanisch</system:String>
+  <system:String x:Key="languages.pl">Polnisch</system:String>
+  <system:String x:Key="languages.pt">Portugiesisch</system:String>
+  <system:String x:Key="languages.ru">Russisch</system:String>
+  <system:String x:Key="languages.vi">Vietnamesisch</system:String>
+  <system:String x:Key="languages.zh">Chinesisch</system:String>
+  <system:String x:Key="languages.zh-yue">Kantonesisch</system:String>
 
   <system:String x:Key="lyrics.apply">Anwenden</system:String>
   <system:String x:Key="lyrics.cancel">Abbrechen</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Werkzeuge</system:String>
   <system:String x:Key="menu.tools.clearcache">Cache leeren</system:String>
   <system:String x:Key="menu.tools.debugwindow">Debug Fenster</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <!--<system:String x:Key="menu.tools.layout">Layout</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit11">Horizontal 1:1</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit12">Horizontal 1:2</system:String>-->
@@ -296,6 +313,7 @@ Warnung: Diese Option entfernt alle benutzerdefinierten Einstellungen.</system:S
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Sprache</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Die Noten anderer Tonspuren im Piano-Modus anzeigen.</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Portrait im Piano-Modus anzeigen</system:String>
   <system:String x:Key="prefs.appearance.sortorder">Sänger Sortierreihenfolge</system:String>
   <system:String x:Key="prefs.appearance.theme">Aussehen</system:String>
@@ -399,6 +417,7 @@ Warnung: moresampler wird nicht vollständig unterstützt. Es kann das Programm 
   <system:String x:Key="singers.subbanks.set">Setzen</system:String>
   <system:String x:Key="singers.subbanks.tone">Ton</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Tonumfänge</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">Website aufrufen</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">Dateikodierung archivieren</system:String>

--- a/OpenUtau/Strings/Strings.es-ES.axaml
+++ b/OpenUtau/Strings/Strings.es-ES.axaml
@@ -51,6 +51,8 @@
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <!--<system:String x:Key="exps.type.curve">Curve</system:String>-->
   <!--<system:String x:Key="exps.type.numerical">Numerical</system:String>-->
   <!--<system:String x:Key="exps.type.options">Options</system:String>-->
+
+  <system:String x:Key="languages.de">alemán</system:String>
+  <system:String x:Key="languages.en">inglés</system:String>
+  <system:String x:Key="languages.es">español</system:String>
+  <system:String x:Key="languages.fr">francés</system:String>
+  <system:String x:Key="languages.it">italiano</system:String>
+  <system:String x:Key="languages.ja">japonés</system:String>
+  <system:String x:Key="languages.ko">coreano</system:String>
+  <system:String x:Key="languages.pl">polaco</system:String>
+  <system:String x:Key="languages.pt">portugués</system:String>
+  <system:String x:Key="languages.ru">ruso</system:String>
+  <system:String x:Key="languages.vi">vietnamita</system:String>
+  <system:String x:Key="languages.zh">chino</system:String>
+  <system:String x:Key="languages.zh-yue">cantonés</system:String>
 
   <!--<system:String x:Key="lyrics.apply">Apply</system:String>-->
   <!--<system:String x:Key="lyrics.cancel">Cancel</system:String>-->
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Herramientas</system:String>
   <!--<system:String x:Key="menu.tools.clearcache">Clear Cache</system:String>-->
   <!--<system:String x:Key="menu.tools.debugwindow">Debug Window</system:String>-->
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <!--<system:String x:Key="menu.tools.layout">Layout</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit11">Horizontal 1:1</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit12">Horizontal 1:2</system:String>-->
@@ -296,6 +313,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <!--<system:String x:Key="prefs.appearance.lang">Language</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">Tema</system:String>
@@ -399,6 +417,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="singers.subbanks.set">Set</system:String>-->
   <!--<system:String x:Key="singers.subbanks.tone">Tone</system:String>-->
   <!--<system:String x:Key="singers.subbanks.toneranges">Tone Ranges</system:String>-->
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <!--<system:String x:Key="singers.visitwebsite">Visit Website</system:String>-->
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.es-MX.axaml
+++ b/OpenUtau/Strings/Strings.es-MX.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Ubicación</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Renderizador</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Usar como predeterminado</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Curva</system:String>
   <system:String x:Key="exps.type.numerical">Numérico</system:String>
   <system:String x:Key="exps.type.options">Opciones</system:String>
+
+  <system:String x:Key="languages.de">alemán</system:String>
+  <system:String x:Key="languages.en">inglés</system:String>
+  <system:String x:Key="languages.es">español</system:String>
+  <system:String x:Key="languages.fr">francés</system:String>
+  <system:String x:Key="languages.it">italiano</system:String>
+  <system:String x:Key="languages.ja">japonés</system:String>
+  <system:String x:Key="languages.ko">coreano</system:String>
+  <system:String x:Key="languages.pl">polaco</system:String>
+  <system:String x:Key="languages.pt">portugués</system:String>
+  <system:String x:Key="languages.ru">ruso</system:String>
+  <system:String x:Key="languages.vi">vietnamita</system:String>
+  <system:String x:Key="languages.zh">chino</system:String>
+  <system:String x:Key="languages.zh-yue">cantonés</system:String>
 
   <system:String x:Key="lyrics.apply">Aplicar</system:String>
   <system:String x:Key="lyrics.cancel">Cancelar</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">_Herramientas</system:String>
   <system:String x:Key="menu.tools.clearcache">Limpiar caché</system:String>
   <system:String x:Key="menu.tools.debugwindow">Ventana de depuración</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <!--<system:String x:Key="menu.tools.layout">Layout</system:String>-->
   <system:String x:Key="menu.tools.layout.hsplit11">1:1 Horizontal</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">1:2 Horizontal</system:String>
@@ -292,6 +309,7 @@ Advertencia: Esta opción eliminará las bases personalizadas.</system:String>
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Lenguaje</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Mostrar notas de otras pistas en el piano</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Mostrar foto en el piano</system:String>
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">Tema</system:String>
@@ -395,6 +413,7 @@ Advertencia: Moresampler no es totalmente compatible por ahora. Este puede ser l
   <system:String x:Key="singers.subbanks.set">Carpeta</system:String>
   <system:String x:Key="singers.subbanks.tone">Tono</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Rangos tonales</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">Visitar sitio web</system:String>
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.fi-FI.axaml
+++ b/OpenUtau/Strings/Strings.fi-FI.axaml
@@ -51,6 +51,8 @@
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <!--<system:String x:Key="exps.type.curve">Curve</system:String>-->
   <system:String x:Key="exps.type.numerical">Numeraalinen</system:String>
   <system:String x:Key="exps.type.options">Kustomoi</system:String>
+
+  <system:String x:Key="languages.de">saksa</system:String>
+  <system:String x:Key="languages.en">englanti</system:String>
+  <system:String x:Key="languages.es">espanja</system:String>
+  <system:String x:Key="languages.fr">ranska</system:String>
+  <system:String x:Key="languages.it">italia</system:String>
+  <system:String x:Key="languages.ja">japani</system:String>
+  <system:String x:Key="languages.ko">korea</system:String>
+  <system:String x:Key="languages.pl">puola</system:String>
+  <system:String x:Key="languages.pt">portugali</system:String>
+  <system:String x:Key="languages.ru">venäjä</system:String>
+  <system:String x:Key="languages.vi">vietnam</system:String>
+  <system:String x:Key="languages.zh">kiina</system:String>
+  <system:String x:Key="languages.zh-yue">kantoninkiina</system:String>
 
   <!--<system:String x:Key="lyrics.apply">Apply</system:String>-->
   <!--<system:String x:Key="lyrics.cancel">Cancel</system:String>-->
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Työkalut</system:String>
   <!--<system:String x:Key="menu.tools.clearcache">Clear Cache</system:String>-->
   <!--<system:String x:Key="menu.tools.debugwindow">Debug Window</system:String>-->
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">Asettelu</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">Vaakasuora 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">Vaakasuora 1:2</system:String>
@@ -296,6 +313,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Kieli</system:String>
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">Teema</system:String>
@@ -399,6 +417,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="singers.subbanks.set">Set</system:String>-->
   <!--<system:String x:Key="singers.subbanks.tone">Tone</system:String>-->
   <system:String x:Key="singers.subbanks.toneranges">Ääniala</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <!--<system:String x:Key="singers.visitwebsite">Visit Website</system:String>-->
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.fr-FR.axaml
+++ b/OpenUtau/Strings/Strings.fr-FR.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Emplacement</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Moteur de rendu</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Réglage par défaut</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <!--<system:String x:Key="exps.type.curve">Curve</system:String>-->
   <system:String x:Key="exps.type.numerical">Numérique</system:String>
   <!--<system:String x:Key="exps.type.options">Options</system:String>-->
+
+  <system:String x:Key="languages.de">allemand</system:String>
+  <system:String x:Key="languages.en">anglais</system:String>
+  <system:String x:Key="languages.es">espagnol</system:String>
+  <system:String x:Key="languages.fr">français</system:String>
+  <system:String x:Key="languages.it">italien</system:String>
+  <system:String x:Key="languages.ja">japonais</system:String>
+  <system:String x:Key="languages.ko">coréen</system:String>
+  <system:String x:Key="languages.pl">polonais</system:String>
+  <system:String x:Key="languages.pt">portugais</system:String>
+  <system:String x:Key="languages.ru">russe</system:String>
+  <system:String x:Key="languages.vi">vietnamien</system:String>
+  <system:String x:Key="languages.zh">chinois</system:String>
+  <system:String x:Key="languages.zh-yue">cantonais</system:String>
 
   <system:String x:Key="lyrics.apply">Appliquer</system:String>
   <system:String x:Key="lyrics.cancel">Annuler</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Outils</system:String>
   <system:String x:Key="menu.tools.clearcache">Effacer le Cache</system:String>
   <system:String x:Key="menu.tools.debugwindow">Fenêtre de débogage</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">Disposition des fenêtres</system:String>
   <!--<system:String x:Key="menu.tools.layout.hsplit11">Horizontal 1:1</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit12">Horizontal 1:2</system:String>-->
@@ -292,6 +309,7 @@ Attention: cela va effacer le préréglage.</system:String>
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Langue</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Montrer les notes des autres pistes sur le piano roll</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Montrer le portrait sur le piano roll</system:String>
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">Thème</system:String>
@@ -395,6 +413,7 @@ Avertissement : moresampler n'est pas entièrement pris en charge. Il peut être
   <system:String x:Key="singers.subbanks.set">Définir</system:String>
   <system:String x:Key="singers.subbanks.tone">Tonalité</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Registre</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">Visiter le site</system:String>
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.id-ID.axaml
+++ b/OpenUtau/Strings/Strings.id-ID.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Lokasi</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Perender</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Tetapkan Sebagai Bawaan</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <system:String x:Key="dialogs.voicecolorremapping">Pemetaan ulang warna suara</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">Terapkan ke semua nada di trek ini:</system:String>
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Kurva</system:String>
   <system:String x:Key="exps.type.numerical">Numerik</system:String>
   <system:String x:Key="exps.type.options">Opsi</system:String>
+
+  <system:String x:Key="languages.de">Jerman</system:String>
+  <system:String x:Key="languages.en">Inggris</system:String>
+  <system:String x:Key="languages.es">Spanyol</system:String>
+  <system:String x:Key="languages.fr">Prancis</system:String>
+  <system:String x:Key="languages.it">Italia</system:String>
+  <system:String x:Key="languages.ja">Jepang</system:String>
+  <system:String x:Key="languages.ko">Korea</system:String>
+  <system:String x:Key="languages.pl">Polski</system:String>
+  <system:String x:Key="languages.pt">Portugis</system:String>
+  <system:String x:Key="languages.ru">Rusia</system:String>
+  <system:String x:Key="languages.vi">Vietnam</system:String>
+  <system:String x:Key="languages.zh">Tionghoa</system:String>
+  <system:String x:Key="languages.zh-yue">Kanton</system:String>
 
   <system:String x:Key="lyrics.apply">Terapkan</system:String>
   <system:String x:Key="lyrics.cancel">Batalkan</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Peralatan</system:String>
   <system:String x:Key="menu.tools.clearcache">Hapus Cache</system:String>
   <system:String x:Key="menu.tools.debugwindow">Jendela Debug</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">Tata Letak</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">Horisontal 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">Horisontal 1:2</system:String>
@@ -298,6 +315,7 @@ Peringatan: opsi ini menghapus prasetel khusus.</system:String>
   <system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la si)</system:String>
   <system:String x:Key="prefs.appearance.lang">Bahasa</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Tampilkan not trek lain di piano roll</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Tampilkan foto potret di piano roll</system:String>
   <system:String x:Key="prefs.appearance.sortorder">Bahasa tampilan nama penyanyi</system:String>
   <system:String x:Key="prefs.appearance.theme">Tema</system:String>
@@ -401,6 +419,7 @@ Peringatan: moresampler tidak sepenuhnya didukung. Ini mungkin melambat dan meny
   <system:String x:Key="singers.subbanks.set">Setel</system:String>
   <system:String x:Key="singers.subbanks.tone">Nada</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Rentang Nada</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">Visit Situs Web</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">Pengkodean Berkas Arsip</system:String>

--- a/OpenUtau/Strings/Strings.it-IT.axaml
+++ b/OpenUtau/Strings/Strings.it-IT.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Percorso</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">Imposta default</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Curva</system:String>
   <system:String x:Key="exps.type.numerical">Numerico</system:String>
   <system:String x:Key="exps.type.options">Opzioni</system:String>
+
+  <system:String x:Key="languages.de">tedesco</system:String>
+  <system:String x:Key="languages.en">inglese</system:String>
+  <system:String x:Key="languages.es">spagnolo</system:String>
+  <system:String x:Key="languages.fr">francese</system:String>
+  <system:String x:Key="languages.it">italiano</system:String>
+  <system:String x:Key="languages.ja">giapponese</system:String>
+  <system:String x:Key="languages.ko">coreano</system:String>
+  <system:String x:Key="languages.pl">polacco</system:String>
+  <system:String x:Key="languages.pt">portoghese</system:String>
+  <system:String x:Key="languages.ru">russo</system:String>
+  <system:String x:Key="languages.vi">vietnamita</system:String>
+  <system:String x:Key="languages.zh">cinese</system:String>
+  <system:String x:Key="languages.zh-yue">cantonese</system:String>
 
   <system:String x:Key="lyrics.apply">Applica</system:String>
   <system:String x:Key="lyrics.cancel">Cancella</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Strumenti</system:String>
   <system:String x:Key="menu.tools.clearcache">Svuota Cache</system:String>
   <system:String x:Key="menu.tools.debugwindow">Finestra di Debug</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">Disposizione</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">Orizzontale 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">Orizzontale 1:2</system:String>
@@ -296,6 +313,7 @@ Tieni premuto Ctrl per selezionare</system:String>
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Lingua</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Mostra note di altre tracce sul piano roll</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Mostra immagine del cantante sul piano roll</system:String>
   <system:String x:Key="prefs.appearance.sortorder">Ordine cantanti</system:String>
   <system:String x:Key="prefs.appearance.theme">Tema</system:String>
@@ -399,6 +417,7 @@ Attenzione: moresampler non è completamente supportato. Potrebbe causare rallen
   <system:String x:Key="singers.subbanks.set">Imposta</system:String>
   <system:String x:Key="singers.subbanks.tone">Tono</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Range Tonale</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">Visita il sito web</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">Codifica del File d'Archivio </system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">場所</system:String>
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <system:String x:Key="dialogs.tracksettings.setasdefault">デフォルト設定として保存</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <system:String x:Key="dialogs.voicecolorremapping">Voice colorの再マッピング</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">このトラック内のすべての音符に適用されます：</system:String>
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">カーブ</system:String>
   <system:String x:Key="exps.type.numerical">数値</system:String>
   <system:String x:Key="exps.type.options">カスタム</system:String>
+
+  <system:String x:Key="languages.de">ドイツ語</system:String>
+  <system:String x:Key="languages.en">英語</system:String>
+  <system:String x:Key="languages.es">スペイン語</system:String>
+  <system:String x:Key="languages.fr">フランス語</system:String>
+  <system:String x:Key="languages.it">イタリア語</system:String>
+  <system:String x:Key="languages.ja">日本語</system:String>
+  <system:String x:Key="languages.ko">韓国語</system:String>
+  <system:String x:Key="languages.pl">ポーランド語</system:String>
+  <system:String x:Key="languages.pt">ポルトガル語</system:String>
+  <system:String x:Key="languages.ru">ロシア語</system:String>
+  <system:String x:Key="languages.vi">ベトナム語</system:String>
+  <system:String x:Key="languages.zh">中国語</system:String>
+  <system:String x:Key="languages.zh-yue">広東語</system:String>
 
   <system:String x:Key="lyrics.apply">適用</system:String>
   <system:String x:Key="lyrics.cancel">キャンセル</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">ツール</system:String>
   <system:String x:Key="menu.tools.clearcache">キャッシュクリア</system:String>
   <system:String x:Key="menu.tools.debugwindow">デバッグウインドウ</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">レイアウト</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">横並び 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">横並び 1:2</system:String>
@@ -296,6 +313,7 @@
   <system:String x:Key="prefs.appearance.degree.solfege">Solfège (ドレミファソラシ)</system:String>
   <system:String x:Key="prefs.appearance.lang">言語</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">ピアノロール上に他トラックの音符を表示</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">ピアノロール上に背景イラストを表示</system:String>
   <system:String x:Key="prefs.appearance.sortorder">シンガー名の表示言語</system:String>
   <system:String x:Key="prefs.appearance.theme">テーマ</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -11,10 +11,10 @@
   <system:String x:Key="context.part.replaceaudio">오디오 파일 교체</system:String>
   <system:String x:Key="context.part.transcribe">새 노트 파트로 오디오 전사</system:String>
   <system:String x:Key="context.part.transcribing">전사 중</system:String>
-  <system:String x:Key="context.pitch.easein">Ease in</system:String>
-  <system:String x:Key="context.pitch.easeinout">Ease in/out</system:String>
-  <system:String x:Key="context.pitch.easeout">Ease out</system:String>
-  <system:String x:Key="context.pitch.linear">Linear</system:String>
+  <!--<system:String x:Key="context.pitch.easein">Ease in</system:String>-->
+  <!--<system:String x:Key="context.pitch.easeinout">Ease in/out</system:String>-->
+  <!--<system:String x:Key="context.pitch.easeout">Ease out</system:String>-->
+  <!--<system:String x:Key="context.pitch.linear">Linear</system:String>-->
   <system:String x:Key="context.pitch.pointadd">피치 점 추가</system:String>
   <system:String x:Key="context.pitch.pointdel">피치 점 삭제</system:String>
   <system:String x:Key="context.pitch.pointsnapprev">이전 노트에 물리기</system:String>
@@ -35,6 +35,8 @@
   <system:String x:Key="dialogs.exitsave.message">프로젝트가 저장되지 않았습니다. 저장할까요?</system:String>
   <system:String x:Key="dialogs.export.caption">내보내기</system:String>
   <system:String x:Key="dialogs.export.savefirst">먼저 프로젝트 파일을 저장해 주세요</system:String>
+  <!--<system:String x:Key="dialogs.importtracks.caption">Import tracks</system:String>-->
+  <!--<system:String x:Key="dialogs.importtracks.importtempo">The imported project contains the following tempo markers. Do you want to use them?</system:String>-->
   <system:String x:Key="dialogs.installdependency.caption">의존 요소 설치 중</system:String>
   <system:String x:Key="dialogs.installdependency.message">설치 중</system:String>
   <system:String x:Key="dialogs.installdll.caption">음소화기 설치 중</system:String>
@@ -46,13 +48,13 @@
   <system:String x:Key="dialogs.messagebox.yes">네</system:String>
   <system:String x:Key="dialogs.noresampler.caption">리샘플러가 없어요</system:String>
   <system:String x:Key="dialogs.noresampler.message">리샘플러가 없어요! 'Resamplers' 폴더에 좋아하는 리샘플러의 exe나 dll을 넣고, 환경 설정에서 원하는 리샘플러를 골라 보세요!</system:String>
-  <system:String x:Key="dialogs.unsupportedfile.caption">이 파일 유형은 지원하지 않아요</system:String>
-  <system:String x:Key="dialogs.unsupportedfile.message">이 파일 유형은 지원하지 않아요: </system:String>
   <system:String x:Key="dialogs.timesig.caption">박자표</system:String>
   <system:String x:Key="dialogs.tracksettings.caption">트랙 설정</system:String>
   <system:String x:Key="dialogs.tracksettings.location">위치 열기</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">렌더러</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">기본값으로 설정</system:String>
+  <system:String x:Key="dialogs.unsupportedfile.caption">이 파일 유형은 지원하지 않아요</system:String>
+  <system:String x:Key="dialogs.unsupportedfile.message">이 파일 유형은 지원하지 않아요: </system:String>
   <system:String x:Key="dialogs.voicecolorremapping">음색 재배치</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">다음 트랙의 모든 노트에 적용됩니다.</system:String>
 
@@ -74,6 +76,20 @@
   <system:String x:Key="exps.type.curve">커브형</system:String>
   <system:String x:Key="exps.type.numerical">숫자형</system:String>
   <system:String x:Key="exps.type.options">선택지형</system:String>
+
+  <system:String x:Key="languages.de">독일어</system:String>
+  <system:String x:Key="languages.en">영어</system:String>
+  <system:String x:Key="languages.es">스페인어</system:String>
+  <system:String x:Key="languages.fr">프랑스어</system:String>
+  <system:String x:Key="languages.it">이탈리아어</system:String>
+  <system:String x:Key="languages.ja">일본어</system:String>
+  <system:String x:Key="languages.ko">한국어</system:String>
+  <system:String x:Key="languages.pl">폴란드어</system:String>
+  <system:String x:Key="languages.pt">포르투갈어</system:String>
+  <system:String x:Key="languages.ru">러시아어</system:String>
+  <system:String x:Key="languages.vi">베트남어</system:String>
+  <system:String x:Key="languages.zh">중국어</system:String>
+  <system:String x:Key="languages.zh-yue">광둥어</system:String>
 
   <system:String x:Key="lyrics.apply">적용</system:String>
   <system:String x:Key="lyrics.cancel">취소</system:String>
@@ -164,7 +180,7 @@
   <system:String x:Key="notedefaults.preset">프리셋</system:String>
   <system:String x:Key="notedefaults.preset.namenew">새 프리셋 이름</system:String>
   <system:String x:Key="notedefaults.preset.remove">삭제</system:String>
-<system:String x:Key="notedefaults.preset.remove.tooltip">마지막으로 적용된 프리셋을 삭제합니다.</system:String>
+  <system:String x:Key="notedefaults.preset.remove.tooltip">마지막으로 적용된 프리셋을 삭제합니다.</system:String>
   <system:String x:Key="notedefaults.preset.save">프리셋 저장</system:String>
   <system:String x:Key="notedefaults.preset.save.tooltip">현재 세팅으로 새 프리셋 추가</system:String>
   <system:String x:Key="notedefaults.reset">사용자 설정 초기화</system:String>
@@ -285,6 +301,10 @@
 
   <system:String x:Key="prefs.advanced">고급</system:String>
   <system:String x:Key="prefs.advanced.beta">베타 버전 사용</system:String>
+  <!--<system:String x:Key="prefs.advanced.importtempo">When importing tracks, use the tempos of the imported project</system:String>-->
+  <!--<system:String x:Key="prefs.advanced.importtempo.always">Always</system:String>-->
+  <!--<system:String x:Key="prefs.advanced.importtempo.ask">Ask me each time</system:String>-->
+  <!--<system:String x:Key="prefs.advanced.importtempo.never">Never</system:String>-->
   <system:String x:Key="prefs.advanced.lyricshelper">가사 입력 도우미</system:String>
   <system:String x:Key="prefs.advanced.lyricshelper.brackets">가사 입력 도우미의 대괄호 자동 추가</system:String>
   <system:String x:Key="prefs.advanced.rememberfiletypes">'최근 파일'에 표시할 파일 유형</system:String>
@@ -317,6 +337,7 @@
   <system:String x:Key="prefs.paths">경로</system:String>
   <system:String x:Key="prefs.paths.addlsinger">확장 가수 폴더</system:String>
   <system:String x:Key="prefs.paths.addlsinger.install">가수 설치 시 '확장 가수 폴더'에 설치</system:String>
+  <!--<system:String x:Key="prefs.paths.loaddeepfolders">Load all depth folders</system:String>-->
   <system:String x:Key="prefs.paths.reset">재설정</system:String>
   <system:String x:Key="prefs.paths.select">선택</system:String>
   <system:String x:Key="prefs.playback">재생</system:String>
@@ -326,7 +347,7 @@
   <system:String x:Key="prefs.playback.autoscrollmode.stationarycursor">커서 스크롤</system:String>
   <system:String x:Key="prefs.playback.backend">오디오 백엔드</system:String>
   <system:String x:Key="prefs.playback.backend.auto">자동</system:String>
-  <system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>
+  <!--<system:String x:Key="prefs.playback.backend.port">PortAudio</system:String>-->
   <system:String x:Key="prefs.playback.cursorposition">자동 스크롤 여백</system:String>
   <system:String x:Key="prefs.playback.device">오디오 재생 장치</system:String>
   <system:String x:Key="prefs.playback.lockstarttime">일시정지할 때</system:String>
@@ -355,7 +376,7 @@
     경고: 렌더링 스레드가 너무 많으면 OpenUtau가 느리게 작동할 수 있습니다.
   </system:String>
   <system:String x:Key="prefs.rendering.threads.numthreads">최대 렌더링 스레드 수</system:String>
-  <system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>
+  <!--<system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>-->
 
   <system:String x:Key="progress.loadingsingers">가수를 불러오는 중...</system:String>
   <system:String x:Key="progress.saved">{0} 프로젝트를 저장했습니다.</system:String>
@@ -465,7 +486,7 @@
 
   <system:String x:Key="updater.caption">업데이트 확인</system:String>
   <system:String x:Key="updater.description">오픈소스 음성 합성 플랫폼</system:String>
-  <system:String x:Key="updater.github">GitHub</system:String>
+  <!--<system:String x:Key="updater.github">GitHub</system:String>-->
   <system:String x:Key="updater.status.available">v{0} 버전 업데이트가 있어요!</system:String>
   <system:String x:Key="updater.status.checking">업데이트 확인 중...</system:String>
   <system:String x:Key="updater.status.notavailable">최신 버전</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -51,8 +51,6 @@
   <system:String x:Key="dialogs.tracksettings.location">위치 열기</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">렌더러</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">기본값으로 사용</system:String>
-  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
-  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <system:String x:Key="dialogs.voicecolorremapping">보이스 컬러 재맵핑</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">▼ 재맵핑된 컬러가 이 트랙의 모든 노트에 적용되요 </system:String>
 
@@ -74,20 +72,6 @@
   <system:String x:Key="exps.type.curve">커브형 표현</system:String>
   <system:String x:Key="exps.type.numerical">숫자형 표현</system:String>
   <system:String x:Key="exps.type.options">선택지형 표현</system:String>
-
-  <system:String x:Key="languages.de">독일어</system:String>
-  <system:String x:Key="languages.en">영어</system:String>
-  <system:String x:Key="languages.es">스페인어</system:String>
-  <system:String x:Key="languages.fr">프랑스어</system:String>
-  <system:String x:Key="languages.it">이탈리아어</system:String>
-  <system:String x:Key="languages.ja">일본어</system:String>
-  <system:String x:Key="languages.ko">한국어</system:String>
-  <system:String x:Key="languages.pl">폴란드어</system:String>
-  <system:String x:Key="languages.pt">포르투갈어</system:String>
-  <system:String x:Key="languages.ru">러시아어</system:String>
-  <system:String x:Key="languages.vi">베트남어</system:String>
-  <system:String x:Key="languages.zh">중국어</system:String>
-  <system:String x:Key="languages.zh-yue">광둥어</system:String>
 
   <system:String x:Key="lyrics.apply">적용하기</system:String>
   <system:String x:Key="lyrics.cancel">취소</system:String>
@@ -155,7 +139,6 @@
   <system:String x:Key="menu.tools">도구</system:String>
   <system:String x:Key="menu.tools.clearcache">캐시 비우기</system:String>
   <system:String x:Key="menu.tools.debugwindow">디버그 창</system:String>
-  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">레이아웃</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">1:1 수평 배치</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">1:2 수평 배치</system:String>
@@ -330,7 +313,6 @@
   <system:String x:Key="prefs.appearance.degree.solfege">계이름 도우미 (도 레 미 파 솔 라 시)</system:String>
   <system:String x:Key="prefs.appearance.lang">인터페이스 언어</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">피아노 롤에 다른 트랙의 노트 표시(유령 노트)</system:String>
-  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">피아노 롤에 가수의 스탠딩 표시</system:String>
   <system:String x:Key="prefs.appearance.sortorder">가수 이름 표시 언어</system:String>
   <system:String x:Key="prefs.appearance.theme">테마 설정</system:String>
@@ -437,7 +419,6 @@
   <system:String x:Key="singers.subbanks.set">설정</system:String>
   <system:String x:Key="singers.subbanks.tone">음계</system:String>
   <system:String x:Key="singers.subbanks.toneranges">음역대</system:String>
-  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">가수 공식 사이트 방문</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">압축 파일의 인코딩</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">위치 열기</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">렌더러</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">기본값으로 사용</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <system:String x:Key="dialogs.voicecolorremapping">보이스 컬러 재맵핑</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">▼ 재맵핑된 컬러가 이 트랙의 모든 노트에 적용되요 </system:String>
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">커브형 표현</system:String>
   <system:String x:Key="exps.type.numerical">숫자형 표현</system:String>
   <system:String x:Key="exps.type.options">선택지형 표현</system:String>
+
+  <system:String x:Key="languages.de">독일어</system:String>
+  <system:String x:Key="languages.en">영어</system:String>
+  <system:String x:Key="languages.es">스페인어</system:String>
+  <system:String x:Key="languages.fr">프랑스어</system:String>
+  <system:String x:Key="languages.it">이탈리아어</system:String>
+  <system:String x:Key="languages.ja">일본어</system:String>
+  <system:String x:Key="languages.ko">한국어</system:String>
+  <system:String x:Key="languages.pl">폴란드어</system:String>
+  <system:String x:Key="languages.pt">포르투갈어</system:String>
+  <system:String x:Key="languages.ru">러시아어</system:String>
+  <system:String x:Key="languages.vi">베트남어</system:String>
+  <system:String x:Key="languages.zh">중국어</system:String>
+  <system:String x:Key="languages.zh-yue">광둥어</system:String>
 
   <system:String x:Key="lyrics.apply">적용하기</system:String>
   <system:String x:Key="lyrics.cancel">취소</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">도구</system:String>
   <system:String x:Key="menu.tools.clearcache">캐시 비우기</system:String>
   <system:String x:Key="menu.tools.debugwindow">디버그 창</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">레이아웃</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">1:1 수평 배치</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">1:2 수평 배치</system:String>
@@ -313,6 +330,7 @@
   <system:String x:Key="prefs.appearance.degree.solfege">계이름 도우미 (도 레 미 파 솔 라 시)</system:String>
   <system:String x:Key="prefs.appearance.lang">인터페이스 언어</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">피아노 롤에 다른 트랙의 노트 표시(유령 노트)</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">피아노 롤에 가수의 스탠딩 표시</system:String>
   <system:String x:Key="prefs.appearance.sortorder">가수 이름 표시 언어</system:String>
   <system:String x:Key="prefs.appearance.theme">테마 설정</system:String>
@@ -419,6 +437,7 @@
   <system:String x:Key="singers.subbanks.set">설정</system:String>
   <system:String x:Key="singers.subbanks.tone">음계</system:String>
   <system:String x:Key="singers.subbanks.toneranges">음역대</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">가수 공식 사이트 방문</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">압축 파일의 인코딩</system:String>

--- a/OpenUtau/Strings/Strings.nl-NL.axaml
+++ b/OpenUtau/Strings/Strings.nl-NL.axaml
@@ -51,6 +51,8 @@
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Bocht</system:String>
   <system:String x:Key="exps.type.numerical">Numeriek</system:String>
   <system:String x:Key="exps.type.options">Opties</system:String>
+
+  <system:String x:Key="languages.de">Duits</system:String>
+  <system:String x:Key="languages.en">Engels</system:String>
+  <system:String x:Key="languages.es">Spaans</system:String>
+  <system:String x:Key="languages.fr">Frans</system:String>
+  <system:String x:Key="languages.it">Italiaans</system:String>
+  <system:String x:Key="languages.ja">Japans</system:String>
+  <system:String x:Key="languages.ko">Koreaans</system:String>
+  <system:String x:Key="languages.pl">Pools</system:String>
+  <system:String x:Key="languages.pt">Portugees</system:String>
+  <system:String x:Key="languages.ru">Russisch</system:String>
+  <system:String x:Key="languages.vi">Vietnamees</system:String>
+  <system:String x:Key="languages.zh">Chinees</system:String>
+  <system:String x:Key="languages.zh-yue">Kantonees</system:String>
 
   <system:String x:Key="lyrics.apply">Toepassen</system:String>
   <system:String x:Key="lyrics.cancel">Annuleer</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">_Tools</system:String>
   <system:String x:Key="menu.tools.clearcache">Cache wissen</system:String>
   <system:String x:Key="menu.tools.debugwindow">Debug venster</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">Indeling</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">Horizontaal 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">Horizontaal 1:2</system:String>
@@ -292,6 +309,7 @@ Ctrl ingedrukt houden om te selecteren</system:String>
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Taal</system:String>
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Toon portret op pianorol</system:String>
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">Thema</system:String>
@@ -395,6 +413,7 @@ Waarschuwing: moresampler wordt niet volledig ondersteund. Het kan traag zijn en
   <!--<system:String x:Key="singers.subbanks.set">Set</system:String>-->
   <system:String x:Key="singers.subbanks.tone">Toon</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Toonbereiken</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <!--<system:String x:Key="singers.visitwebsite">Visit Website</system:String>-->
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.pl-PL.axaml
+++ b/OpenUtau/Strings/Strings.pl-PL.axaml
@@ -51,6 +51,8 @@
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <!--<system:String x:Key="exps.type.curve">Curve</system:String>-->
   <!--<system:String x:Key="exps.type.numerical">Numerical</system:String>-->
   <!--<system:String x:Key="exps.type.options">Options</system:String>-->
+
+  <system:String x:Key="languages.de">niemiecki</system:String>
+  <system:String x:Key="languages.en">angielski</system:String>
+  <system:String x:Key="languages.es">hiszpański</system:String>
+  <system:String x:Key="languages.fr">francuski</system:String>
+  <system:String x:Key="languages.it">włoski</system:String>
+  <system:String x:Key="languages.ja">japoński</system:String>
+  <system:String x:Key="languages.ko">koreański</system:String>
+  <system:String x:Key="languages.pl">polski</system:String>
+  <system:String x:Key="languages.pt">portugalski</system:String>
+  <system:String x:Key="languages.ru">rosyjski</system:String>
+  <system:String x:Key="languages.vi">wietnamski</system:String>
+  <system:String x:Key="languages.zh">chiński</system:String>
+  <system:String x:Key="languages.zh-yue">kantoński</system:String>
 
   <!--<system:String x:Key="lyrics.apply">Apply</system:String>-->
   <!--<system:String x:Key="lyrics.cancel">Cancel</system:String>-->
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Narzędzia</system:String>
   <!--<system:String x:Key="menu.tools.clearcache">Clear Cache</system:String>-->
   <!--<system:String x:Key="menu.tools.debugwindow">Debug Window</system:String>-->
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <!--<system:String x:Key="menu.tools.layout">Layout</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit11">Horizontal 1:1</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit12">Horizontal 1:2</system:String>-->
@@ -296,6 +313,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <!--<system:String x:Key="prefs.appearance.lang">Language</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.showportrait">Show portrait on piano roll</system:String>-->
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">Motyw</system:String>
@@ -399,6 +417,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="singers.subbanks.set">Set</system:String>-->
   <!--<system:String x:Key="singers.subbanks.tone">Tone</system:String>-->
   <!--<system:String x:Key="singers.subbanks.toneranges">Tone Ranges</system:String>-->
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <!--<system:String x:Key="singers.visitwebsite">Visit Website</system:String>-->
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.pt-BR.axaml
+++ b/OpenUtau/Strings/Strings.pt-BR.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Local</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Renderizador</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Definir como Padrão</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Curva</system:String>
   <system:String x:Key="exps.type.numerical">Numérico</system:String>
   <system:String x:Key="exps.type.options">Opções</system:String>
+
+  <system:String x:Key="languages.de">alemão</system:String>
+  <system:String x:Key="languages.en">inglês</system:String>
+  <system:String x:Key="languages.es">espanhol</system:String>
+  <system:String x:Key="languages.fr">francês</system:String>
+  <system:String x:Key="languages.it">italiano</system:String>
+  <system:String x:Key="languages.ja">japonês</system:String>
+  <system:String x:Key="languages.ko">coreano</system:String>
+  <system:String x:Key="languages.pl">polonês</system:String>
+  <system:String x:Key="languages.pt">português</system:String>
+  <system:String x:Key="languages.ru">russo</system:String>
+  <system:String x:Key="languages.vi">vietnamita</system:String>
+  <system:String x:Key="languages.zh">chinês</system:String>
+  <system:String x:Key="languages.zh-yue">cantonês</system:String>
 
   <system:String x:Key="lyrics.apply">Aplicar</system:String>
   <system:String x:Key="lyrics.cancel">Cancelar</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Ferramentas</system:String>
   <system:String x:Key="menu.tools.clearcache">Limpar Cache</system:String>
   <system:String x:Key="menu.tools.debugwindow">Janela de Debug</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <!--<system:String x:Key="menu.tools.layout">Layout</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit11">Horizontal 1:1</system:String>-->
   <!--<system:String x:Key="menu.tools.layout.hsplit12">Horizontal 1:2</system:String>-->
@@ -292,6 +309,7 @@ Segure Ctrl para selecionar</system:String>
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Idioma</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Mostrar notas fantasma</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Mostrar retrato no piano roll</system:String>
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">Tema</system:String>
@@ -395,6 +413,7 @@ Segure Ctrl para selecionar</system:String>
   <system:String x:Key="singers.subbanks.set">Aplicar</system:String>
   <system:String x:Key="singers.subbanks.tone">Tom</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Alcance</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">Visite o Website</system:String>
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.ru-RU.axaml
+++ b/OpenUtau/Strings/Strings.ru-RU.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Расположение</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Рендерер</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Установить по умолчанию</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <system:String x:Key="dialogs.voicecolorremapping">Изменение цвета голоса</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">Применится ко всем нотам в этом треке:</system:String>
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Кривая</system:String>
   <system:String x:Key="exps.type.numerical">Числовой</system:String>
   <system:String x:Key="exps.type.options">Параметры</system:String>
+
+  <system:String x:Key="languages.de">немецкий</system:String>
+  <system:String x:Key="languages.en">английский</system:String>
+  <system:String x:Key="languages.es">испанский</system:String>
+  <system:String x:Key="languages.fr">французский</system:String>
+  <system:String x:Key="languages.it">итальянский</system:String>
+  <system:String x:Key="languages.ja">японский</system:String>
+  <system:String x:Key="languages.ko">корейский</system:String>
+  <system:String x:Key="languages.pl">польский</system:String>
+  <system:String x:Key="languages.pt">португальский</system:String>
+  <system:String x:Key="languages.ru">русский</system:String>
+  <system:String x:Key="languages.vi">вьетнамский</system:String>
+  <system:String x:Key="languages.zh">китайский</system:String>
+  <system:String x:Key="languages.zh-yue">кантонский</system:String>
 
   <system:String x:Key="lyrics.apply">Применить</system:String>
   <system:String x:Key="lyrics.cancel">Отмена</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Инструменты</system:String>
   <system:String x:Key="menu.tools.clearcache">Очистить кэш</system:String>
   <system:String x:Key="menu.tools.debugwindow">Окно отладки</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">Расположение</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">Горизонтально 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">Горизонтально 1:2</system:String>
@@ -292,6 +309,7 @@
   <system:String x:Key="prefs.appearance.degree.solfege">Сольфеджио (do re mi fa sol la ti)</system:String>
   <system:String x:Key="prefs.appearance.lang">Язык</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Отображать ноты других треков на пианоролле</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Отображать портрет на пианоролле</system:String>
   <system:String x:Key="prefs.appearance.sortorder">Порядок сортировки вокалистов</system:String>
   <system:String x:Key="prefs.appearance.theme">Тема</system:String>
@@ -395,6 +413,7 @@
   <system:String x:Key="singers.subbanks.set">Установить</system:String>
   <system:String x:Key="singers.subbanks.tone">Тон</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Диапазон тональности</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">Посетить сайт</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">Кодировка архива</system:String>

--- a/OpenUtau/Strings/Strings.th-TH.axaml
+++ b/OpenUtau/Strings/Strings.th-TH.axaml
@@ -51,6 +51,8 @@
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">เส้นโค้ง</system:String>
   <system:String x:Key="exps.type.numerical">ตัวเลข</system:String>
   <system:String x:Key="exps.type.options">ตัวเลือก</system:String>
+
+  <system:String x:Key="languages.de">เยอรมัน</system:String>
+  <system:String x:Key="languages.en">อังกฤษ</system:String>
+  <system:String x:Key="languages.es">สเปน</system:String>
+  <system:String x:Key="languages.fr">ฝรั่งเศส</system:String>
+  <system:String x:Key="languages.it">อิตาลี</system:String>
+  <system:String x:Key="languages.ja">ญี่ปุ่น</system:String>
+  <system:String x:Key="languages.ko">เกาหลี</system:String>
+  <system:String x:Key="languages.pl">โปแลนด์</system:String>
+  <system:String x:Key="languages.pt">โปรตุเกส</system:String>
+  <system:String x:Key="languages.ru">รัสเซีย</system:String>
+  <system:String x:Key="languages.vi">เวียดนาม</system:String>
+  <system:String x:Key="languages.zh">จีน</system:String>
+  <system:String x:Key="languages.zh-yue">กวางตุ้ง</system:String>
 
   <system:String x:Key="lyrics.apply">ใช้งาน</system:String>
   <system:String x:Key="lyrics.cancel">ยกเลิก</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">เครื่องมือ</system:String>
   <system:String x:Key="menu.tools.clearcache">ล้างแคช</system:String>
   <!--<system:String x:Key="menu.tools.debugwindow">Debug Window</system:String>-->
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">เลย์เอาท์</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">แนวนอน 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">แนวนอน 1:2</system:String>
@@ -292,6 +309,7 @@
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">ภาษา</system:String>
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">แสดงภาพเหมือนบน Piano roll</system:String>
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">ธีม</system:String>
@@ -395,6 +413,7 @@
   <system:String x:Key="singers.subbanks.set">ตั้งค่า</system:String>
   <!--<system:String x:Key="singers.subbanks.tone">Tone</system:String>-->
   <!--<system:String x:Key="singers.subbanks.toneranges">Tone Ranges</system:String>-->
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <!--<system:String x:Key="singers.visitwebsite">Visit Website</system:String>-->
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.vi-VN.axaml
+++ b/OpenUtau/Strings/Strings.vi-VN.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">Thư mục</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">Trình render</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">Đặt thành mặc định</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">Vẽ tự do</system:String>
   <system:String x:Key="exps.type.numerical">Giá trị số</system:String>
   <system:String x:Key="exps.type.options">Lựa chọn các giá trị</system:String>
+
+  <system:String x:Key="languages.de">Tiếng Đức</system:String>
+  <system:String x:Key="languages.en">Tiếng Anh</system:String>
+  <system:String x:Key="languages.es">Tiếng Tây Ban Nha</system:String>
+  <system:String x:Key="languages.fr">Tiếng Pháp</system:String>
+  <system:String x:Key="languages.it">Tiếng Italy</system:String>
+  <system:String x:Key="languages.ja">Tiếng Nhật</system:String>
+  <system:String x:Key="languages.ko">Tiếng Hàn</system:String>
+  <system:String x:Key="languages.pl">Tiếng Ba Lan</system:String>
+  <system:String x:Key="languages.pt">Tiếng Bồ Đào Nha</system:String>
+  <system:String x:Key="languages.ru">Tiếng Nga</system:String>
+  <system:String x:Key="languages.vi">Tiếng Việt</system:String>
+  <system:String x:Key="languages.zh">Tiếng Trung</system:String>
+  <system:String x:Key="languages.zh-yue">Tiếng Quảng Đông</system:String>
 
   <system:String x:Key="lyrics.apply">Áp dụng</system:String>
   <system:String x:Key="lyrics.cancel">Huỷ bỏ</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">Công cụ</system:String>
   <system:String x:Key="menu.tools.clearcache">Xoá bộ nhớ đệm</system:String>
   <system:String x:Key="menu.tools.debugwindow">Mở cửa sổ Debug</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">Bố cục</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">Ngang 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">Ngang 1:2</system:String>
@@ -292,6 +309,7 @@ Nhấn giữ Ctrl để chọn nhiều nốt</system:String>
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">Ngôn ngữ</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">Hiện nốt của các track khác trong Piano Roll</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">Hiện avatar trong Piano Roll</system:String>
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">Chủ đề</system:String>
@@ -395,6 +413,7 @@ Nhấn giữ Ctrl để chọn nhiều nốt</system:String>
   <system:String x:Key="singers.subbanks.set">Áp dụng</system:String>
   <system:String x:Key="singers.subbanks.tone">Cao độ</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Cao độ</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">Mở trang web</system:String>
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -51,6 +51,8 @@
   <system:String x:Key="dialogs.tracksettings.location">位置</system:String>
   <system:String x:Key="dialogs.tracksettings.renderer">渲染器</system:String>
   <system:String x:Key="dialogs.tracksettings.setasdefault">设为默认</system:String>
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <system:String x:Key="dialogs.voicecolorremapping">音色重映射</system:String>
   <system:String x:Key="dialogs.voicecolorremapping.caption">以下设置将应用于音轨中的所有音符：</system:String>
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">曲线</system:String>
   <system:String x:Key="exps.type.numerical">数值</system:String>
   <system:String x:Key="exps.type.options">选项</system:String>
+
+  <system:String x:Key="languages.de">德语</system:String>
+  <system:String x:Key="languages.en">英语</system:String>
+  <system:String x:Key="languages.es">西班牙语</system:String>
+  <system:String x:Key="languages.fr">法语</system:String>
+  <system:String x:Key="languages.it">意大利语</system:String>
+  <system:String x:Key="languages.ja">日语</system:String>
+  <system:String x:Key="languages.ko">韩语</system:String>
+  <system:String x:Key="languages.pl">波兰语</system:String>
+  <system:String x:Key="languages.pt">葡萄牙语</system:String>
+  <system:String x:Key="languages.ru">俄语</system:String>
+  <system:String x:Key="languages.vi">越南语</system:String>
+  <system:String x:Key="languages.zh">中文</system:String>
+  <system:String x:Key="languages.zh-yue">粤语</system:String>
 
   <system:String x:Key="lyrics.apply">应用</system:String>
   <system:String x:Key="lyrics.cancel">取消</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">工具</system:String>
   <system:String x:Key="menu.tools.clearcache">清空缓存</system:String>
   <system:String x:Key="menu.tools.debugwindow">调试窗口</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">界面布局</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">水平分布 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">水平分布 1:2</system:String>
@@ -292,6 +309,7 @@
   <system:String x:Key="prefs.appearance.degree.solfege">唱名（do re mi fa sol la ti）</system:String>
   <system:String x:Key="prefs.appearance.lang">语言</system:String>
   <system:String x:Key="prefs.appearance.showghostnotes">在钢琴窗上显示其他音轨的音符</system:String>
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">在钢琴窗上显示歌手背景图</system:String>
   <system:String x:Key="prefs.appearance.sortorder">歌手名称显示语言</system:String>
   <system:String x:Key="prefs.appearance.theme">主题</system:String>
@@ -395,6 +413,7 @@
   <system:String x:Key="singers.subbanks.set">设定</system:String>
   <system:String x:Key="singers.subbanks.tone">音调</system:String>
   <system:String x:Key="singers.subbanks.toneranges">音调范围</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <system:String x:Key="singers.visitwebsite">访问歌手官网</system:String>
 
   <system:String x:Key="singersetup.archivefileencoding">压缩包编码</system:String>

--- a/OpenUtau/Strings/Strings.zh-TW.axaml
+++ b/OpenUtau/Strings/Strings.zh-TW.axaml
@@ -51,6 +51,8 @@
   <!--<system:String x:Key="dialogs.tracksettings.location">Location</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.renderer">Renderer</system:String>-->
   <!--<system:String x:Key="dialogs.tracksettings.setasdefault">Set As Default</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.caption">Unsupported file format</system:String>-->
+  <!--<system:String x:Key="dialogs.unsupportedfile.message">Unsupported file format: </system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping">Voice color remapping</system:String>-->
   <!--<system:String x:Key="dialogs.voicecolorremapping.caption">Applies to all notes in this track:</system:String>-->
 
@@ -72,6 +74,20 @@
   <system:String x:Key="exps.type.curve">曲線</system:String>
   <system:String x:Key="exps.type.numerical">數值</system:String>
   <system:String x:Key="exps.type.options">選項</system:String>
+
+  <system:String x:Key="languages.de">德文</system:String>
+  <system:String x:Key="languages.en">英文</system:String>
+  <system:String x:Key="languages.es">西班牙文</system:String>
+  <system:String x:Key="languages.fr">法文</system:String>
+  <system:String x:Key="languages.it">義大利文</system:String>
+  <system:String x:Key="languages.ja">日文</system:String>
+  <system:String x:Key="languages.ko">韓文</system:String>
+  <system:String x:Key="languages.pl">波蘭文</system:String>
+  <system:String x:Key="languages.pt">葡萄牙文</system:String>
+  <system:String x:Key="languages.ru">俄文</system:String>
+  <system:String x:Key="languages.vi">越南文</system:String>
+  <system:String x:Key="languages.zh">中文</system:String>
+  <system:String x:Key="languages.zh-yue">粵語</system:String>
 
   <system:String x:Key="lyrics.apply">套用</system:String>
   <system:String x:Key="lyrics.cancel">取消</system:String>
@@ -139,6 +155,7 @@
   <system:String x:Key="menu.tools">工具</system:String>
   <system:String x:Key="menu.tools.clearcache">清除快取</system:String>
   <system:String x:Key="menu.tools.debugwindow">除錯視窗</system:String>
+  <!--<system:String x:Key="menu.tools.dependency.install">Install Dependency (.oudep)...</system:String>-->
   <system:String x:Key="menu.tools.layout">版面配置</system:String>
   <system:String x:Key="menu.tools.layout.hsplit11">橫向 1:1</system:String>
   <system:String x:Key="menu.tools.layout.hsplit12">橫向 1:2</system:String>
@@ -292,6 +309,7 @@
   <!--<system:String x:Key="prefs.appearance.degree.solfege">Solfège (do re mi fa sol la ti)</system:String>-->
   <system:String x:Key="prefs.appearance.lang">語言</system:String>
   <!--<system:String x:Key="prefs.appearance.showghostnotes">Show other tracks' notes on piano roll</system:String>-->
+  <!--<system:String x:Key="prefs.appearance.showicon">Show icon on piano roll</system:String>-->
   <system:String x:Key="prefs.appearance.showportrait">在鋼琴卷軸上顯示角色背景圖</system:String>
   <!--<system:String x:Key="prefs.appearance.sortorder">Singer name display language</system:String>-->
   <system:String x:Key="prefs.appearance.theme">主題</system:String>
@@ -395,6 +413,7 @@
   <system:String x:Key="singers.subbanks.set">設定</system:String>
   <system:String x:Key="singers.subbanks.tone">音調</system:String>
   <system:String x:Key="singers.subbanks.toneranges">音調範圍</system:String>
+  <!--<system:String x:Key="singers.usefilename">Use filename as alias</system:String>-->
   <!--<system:String x:Key="singers.visitwebsite">Visit Website</system:String>-->
 
   <!--<system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>-->

--- a/OpenUtau/ThemeManager.cs
+++ b/OpenUtau/ThemeManager.cs
@@ -261,6 +261,20 @@ namespace OpenUtau.App {
             return key;
         }
 
+        public static bool TryGetString(string key, out string value) {
+            if (Application.Current == null) {
+                value = key;
+                return false;
+            }
+            IResourceDictionary resDict = Application.Current.Resources;
+            if (resDict.TryGetResource(key, ThemeVariant.Default, out var outVar) && outVar is string s) {
+                value = s;
+                return true;
+            }
+            value = key;
+            return false;
+        }
+
         public static TrackColor GetTrackColor(string name) {
             if (TrackColors.Any(c => c.Name == name)) {
                 return TrackColors.First(c => c.Name == name);

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -270,6 +270,16 @@ namespace OpenUtau.App.ViewModels {
             this.RaisePropertyChanged(nameof(SingerMenuItems));
         }
 
+        public string GetPhonemizerGroupHeader(string key){
+            if(key is null){
+                return "General";
+            }
+            if(ThemeManager.TryGetString($"languages.{key.ToLowerInvariant()}", out var value)){
+                return $"{key}: {value}";
+            }
+            return key;
+        }
+
         public void RefreshPhonemizers() {
             var items = new List<MenuItemViewModel>();
             //Recently used phonemizers
@@ -288,7 +298,7 @@ namespace OpenUtau.App.ViewModels {
                 Items = DocManager.Inst.PhonemizerFactories.GroupBy(factory => factory.language)
                 .OrderBy(group => group.Key)
                 .Select(group => new MenuItemViewModel() {
-                    Header = (group.Key is null) ? "General" : group.Key,
+                    Header = GetPhonemizerGroupHeader(group.Key),
                     Items = group.Select(factory => new MenuItemViewModel() {
                         Header = factory.ToString(),
                         Command = SelectPhonemizerCommand,


### PR DESCRIPTION
After this change, OpenUtau will show localized name for each singing language it supports when selecting phonemizer.
![image](https://github.com/stakira/OpenUtau/assets/54425948/92f583ef-2154-4b99-bdf4-8ea1a94930c0)

The localized names of each language come from https://github.com/symfony/symfony, and are converted to openutau format using the following script:
```python
#symfony repo contains the names of one language in different languages
#https://github.com/symfony/symfony
#This script converts them to openutau's localization file format.

#Before running this script, please run the following commands:
#git clone https://github.com/symfony/symfony
#git clone https://github.com/stakira/OpenUtau
#pip install py_linq

from   typing  import List, Dict, Tuple
import pathlib
from   py_linq import Enumerable
from   OpenUtau.Misc.sync_strings import file_to_dict, dict_to_file

oRoot = pathlib.Path("OpenUtau")
sRoot = pathlib.Path("symfony")

oLangsFolder = oRoot / "OpenUtau" / "Strings"
sLangsFolder = sRoot / "src" / "Symfony" / "Component" / "Intl" / "Resources" / "data" / "languages"

uiLangMapping = {
    "axaml": "en",
    "zh-TW": "zh_Hant",
}

singingLangMapping = {
    "zh-yue": "yue",
}

#Singing languages supported by OpenUtau
keys = [
    "de",
    "en",
    "es",
    "fr",
    "it",
    "ja",
    "ko",
    "pl",
    "pt",
    "ru",
    "vi",
    "zh",
    "zh-yue",
]

def uiOLangToSLang(oLang: str) -> str:
    if(oLang in uiLangMapping):
        return uiLangMapping[oLang]
    else:
        return oLang.split("-")[0]

def singingOLangToSLang(oLang: str) -> str:
    if(oLang in singingLangMapping):
        return singingLangMapping[oLang]
    else:
        return oLang.split("-")[0]

def loadSymfonyLangs(filepath: pathlib.Path) -> Dict[str, str]:
    with open(filepath, "r", encoding="utf-8") as f:
        return Enumerable(f.readlines())\
            .where(lambda line: "' => '" in line)\
            .select(lambda line: line.split("'"))\
            .to_dictionary(lambda parts: parts[1], lambda parts: parts[3])

def main():
    for oLangFile in oLangsFolder.iterdir():
        oLang = file_to_dict(oLangFile)
        if(oLangFile.name == "Strings.axaml"):
            oLangEn = {}
        else:
            oLangEn = file_to_dict(oLangsFolder / "Strings.axaml")
        to_add = set(oLangEn.keys()) - set(oLang.keys())
        [oLang.update({k: oLangEn[k]}) for k in to_add]
        sLangFile = sLangsFolder / f"{uiOLangToSLang(oLangFile.name.split('.')[1])}.php"
        print(sLangFile, "\n", oLangFile, "\n")
        sLang = loadSymfonyLangs(sLangFile)
        for key in keys:
            sKey = singingOLangToSLang(key)
            if(sKey in sLang):
                oLang[f"languages.{key}"] = ("String", sLang[sKey])
        dict_to_file(oLangFile, oLang, oLangEn)

if(__name__ == "__main__"):
    main()
```