### PR TITLE
Fix file system path handling by adding surrounding ""

### DIFF
--- a/OpenUtau.Core/Util/OS.cs
+++ b/OpenUtau.Core/Util/OS.cs
@@ -13,22 +13,23 @@ namespace OpenUtau {
             if (Directory.Exists(path)) {
                 Process.Start(new ProcessStartInfo {
                     FileName = GetOpener(),
-                    Arguments = $"\"{path}\"",
+                    Arguments = GetWrappedPath(path),
                 });
             }
         }
 
         public static void GotoFile(string path) {
             if (File.Exists(path)) {
+                var wrappedPath = GetWrappedPath(path);
                 if (IsWindows()) {
                     Process.Start(new ProcessStartInfo {
                         FileName = GetOpener(),
-                        Arguments = $"/select, \"{path}\"",
+                        Arguments = $"/select, {wrappedPath}",
                     });
                 } else if (IsMacOS()) {
                     Process.Start(new ProcessStartInfo {
                         FileName = GetOpener(),
-                        Arguments = $" -R \"{path}\"",
+                        Arguments = $" -R {wrappedPath}",
                     });
                 } else {
                     OpenFolder(Path.GetDirectoryName(path));
@@ -94,6 +95,13 @@ namespace OpenUtau {
                 }
             }
             throw new IOException($"None of {string.Join(", ", linuxOpeners)} found.");
+        }
+        private static string GetWrappedPath(string path) {
+            if (IsWindows()) {
+                return path;
+            } else {
+                return $"\"{path}\"";
+            }
         }
     }
 }

--- a/OpenUtau.Core/Util/OS.cs
+++ b/OpenUtau.Core/Util/OS.cs
@@ -13,7 +13,7 @@ namespace OpenUtau {
             if (Directory.Exists(path)) {
                 Process.Start(new ProcessStartInfo {
                     FileName = GetOpener(),
-                    Arguments = path,
+                    Arguments = $"\"{path}\"",
                 });
             }
         }
@@ -23,12 +23,12 @@ namespace OpenUtau {
                 if (IsWindows()) {
                     Process.Start(new ProcessStartInfo {
                         FileName = GetOpener(),
-                        Arguments = $"/select, {path}",
+                        Arguments = $"/select, \"{path}\"",
                     });
                 } else if (IsMacOS()) {
                     Process.Start(new ProcessStartInfo {
                         FileName = GetOpener(),
-                        Arguments = $" -R {path}",
+                        Arguments = $" -R \"{path}\"",
                     });
                 } else {
                     OpenFolder(Path.GetDirectoryName(path));


### PR DESCRIPTION
I found on macOS, when my vb's path contains a whitespace, the "open location" and "generate error report" features don't work properly, so I added `"` in the path passed to the CMD.

I tested only on macOS, so could you help test on Windows? I'm not sure whether the fix is redundant or making a problem on Windows.