### PR TITLE
Add singer favorite function

### DIFF
--- a/OpenUtau.Core/Ustx/USinger.cs
+++ b/OpenUtau.Core/Ustx/USinger.cs
@@ -222,7 +222,7 @@ namespace OpenUtau.Core.Ustx {
                 NotifyPropertyChanged(nameof(OtoDirty));
             }
         }
-        public bool Favored {
+        public bool IsFavourite {
             get => Preferences.Default.FavoriteSingers.Contains(Id);
             set {
                 if (value) {

--- a/OpenUtau.Core/Ustx/USinger.cs
+++ b/OpenUtau.Core/Ustx/USinger.cs
@@ -222,6 +222,19 @@ namespace OpenUtau.Core.Ustx {
                 NotifyPropertyChanged(nameof(OtoDirty));
             }
         }
+        public bool Favored {
+            get => Preferences.Default.FavoriteSingers.Contains(Id);
+            set {
+                if (value) {
+                    if (!Preferences.Default.FavoriteSingers.Contains(Id)) {
+                        Preferences.Default.FavoriteSingers.Add(Id);
+                    }
+                } else {
+                    Preferences.Default.FavoriteSingers.Remove(Id);
+                }
+                Preferences.Save();
+            }
+        }
 
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -152,6 +152,7 @@ namespace OpenUtau.Core.Util {
             public bool PreferCommaSeparator = false;
             public bool ResamplerLogging = false;
             public List<string> RecentSingers = new List<string>();
+            public List<string> FavoriteSingers = new List<string>();
             public Dictionary<string, string> SingerPhonemizers = new Dictionary<string, string>();
             public List<string> RecentPhonemizers = new List<string>();
             public bool PreferPortAudio = false;

--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -61,6 +61,30 @@
                 <Setter Property="Command" Value="{Binding Command}"/>
                 <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
                 <Setter Property="ItemsSource" Value="{Binding Items}"/>
+                <Setter Property="Icon" Value="{Binding Icon}"/>
+                <Setter Property="ToolTip.Tip" Value="{Binding Location}"/>
+              </Style>
+              
+              <Style Selector="ToggleButton">
+                <Setter Property="Padding" Value="0"/>
+                <Setter Property="Content" Value="♡"/>
+                <Setter Property="FontSize" Value="16"/>
+                <Setter Property="Width" Value="20"/>
+                <Setter Property="Height" Value="20"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="Foreground" Value="{DynamicResource AccentBrush3}"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Style Selector="^:checked">
+                  <Setter Property="Content" Value="♥"/>
+                </Style>
+                <Style Selector="^:checked /template/ ContentPresenter#PART_ContentPresenter">
+                  <Setter Property="Foreground" Value="{DynamicResource AccentBrush3}" />
+                  <Setter Property="Background" Value="Transparent"/>
+                </Style>
+                <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                  <Setter Property="Foreground" Value="{DynamicResource AccentBrush3}" />
+                  <Setter Property="Background" Value="Transparent"/>
+                </Style>
               </Style>
             </ContextMenu.Styles>
           </ContextMenu>

--- a/OpenUtau/Controls/TrackHeader.axaml.cs
+++ b/OpenUtau/Controls/TrackHeader.axaml.cs
@@ -6,8 +6,10 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
+using OpenUtau.App.Views;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
+using Org.BouncyCastle.Cms;
 using ReactiveUI;
 
 namespace OpenUtau.App.Controls {
@@ -86,6 +88,8 @@ namespace OpenUtau.App.Controls {
             if (SingerManager.Inst.Singers.Count > 0) {
                 ViewModel?.RefreshSingers();
                 SingersMenu.Open();
+            } else {
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification("There is no singer."));
             }
             args.Handled = true;
         }

--- a/OpenUtau/Controls/TrackHeader.axaml.cs
+++ b/OpenUtau/Controls/TrackHeader.axaml.cs
@@ -6,10 +6,8 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using OpenUtau.App.ViewModels;
-using OpenUtau.App.Views;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
-using Org.BouncyCastle.Cms;
 using ReactiveUI;
 
 namespace OpenUtau.App.Controls {

--- a/OpenUtau/ViewModels/MenuItemViewModel.cs
+++ b/OpenUtau/ViewModels/MenuItemViewModel.cs
@@ -14,16 +14,16 @@ namespace OpenUtau.App.ViewModels {
     }
 
     public class SingerMenuItemViewModel : MenuItemViewModel {
-        public bool IsFav {
+        public bool IsFavourite {
             get {
                 if(CommandParameter is USinger singer) {
-                    return singer.Favored;
+                    return singer.IsFavourite;
                 }
                 return false;
             }
             set {
                 if (CommandParameter is USinger singer) {
-                    singer.Favored = value;
+                    singer.IsFavourite = value;
                 }
             }
         }
@@ -33,7 +33,7 @@ namespace OpenUtau.App.ViewModels {
                 if(_icon == null) {
                     if (CommandParameter is USinger) {
                         _icon = new ToggleButton() {
-                            [!ToggleButton.IsCheckedProperty] = new Binding("IsFav")
+                            [!ToggleButton.IsCheckedProperty] = new Binding("IsFavourite")
                         };
                     }
                 }

--- a/OpenUtau/ViewModels/MenuItemViewModel.cs
+++ b/OpenUtau/ViewModels/MenuItemViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Windows.Input;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.App.ViewModels {
     public class MenuItemViewModel {
@@ -8,5 +11,42 @@ namespace OpenUtau.App.ViewModels {
         public object? CommandParameter { get; set; }
         public IList<MenuItemViewModel>? Items { get; set; }
         public double Height { get; set; } = 24;
+    }
+
+    public class SingerMenuItemViewModel : MenuItemViewModel {
+        public bool IsFav {
+            get {
+                if(CommandParameter is USinger singer) {
+                    return singer.Favored;
+                }
+                return false;
+            }
+            set {
+                if (CommandParameter is USinger singer) {
+                    singer.Favored = value;
+                }
+            }
+        }
+        private object? _icon;
+        public object? Icon {
+            get {
+                if(_icon == null) {
+                    if (CommandParameter is USinger) {
+                        _icon = new ToggleButton() {
+                            [!ToggleButton.IsCheckedProperty] = new Binding("IsFav")
+                        };
+                    }
+                }
+                return _icon;
+            }
+        }
+        public string? Location {
+            get {
+                if (CommandParameter is USinger singer) {
+                    return singer.Location;
+                }
+                return null;
+            }
+        }
     }
 }

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -248,18 +248,30 @@ namespace OpenUtau.App.ViewModels {
             items.AddRange(Preferences.Default.RecentSingers
                 .Select(id => SingerManager.Inst.Singers.Values.FirstOrDefault(singer => singer.Id == id))
                 .OfType<USinger>()
-                .LocalizedOrderBy(singer => singer.LocalizedName)
-                .Select(singer => new MenuItemViewModel() {
+                .Select(singer => new SingerMenuItemViewModel() {
                     Header = singer.LocalizedName,
                     Command = SelectSingerCommand,
                     CommandParameter = singer,
                 }));
+            items.Add(new SingerMenuItemViewModel() {
+                Header = "Favs ...",
+                Items = Preferences.Default.FavoriteSingers
+                    .Select(id => SingerManager.Inst.Singers.Values.FirstOrDefault(singer => singer.Id == id))
+                    .OfType<USinger>()
+                    .LocalizedOrderBy(singer => singer.LocalizedName)
+                    .Select(singer => new SingerMenuItemViewModel() {
+                        Header = singer.LocalizedName,
+                        Command = SelectSingerCommand,
+                        CommandParameter = singer,
+                    }).ToArray(),
+            });
+
             var keys = SingerManager.Inst.SingerGroups.Keys.OrderBy(k => k);
             foreach (var key in keys) {
-                items.Add(new MenuItemViewModel() {
+                items.Add(new SingerMenuItemViewModel() {
                     Header = $"{key} ...",
                     Items = SingerManager.Inst.SingerGroups[key]
-                        .Select(singer => new MenuItemViewModel() {
+                        .Select(singer => new SingerMenuItemViewModel() {
                             Header = singer.LocalizedName,
                             Command = SelectSingerCommand,
                             CommandParameter = singer,

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -254,7 +254,7 @@ namespace OpenUtau.App.ViewModels {
                     CommandParameter = singer,
                 }));
             items.Add(new SingerMenuItemViewModel() {
-                Header = "Favs ...",
+                Header = "Favourites ...",
                 Items = Preferences.Default.FavoriteSingers
                     .Select(id => SingerManager.Inst.Singers.Values.FirstOrDefault(singer => singer.Id == id))
                     .OfType<USinger>()

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -78,11 +78,13 @@
             <TextBlock Text="{DynamicResource prefs.paths.addlsinger}"/>
             <TextBlock HorizontalAlignment="Stretch" Margin="4"
                        TextWrapping="Wrap" FontSize="11" Text="{Binding AdditionalSingersPath}"/>
-            <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
+            <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*,10,*">
               <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
                       HorizontalAlignment="Stretch" Click="ResetAddlSingersPath"/>
               <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
                       HorizontalAlignment="Stretch" Click="SelectAddlSingersPath"/>
+              <Button Grid.Column="4" Content="{DynamicResource singers.refresh}"
+                      HorizontalAlignment="Stretch" Click="ReloadSingers"/>
             </Grid>
             <Grid Margin="0,5,0,0">
               <TextBlock Text="{DynamicResource prefs.paths.addlsinger.install}" HorizontalAlignment="Left"/>

--- a/OpenUtau/Views/PreferencesDialog.axaml.cs
+++ b/OpenUtau/Views/PreferencesDialog.axaml.cs
@@ -1,8 +1,10 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using OpenUtau.App.ViewModels;
+using OpenUtau.Core;
 
 namespace OpenUtau.App.Views {
     public partial class PreferencesDialog : Window {
@@ -21,6 +23,18 @@ namespace OpenUtau.App.Views {
             }
             if (Directory.Exists(path)) {
                 ((PreferencesViewModel)DataContext!).SetAddlSingersPath(path);
+            }
+        }
+
+        void ReloadSingers(object sender, RoutedEventArgs e) {
+            DocManager.Inst.ExecuteCmd(new LoadingNotification(typeof(PreferencesDialog), true, "singer"));
+            try {
+                SingerManager.Inst.SearchAllSingers();
+                DocManager.Inst.ExecuteCmd(new SingersRefreshedNotification());
+            } catch (Exception ex) {
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
+            } finally {
+                DocManager.Inst.ExecuteCmd(new LoadingNotification(typeof(PreferencesDialog), false, "singer"));
             }
         }
 


### PR DESCRIPTION
New Features:
- Singer favorite function
![image](https://github.com/stakira/OpenUtau/assets/130257355/78377c66-151b-48d5-82b4-549c4c31918b)
These are stored in the preferences.
- Reloading singers in the Preferences dialog (e.g., when singer path is changed)

Specification Changes:
- Recently used singers are now sorted in the order in which they were used.
- Now notifies when there is no singer.
- When selecting singers, paths are now shown on mouse over.

Known Issues (I tried these things but could not fix them):
- Favorite status in the singer selection menu is not bound in real time.
- Heart button is small.
- I want to move the heart button to the far right.