### PR TITLE
Add option to load only top directories of singers

### DIFF
--- a/OpenUtau.Core/Classic/ClassicSingerLoader.cs
+++ b/OpenUtau.Core/Classic/ClassicSingerLoader.cs
@@ -17,11 +17,7 @@ namespace OpenUtau.Classic {
         }
         public static IEnumerable<USinger> FindAllSingers() {
             List<USinger> singers = new List<USinger>();
-            foreach (var path in new string[] {
-                PathManager.Inst.SingersPathOld,
-                PathManager.Inst.SingersPath,
-                PathManager.Inst.AdditionalSingersPath,
-            }) {
+            foreach (var path in PathManager.Inst.SingersPaths) {
                 var loader = new VoicebankLoader(path);
                 singers.AddRange(loader.SearchAll()
                     .Select(AdjustSingerType));

--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using Serilog;
 
 namespace OpenUtau.Classic {
@@ -45,7 +46,15 @@ namespace OpenUtau.Classic {
             if (!Directory.Exists(basePath)) {
                 return result;
             }
-            result.AddRange(Directory.EnumerateFiles(basePath, kCharTxt, SearchOption.AllDirectories)
+            IEnumerable<string> files;
+            if (Preferences.Default.LoadDeepFolderSinger) {
+                files = Directory.EnumerateFiles(basePath, kCharTxt, SearchOption.AllDirectories);
+            } else {
+                // TopDirectoryOnly
+                files = Directory.GetDirectories(basePath)
+                    .SelectMany(path => Directory.EnumerateFiles(path, kCharTxt));
+            }
+            result.AddRange(files
                 .Select(filePath => {
                     try {
                         var voicebank = new Voicebank();

--- a/OpenUtau.Core/SingerManager.cs
+++ b/OpenUtau.Core/SingerManager.cs
@@ -32,7 +32,8 @@ namespace OpenUtau.Core {
                 Directory.CreateDirectory(PathManager.Inst.SingersPath);
                 var stopWatch = Stopwatch.StartNew();
                 var singers = ClassicSingerLoader.FindAllSingers()
-                    .Concat(Vogen.VogenSingerLoader.FindAllSingers());
+                    .Concat(Vogen.VogenSingerLoader.FindAllSingers())
+                    .Distinct();
                 Singers = singers
                     .ToLookup(s => s.Id)
                     .ToDictionary(g => g.Key, g => g.First());

--- a/OpenUtau.Core/Ustx/USinger.cs
+++ b/OpenUtau.Core/Ustx/USinger.cs
@@ -187,7 +187,7 @@ namespace OpenUtau.Core.Ustx {
 
     [Flags] public enum USingerType { Classic = 0x1, Enunu = 0x2, Vogen = 0x4, DiffSinger=0x5 }
 
-    public class USinger : INotifyPropertyChanged {
+    public class USinger : INotifyPropertyChanged, IEquatable<USinger> {
         protected static readonly List<UOto> emptyOtos = new List<UOto>();
 
         public virtual string Id { get; }
@@ -268,6 +268,16 @@ namespace OpenUtau.Core.Ustx {
         public virtual byte[] LoadPortrait() => null;
         public virtual byte[] LoadSample() => null;
         public override string ToString() => Name;
+        public bool Equals(USinger other) {
+            // Tentative: Since only the singer's Id is recorded in ustx and preferences, singers with the same Id are considered identical.
+            // Singer with the same directory name in different locations may be identical.
+            if (other != null && other.Id == this.Id) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+        public override int GetHashCode() => Id.GetHashCode();
 
         public static USinger CreateMissing(string name) {
             return new USinger() {

--- a/OpenUtau.Core/Util/PathManager.cs
+++ b/OpenUtau.Core/Util/PathManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -84,6 +85,19 @@ namespace OpenUtau.Core {
         public string PrefsFilePath => Path.Combine(DataPath, "prefs.json");
         public string NotePresetsFilePath => Path.Combine(DataPath, "notepresets.json");
         public string BackupsPath => Path.Combine(DataPath, "Backups");
+
+        public List<string> SingersPaths {
+            get {
+                var list = new List<string> { SingersPath };
+                if (Directory.Exists(SingersPathOld)) {
+                    list.Add(SingersPathOld);
+                }
+                if (Directory.Exists(AdditionalSingersPath)) {
+                    list.Add(AdditionalSingersPath);
+                }
+                return list.Distinct().ToList();
+            }
+        }
 
         Regex invalid = new Regex("[\\x00-\\x1f<>:\"/\\\\|?*]|^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9]|CLOCK\\$)(\\.|$)|[\\.]$", RegexOptions.IgnoreCase);
 

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -149,6 +149,7 @@ namespace OpenUtau.Core.Util {
             public string SkipUpdate = string.Empty;
             public string AdditionalSingerPath = string.Empty;
             public bool InstallToAdditionalSingersPath = true;
+            public bool LoadDeepFolderSinger = true;
             public bool PreferCommaSeparator = false;
             public bool ResamplerLogging = false;
             public List<string> RecentSingers = new List<string>();

--- a/OpenUtau.Core/Vogen/VogenSingerLoader.cs
+++ b/OpenUtau.Core/Vogen/VogenSingerLoader.cs
@@ -30,11 +30,7 @@ namespace OpenUtau.Core.Vogen {
 
         public static IEnumerable<USinger> FindAllSingers() {
             List<USinger> singers = new List<USinger>();
-            foreach (var path in new string[] {
-                PathManager.Inst.SingersPathOld,
-                PathManager.Inst.SingersPath,
-                PathManager.Inst.AdditionalSingersPath,
-            }) {
+            foreach (var path in PathManager.Inst.SingersPaths) {
                 var loader = new VogenSingerLoader(path);
                 singers.AddRange(loader.SearchAll());
             }
@@ -50,7 +46,15 @@ namespace OpenUtau.Core.Vogen {
             if (!Directory.Exists(basePath)) {
                 return result;
             }
-            result.AddRange(Directory.EnumerateFiles(basePath, "*.vogeon", SearchOption.AllDirectories)
+            IEnumerable<string> files;
+            if (Preferences.Default.LoadDeepFolderSinger) {
+                files = Directory.EnumerateFiles(basePath, "*.vogeon", SearchOption.AllDirectories);
+            } else {
+                // TopDirectoryOnly
+                files = Directory.GetDirectories(basePath)
+                    .SelectMany(path => Directory.EnumerateFiles(path, "*.vogeon"));
+            }
+            result.AddRange(files
                 .Select(filePath => {
                     try {
                         return LoadSinger(filePath);

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -317,6 +317,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.paths">Paths</system:String>
   <system:String x:Key="prefs.paths.addlsinger">Additional Singer Path</system:String>
   <system:String x:Key="prefs.paths.addlsinger.install">Install to Additional Singer Path</system:String>
+  <system:String x:Key="prefs.paths.loaddeepfolders">Load all depth folders</system:String>
   <system:String x:Key="prefs.paths.reset">Reset</system:String>
   <system:String x:Key="prefs.paths.select">Select</system:String>
   <system:String x:Key="prefs.playback">Playback</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -313,6 +313,7 @@
   <system:String x:Key="prefs.paths">ファイルの場所</system:String>
   <system:String x:Key="prefs.paths.addlsinger">シンガーの場所（追加）</system:String>
   <system:String x:Key="prefs.paths.addlsinger.install">シンガーの場所(追加)にインストール</system:String>
+  <system:String x:Key="prefs.paths.loaddeepfolders">深い階層のフォルダも読み込む</system:String>
   <system:String x:Key="prefs.paths.reset">リセット</system:String>
   <system:String x:Key="prefs.paths.select">選択</system:String>
   <system:String x:Key="prefs.playback">再生</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -29,6 +29,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int LockStartTime { get; set; }
         public string AdditionalSingersPath => !string.IsNullOrWhiteSpace(PathManager.Inst.AdditionalSingersPath)? PathManager.Inst.AdditionalSingersPath : "(None)";
         [Reactive] public bool InstallToAdditionalSingersPath { get; set; }
+        [Reactive] public bool LoadDeepFolders { get; set; }
         [Reactive] public bool PreRender { get; set; }
         public List<string> DefaultRendererOptions { get; set; }
         [Reactive] public string DefaultRenderer { get; set; }
@@ -111,6 +112,7 @@ namespace OpenUtau.App.ViewModels {
             PlayPosMarkerMargin = Preferences.Default.PlayPosMarkerMargin;
             LockStartTime = Preferences.Default.LockStartTime;
             InstallToAdditionalSingersPath = Preferences.Default.InstallToAdditionalSingersPath;
+            LoadDeepFolders = Preferences.Default.LoadDeepFolderSinger;
             ToolsManager.Inst.Initialize();
             var pattern = new Regex(@"Strings\.([\w-]+)\.axaml");
             Languages = App.GetLanguages().Keys
@@ -187,6 +189,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.InstallToAdditionalSingersPath)
                 .Subscribe(additionalSingersPath => {
                     Preferences.Default.InstallToAdditionalSingersPath = additionalSingersPath;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.LoadDeepFolders)
+                .Subscribe(loadDeepFolders => {
+                    Preferences.Default.LoadDeepFolderSinger = loadDeepFolders;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.PreRender)

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -88,6 +88,10 @@
               <TextBlock Text="{DynamicResource prefs.paths.addlsinger.install}" HorizontalAlignment="Left"/>
               <ToggleSwitch IsChecked="{Binding InstallToAdditionalSingersPath}"/>
             </Grid>
+            <Grid>
+              <TextBlock Text="{DynamicResource prefs.paths.loaddeepfolders}" HorizontalAlignment="Left"/>
+              <ToggleSwitch IsChecked="{Binding LoadDeepFolders}"/>
+            </Grid>
           </StackPanel>
         </HeaderedContentControl>
         <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.cache}">


### PR DESCRIPTION
Having the same search range for singers as for OG UTAU is useful for users who share a voice folder.
This can be selected in Preferences.

Bug Fixes:
- When the Singers folder is selected as AdditionalSingerPath, it is not loaded twice.
- Avoided loading singers with the same folder name.