### PR TITLE
Add track expression logic

### DIFF
--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -156,23 +156,23 @@ namespace OpenUtau.Core.Ustx {
         }
 
         public List<Tuple<float, bool>> GetExpression(UProject project, UTrack track, string abbr) {
-            track.TryGetExpression(project, abbr, out var descriptor);
+            track.TryGetExpression(project, abbr, out UExpression trackExp);
             var list = new List<Tuple<float, bool>>();
             int indexes = (phonemeExpressions.Max(exp => exp.index) ?? 0) + 1;
 
             for (int i = 0; i < indexes; i++) {
-                var expression = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == descriptor.abbr && exp.index == i);
-                if (expression != null) {
-                    list.Add(Tuple.Create(expression.value, true));
+                var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                if (phonemeExp != null) {
+                    list.Add(Tuple.Create(phonemeExp.value, true));
                 } else {
-                    list.Add(Tuple.Create(descriptor.defaultValue, false));
+                    list.Add(Tuple.Create(trackExp.value, false));
                 }
             }
             return list;
         }
 
         public void SetExpression(UProject project, UTrack track, string abbr, float[] values) {
-            if (!track.TryGetExpression(project, abbr, out var descriptor)) {
+            if (!track.TryGetExpression(project, abbr, out UExpression trackExp)) {
                 return;
             }
             int indexes = (phonemeExpressions.Max(exp => exp.index) ?? 0) + 1;
@@ -185,17 +185,16 @@ namespace OpenUtau.Core.Ustx {
                     value = values.Last();
                 }
 
-                if (descriptor.defaultValue == value) {
-                    phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == descriptor.abbr && exp.index == i);
+                if (trackExp.value == value) {
+                    phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == i);
                     continue;
                 }
-                var expression = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == descriptor.abbr && exp.index == i);
-                if (expression != null) {
-                    expression.descriptor = descriptor;
-                    expression.value = value;
+                var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                if (phonemeExp != null) {
+                    phonemeExp.descriptor = trackExp.descriptor;
+                    phonemeExp.value = value;
                 } else {
-                    phonemeExpressions.Add(new UExpression(descriptor) {
-                        descriptor = descriptor,
+                    phonemeExpressions.Add(new UExpression(trackExp.descriptor) {
                         index = i,
                         value = value,
                     });

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using YamlDotNet.Serialization;
-using OpenUtau.Core.Render;
 
 namespace OpenUtau.Core.Ustx {
     public class UPhoneme {
@@ -166,39 +165,41 @@ namespace OpenUtau.Core.Ustx {
             envelope.data[4] = p4;
         }
 
+        /**  
+            <summary>
+                If the phoneme does not have the corresponding expression, return the track's expression and false
+            </summary>
+        */
         public Tuple<float, bool> GetExpression(UProject project, UTrack track, string abbr) {
-            track.TryGetExpression(project, abbr, out var descriptor);
+            track.TryGetExpression(project, abbr, out UExpression trackExp);
             var note = Parent.Extends ?? Parent;
-            var expression = note.phonemeExpressions.FirstOrDefault(
-                exp => exp.descriptor?.abbr == descriptor.abbr && exp.index == index);
-            if (expression != null) {
-                return Tuple.Create(expression.value, true);
+            var phonemeExp = note.phonemeExpressions.FirstOrDefault(
+                exp => exp.descriptor?.abbr == abbr && exp.index == index);
+            if (phonemeExp != null) {
+                return Tuple.Create(phonemeExp.value, true);
             } else {
-                return Tuple.Create(descriptor.defaultValue, false);
+                return Tuple.Create(trackExp.value, false);
             }
         }
 
-        public void SetExpression(UProject project, UTrack track, string abbr, float value) {
-            if (!track.TryGetExpression(project, abbr, out var descriptor)) {
+        public void SetExpression(UProject project, UTrack track, string abbr, float? value) {
+            if (!track.TryGetExpression(project, abbr, out UExpression trackExp)) {
                 return;
             }
             var note = Parent.Extends ?? Parent;
-            if (descriptor.defaultValue == value) {
-                note.phonemeExpressions.RemoveAll(
-                    exp => exp.descriptor?.abbr == descriptor.abbr && exp.index == index);
-                return;
-            }
-            var expression = note.phonemeExpressions.FirstOrDefault(
-                exp => exp.descriptor?.abbr == descriptor.abbr && exp.index == index);
-            if (expression != null) {
-                expression.descriptor = descriptor;
-                expression.value = value;
+            if (value == null || trackExp.value == value) {
+                note.phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == index);
             } else {
-                note.phonemeExpressions.Add(new UExpression(descriptor) {
-                    descriptor = descriptor,
-                    index = index,
-                    value = value,
-                });
+                var phonemeExp = note.phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == index);
+                if (phonemeExp != null) {
+                    phonemeExp.descriptor = trackExp.descriptor;
+                    phonemeExp.value = (float)value;
+                } else {
+                    note.phonemeExpressions.Add(new UExpression(trackExp.descriptor) {
+                        index = index,
+                        value = (float)value,
+                    });
+                }
             }
         }
 

--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -90,14 +90,14 @@ namespace OpenUtau.App.Controls {
                 return;
             }
             var project = DocManager.Inst.Project;
-            if (!project.tracks[Part.trackNo].TryGetExpression(project, key, out var descriptor)) {
+            var track = project.tracks[Part.trackNo];
+            if (!track.TryGetExpDescriptor(project, key, out var descriptor)) {
                 return;
             }
             if (descriptor.max <= descriptor.min) {
                 return;
             }
             DrawBackgroundForHitTest(context);
-            var track = project.tracks[Part.trackNo];
             double leftTick = TickOffset - 480;
             double rightTick = TickOffset + Bounds.Width / TickWidth + 480;
             double optionHeight = descriptor.type == UExpressionType.Options

--- a/OpenUtau/Views/NoteEditStates.cs
+++ b/OpenUtau/Views/NoteEditStates.cs
@@ -615,8 +615,7 @@ namespace OpenUtau.App.Views {
             var part = notesVm.Part;
             track = project.tracks[part!.trackNo];
             if (project == null || part == null ||
-                !track.TryGetExpression(
-                    project, notesVm.PrimaryKey, out descriptor)) {
+                !track.TryGetExpDescriptor(project, notesVm.PrimaryKey, out descriptor)) {
                 descriptor = null;
             }
         }
@@ -727,8 +726,7 @@ namespace OpenUtau.App.Views {
             var part = notesVm.Part;
             track = project.tracks[part!.trackNo];
             if (project == null || part == null ||
-                !track.TryGetExpression(
-                    project, notesVm.PrimaryKey, out descriptor)) {
+                !track.TryGetExpDescriptor(project, notesVm.PrimaryKey, out descriptor)) {
                 descriptor = null;
             }
         }


### PR DESCRIPTION
Added "List<UExpression> TrackExpressions" to UTrack.

The process for getting phoneme expression:
First get expression descriptor of the project, overriding the track expression if any, and further overriding the phoneme expression if any.

There is no UI yet.
In the future, being able to set expressions for each track would absorb the differences between renderers and resamplers.