### PR TITLE
Diffsinger Rhythmizer phonemizer: Support hanzi input

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerRhythmizerPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRhythmizerPhonemizer.cs
@@ -220,5 +220,9 @@ namespace OpenUtau.Core.DiffSinger {
             result.RemoveAt(result.Count - 1);
             return result;
         }
+
+        protected override string[] Romanize(IEnumerable<string> lyrics) {
+            return BaseChinesePhonemizer.Romanize(lyrics);
+        }
     }
 }


### PR DESCRIPTION
Diffsinger Rhythmizer phonemizer is a legacy solution used by old diffsinger voicebanks. Since the diffsinger rhythmizer is only used by Chinese voicebanks and there is no need to train new rhythmizer models now (because we have dsdur model), this PR directly adds the hanzi to pinyin converter to the rhythmizer phonemizer instead of creating a separate ZH one.