### PR TITLE
Curve performance enhancement

### DIFF
--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -423,6 +423,8 @@ namespace OpenUtau.Core.Editing {
                 int? lastX = null;
                 int? lastY = null;
                 // TODO: Optimize interpolation and command.
+                List<int> xs = new List<int>();
+                List<int> ys = new List<int>();
                 for (int i = 0; i < result.tones.Length; i++) {
                     if (result.tones[i] < 0) {
                         continue;
@@ -434,11 +436,14 @@ namespace OpenUtau.Core.Editing {
                     lastX ??= x;
                     lastY ??= y;
                     if (y > minPitD) {
-                        docManager.ExecuteCmd(new SetCurveCommand(
-                            project, part, Format.Ustx.PITD, x, y, lastX.Value, lastY.Value));
+                        xs.Add(x);
+                        ys.Add(y);
                     }
                     lastX = x;
                     lastY = y;
+                }
+                if (xs.Count > 0) {
+                    docManager.ExecuteCmd(new SetRangeCurveCommand(project, part, Format.Ustx.PITD, xs, ys));
                 }
             }
             docManager.EndUndoGroup();

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -295,8 +295,11 @@ namespace OpenUtau.Core.Render {
             pitchesBeforeDeviation = pitches.ToArray();
             var pitchCurve = part.curves.FirstOrDefault(c => c.abbr == Format.Ustx.PITD);
             if (pitchCurve != null && !pitchCurve.IsEmpty) {
-                for (int i = 0; i < pitches.Length; ++i) {
-                    pitches[i] += pitchCurve.Sample(pitchStart + i * pitchInterval);
+                var pitdSampled = pitchCurve.Samples(pitchStart, pitches.Length, pitchInterval);
+                int i = 0;
+                foreach (int p in pitdSampled) {
+                    pitches[i] += p;
+                    i++;
                 }
             }
 
@@ -357,10 +360,9 @@ namespace OpenUtau.Core.Render {
 
         private static float[] SampleCurve(UCurve curve, int start, int length, Func<float, UCurve, float> convert) {
             const int interval = 5;
-            var result = new float[length];
-            for (int i = 0; i < length; ++i) {
-                result[i] = convert(curve.Sample(start + i * interval), curve);
-            }
+            var result = curve.Samples(start, length, interval)
+                .Select(v => convert(v, curve))
+                .ToArray();
             return result;
         }
 

--- a/OpenUtau.Test/Core/USTx/UCurveTest.cs
+++ b/OpenUtau.Test/Core/USTx/UCurveTest.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenUtau.Core.Ustx {
+    public class UCurveTest {
+        readonly ITestOutputHelper output;
+        readonly UCurve curve; 
+        public UCurveTest(ITestOutputHelper output){
+            this.output = output;
+            var descriptor = new UExpressionDescriptor("testcurve", "TEST", 0, 200, 99);
+            curve = new UCurve(descriptor);
+            curve.xs = new List<int> { 10, 30, 60, 100 };
+            curve.ys = new List<int> { 110, 40, 50, 140 };
+        }
+
+        [Fact]
+        public void UCurveSampleTest() {
+            //If the x value exists in xs, return the corresponding y value
+            Assert.Equal(110, curve.Sample(10));
+            Assert.Equal(40, curve.Sample(30));
+            Assert.Equal(50, curve.Sample(60));
+            Assert.Equal(140, curve.Sample(100));
+            //If the x value is greater than xs[^1] or less than xs[0], return the default value specified in the descriptor
+            Assert.Equal(99, curve.Sample(5));
+            Assert.Equal(99, curve.Sample(120));
+            //If the x value is between xs[i] and xs[i+1], return the linear interpolation of ys[i] and ys[i+1]
+            Assert.Equal(47, curve.Sample(50));
+            Assert.Equal(61, curve.Sample(65));
+        }
+
+        [Fact]
+        public void UCurveSamplesTest() {
+            //UCurve.Samples should give the same reault as UCurve.Sample
+            var samples = curve.Samples(5, 24, 5).ToArray();
+            Assert.Equal(110, samples[1]);
+            Assert.Equal(40, samples[5]);
+            Assert.Equal(50, samples[11]);
+            Assert.Equal(140, samples[19]);
+            Assert.Equal(99, samples[0]);
+            Assert.Equal(99, samples[^1]);
+            Assert.Equal(47, samples[9]);
+            Assert.Equal(61, samples[12]);
+        }
+    }
+}


### PR DESCRIPTION
Changes:
- Add a "samples" method that gets a bunch of Ys for a set of continuously ascending Xs at once, which don't call BinarySearch for each sample point. This method should be used when there are many data points in the curve, and the interval between required sample points are small.
- Add a "SetRangeCurveCommand" command that enables editing macros to set the curve in a certain time range. Before this change, editing macros have to set each sample point with "SetCurveCommand". It have to execute many commands to set the curve which is very slow.
- Use delta Y instead of PerpendicularDistance in Curve.Simplify, because X and Y have different units. The unit of X is tick while the unit of Y depends on the definition of the curve expression. They can't be directly compared. Besides, the original implementation of the algorithm is developed for 2d vector graphics instead of sampled signal here.

This will make loading rendered pitch much faster (especially for enunu voicebanks).