### PR TITLE
diffsinger renderer: stricter vocoder-acoustic compatibility check

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -116,7 +116,7 @@ namespace OpenUtau.Core.DiffSinger
                     new DenseTensor<Int64>(word_dur, new int[] { word_dur.Length }, false)
                     .Reshape(new int[] { 1, word_dur.Length })));
             }else{
-                //if predict_dur is true, use phoneme encode mode
+                //if predict_dur is false, use phoneme encode mode
                 linguisticInputs.Add(NamedOnnxValue.CreateFromTensor("ph_dur",
                     new DenseTensor<Int64>(ph_dur.Select(x=>(Int64)x).ToArray(), new int[] { ph_dur.Length }, false)
                     .Reshape(new int[] { 1, ph_dur.Length })));

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -132,6 +132,14 @@ namespace OpenUtau.Core.DiffSinger {
             }
 
             var vocoder = singer.getVocoder();
+            //Vocoder and singer should have the same hop sizes and sample rates.
+            if(vocoder.hop_size != singer.dsConfig.hop_size){
+                throw new Exception($"Vocoder's hop size is {vocoder.hop_size}, but acoustic's hop size is {singer.dsConfig.hop_size}.");
+            }
+            if(vocoder.sample_rate != singer.dsConfig.sample_rate){
+                throw new Exception($"Vocoder's sample rate is {vocoder.sample_rate}, but acoustic's sample rate is {singer.dsConfig.sample_rate}.");
+            }
+
             var acousticModel = singer.getAcousticSession();
             var frameMs = vocoder.frameMs();
             var frameSec = frameMs / 1000;
@@ -242,7 +250,8 @@ namespace OpenUtau.Core.DiffSinger {
                     } else{
                         userEnergy = Enumerable.Repeat(0d, totalFrames);
                     }
-                    var energy = varianceResult.energy.Zip(userEnergy, (x,y)=>(float)Math.Min(x + y*12/100, 0)).ToArray();
+                    var predictedEnergy = DiffSingerUtils.ResampleCurve(varianceResult.energy, totalFrames);
+                    var energy = predictedEnergy.Zip(userEnergy, (x,y)=>(float)Math.Min(x + y*12/100, 0)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("energy", 
                         new DenseTensor<float>(energy, new int[] { energy.Length })
                         .Reshape(new int[] { 1, energy.Length })));
@@ -251,7 +260,8 @@ namespace OpenUtau.Core.DiffSinger {
                     var userBreathiness = DiffSingerUtils.SampleCurve(phrase, phrase.breathiness,
                         0, frameMs, totalFrames, headFrames, tailFrames,
                         x => x);
-                    var breathiness = varianceResult.breathiness.Zip(userBreathiness, (x,y)=>(float)Math.Min(x + y*12/100, 0)).ToArray();
+                    var predictedBreathiness = DiffSingerUtils.ResampleCurve(varianceResult.breathiness, totalFrames);
+                    var breathiness = predictedBreathiness.Zip(userBreathiness, (x,y)=>(float)Math.Min(x + y*12/100, 0)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("breathiness", 
                         new DenseTensor<float>(breathiness, new int[] { breathiness.Length })
                         .Reshape(new int[] { 1, breathiness.Length })));
@@ -271,14 +281,20 @@ namespace OpenUtau.Core.DiffSinger {
             var vocoderInputs = new List<NamedOnnxValue>();
             vocoderInputs.Add(NamedOnnxValue.CreateFromTensor("mel", mel));
             vocoderInputs.Add(NamedOnnxValue.CreateFromTensor("f0",f0tensor));
-            float[] samples;
+            Tensor<float> samplesTensor;
             lock(vocoder){
                 if(cancellation.IsCancellationRequested) {
                     return null;
                 }
                 var vocoderOutputs = vocoder.session.Run(vocoderInputs);
-                samples = vocoderOutputs.First().AsTensor<float>().ToArray();
+                samplesTensor = vocoderOutputs.First().AsTensor<float>();
             }
+            //Check the size of samplesTensor
+            int[] expectedShape = new int[] { 1, -1 };
+            if(!DiffSingerUtils.ValidateShape(samplesTensor, expectedShape)){
+                throw new Exception($"The shape of vocoder output should be (1, length), but the actual shape is {DiffSingerUtils.ShapeString(samplesTensor)}");
+            }
+            var samples = samplesTensor.ToArray();
             return samples;
         }
 

--- a/OpenUtau.Core/DiffSinger/DiffSingerUtils.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.ML.OnnxRuntime.Tensors;
 using OpenUtau.Core.Render;
 
 namespace OpenUtau.Core.DiffSinger {
@@ -30,6 +31,69 @@ namespace OpenUtau.Core.DiffSinger {
             Array.Fill(result, convert(curve[0]), 0, headFrames);
             Array.Fill(result, convert(curve[^1]), length - tailFrames, tailFrames);
             return result;
+        }
+
+
+        //MusicMath.Linear, but float numbers are used instead of double
+        public static float LinearF(float x0, float x1, float y0, float y1, float x) {
+            const float ep = 0.001f;
+            if(x1 - x0 < ep){
+                return y1;
+            }
+            return y0 + (y1 - y0) * (x - x0) / (x1 - x0);
+        }
+
+        /// <summary>
+        /// Resample a curve to a new length.
+        /// Used when the hopsize of the variance model is different from the hopsize of the acoustic model.
+        /// </summary>
+        /// <param name="curve">The curve to resample.</param>
+        /// <param name="length">The new length of the curve.</param>
+        public static float[] ResampleCurve(float[] curve, int length) {
+            if (curve == null || curve.Length == 0) {
+                return null;
+            }
+            if(length == curve.Length){
+                return curve;
+            }
+            if(length == 1){
+                return new float[]{curve[0]};
+            }
+            float[] result = new float[length];
+            for (int i = 0; i < length; i++) {
+                var x = (float)i / (length - 1) * (curve.Length - 1);
+                int x0 = (int)x;
+                int x1 = Math.Min(x0 + 1, curve.Length - 1);
+                float y0 = curve[x0];
+                float y1 = curve[x1];
+                result[i] = LinearF(x0, x1, y0, y1, x);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Validate the shape of a tensor.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="tensor">Tensor to be validated</param>
+        /// <param name="expectedShape">Expected shape of the tensor, -1 means the length of the axis is dynamic</param>
+        /// <returns></returns>
+        public static bool ValidateShape<T>(Tensor<T> tensor, int[] expectedShape){
+            var shape = tensor.Dimensions;
+            if(shape.Length != expectedShape.Length){
+                return false;
+            }
+            for (int i = 0; i < shape.Length; i++) {
+                if(shape[i] != expectedShape[i] && expectedShape[i] != -1){
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public static string ShapeString<T>(Tensor<T> tensor){
+            var shape = tensor.Dimensions;
+            return "(" + string.Join(", ", shape.ToArray()) + ")";
         }
     }
 }

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -110,7 +110,7 @@ namespace OpenUtau.Core.DiffSinger{
                     new DenseTensor<Int64>(word_dur, new int[] { word_dur.Length }, false)
                     .Reshape(new int[] { 1, word_dur.Length })));
             }else{
-                //if predict_dur is true, use phoneme encode mode
+                //if predict_dur is false, use phoneme encode mode
                 linguisticInputs.Add(NamedOnnxValue.CreateFromTensor("ph_dur",
                     new DenseTensor<Int64>(ph_dur.Select(x=>(Int64)x).ToArray(), new int[] { ph_dur.Length }, false)
                     .Reshape(new int[] { 1, ph_dur.Length })));

--- a/OpenUtau.Core/DiffSinger/DiffSingerVocoder.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVocoder.cs
@@ -8,6 +8,10 @@ namespace OpenUtau.Core.DiffSinger {
         public DsVocoderConfig config;
         public InferenceSession session;
 
+        public int num_mel_bins => config.num_mel_bins;
+        public int hop_size => config.hop_size;
+        public int sample_rate => config.sample_rate;
+
         //Get vocoder by package name
         public DsVocoder(string name) {
             byte[] model;


### PR DESCRIPTION
- Vocoder's hop size and sample rate should be equal to that of the acoustic model. If they aren't the same, openutau will show an error dialog.
  - Hop size is 512 by default. Sample rate is 44100 by default. If you trained a model with a different hop size or sample rate, you should specify in dsconfig.yaml
- Variance model can have a different hop size and sample rate than acoustic model. If they're different, openutau will resample the variance curves.
- The shape of vocoder output should be (1, length). If it isn't, openutau will show an error dialog.