### PR TITLE
fix not loading vogen voicebanks if "load all depth folders" is turned off

### DIFF
--- a/OpenUtau.Core/Vogen/VogenSingerLoader.cs
+++ b/OpenUtau.Core/Vogen/VogenSingerLoader.cs
@@ -51,8 +51,7 @@ namespace OpenUtau.Core.Vogen {
                 files = Directory.EnumerateFiles(basePath, "*.vogeon", SearchOption.AllDirectories);
             } else {
                 // TopDirectoryOnly
-                files = Directory.GetDirectories(basePath)
-                    .SelectMany(path => Directory.EnumerateFiles(path, "*.vogeon"));
+                files = Directory.EnumerateFiles(basePath, "*.vogeon");
             }
             result.AddRange(files
                 .Select(filePath => {


### PR DESCRIPTION
Before this change, if "load all depth folders" is turned off, vogen voicebanks won't show up because openutau try to load them in subfolders of `Singers` folder instead of `Singers` folder where vogen voicebanks install to. This bug is fixed in this PR

---

Note for developers: unlike utau, nnsvs and diffsinger voicebanks that are folders with character.txt and character.yaml, vogen voicebanks are .vogeon files just inside "Singers" folder in your openutau data path.