### PR TITLE
Add toggle for defaulting to pen plus too

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -132,6 +132,7 @@ namespace OpenUtau.Core.Util {
             public bool ShowPrefs = true;
             public bool ShowTips = true;
             public int Theme;
+            public bool PenPlusDefault = false;
             public int DegreeStyle;
             public bool UseTrackColor = false;
             public bool ClearCacheOnQuit = false;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -345,6 +345,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.paths.loaddeepfolders">Load all depth folders</system:String>
   <system:String x:Key="prefs.paths.reset">Reset</system:String>
   <system:String x:Key="prefs.paths.select">Select</system:String>
+  <system:String x:Key="prefs.penplus">Set Pen Plus Tool as Default</system:String>
   <system:String x:Key="prefs.playback">Playback</system:String>
   <system:String x:Key="prefs.playback.autoscroll">Auto-Scroll</system:String>
   <system:String x:Key="prefs.playback.autoscrollmode">Auto-Scroll Mode</system:String>

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -194,15 +194,25 @@ namespace OpenUtau.App.ViewModels {
                 });
 
             CursorTool = false;
-            PenTool = true;
-            PenPlusTool = false;
+            if (Preferences.Default.PenPlusDefault) {
+                PenPlusTool = true;
+                PenTool = false;
+            } else {
+                PenTool = true;
+                PenPlusTool = false;
+            }
             EraserTool = false;
             DrawPitchTool = false;
             KnifeTool = false;
             SelectToolCommand = ReactiveCommand.Create<string>(index => {
                 CursorTool = index == "1";
-                PenTool = index == "2";
-                PenPlusTool = index == "2+";
+                if (Preferences.Default.PenPlusDefault) {
+                    PenPlusTool = index == "2";
+                    PenTool = index == "2+";
+                } else {
+                    PenTool = index == "2";
+                    PenPlusTool = index == "2+";
+                }
                 EraserTool = index == "3";
                 DrawPitchTool = index == "4";
                 KnifeTool = index == "5";

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -44,6 +44,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int DiffsingerSpeedup { get; set; }
         [Reactive] public bool HighThreads { get; set; }
         [Reactive] public int Theme { get; set; }
+        [Reactive] public bool PenPlusDefault { get; set; }
         [Reactive] public int DegreeStyle { get; set; }
         [Reactive] public bool UseTrackColor { get; set; }
         [Reactive] public bool ShowPortrait { get; set; }
@@ -141,6 +142,7 @@ namespace OpenUtau.App.ViewModels {
             DiffSingerDepth = Preferences.Default.DiffSingerDepth;
             DiffsingerSpeedup = Preferences.Default.DiffsingerSpeedup;
             Theme = Preferences.Default.Theme;
+            PenPlusDefault = Preferences.Default.PenPlusDefault;
             DegreeStyle = Preferences.Default.DegreeStyle;
             UseTrackColor = Preferences.Default.UseTrackColor;
             ShowPortrait = Preferences.Default.ShowPortrait;
@@ -201,6 +203,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.PreRender)
                 .Subscribe(preRender => {
                     Preferences.Default.PreRender = preRender;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.PenPlusDefault)
+                .Subscribe(penPlusDefault => {
+                    Preferences.Default.PenPlusDefault = penPlusDefault;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.Language)

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -228,6 +228,10 @@
               <TextBlock Text="{DynamicResource prefs.advanced.lyricshelper.brackets}" HorizontalAlignment="Left"/>
               <ToggleSwitch IsChecked="{Binding LyricsHelperBrackets}"/>
             </Grid>
+            <Grid>
+              <TextBlock Text="{DynamicResource prefs.penplus}" HorizontalAlignment="Left"/>
+              <ToggleSwitch IsChecked="{Binding PenPlusDefault}"/>
+            </Grid>
             <TextBlock Text="{DynamicResource prefs.advanced.rememberfiletypes}" Margin="0,5,0,0"/>
             <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="25,25,25" VerticalAlignment="Center" Margin="4">
               <CheckBox IsChecked="{Binding RememberMid}" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"/>


### PR DESCRIPTION
This PR adds a toggle for the pen plus tool to be the default tool when OpenUtau is first loaded, and when pressing 2 instead of CTRL+2