### PR TITLE
Open voicebank icon file read-only

### DIFF
--- a/OpenUtau.Core/Classic/ClassicSinger.cs
+++ b/OpenUtau.Core/Classic/ClassicSinger.cs
@@ -77,7 +77,7 @@ namespace OpenUtau.Classic {
         void Load() {
             if (Avatar != null && File.Exists(Avatar)) {
                 try {
-                    using (var stream = new FileStream(Avatar, FileMode.Open)) {
+                    using (var stream = new FileStream(Avatar, FileMode.Open, FileAccess.Read)) {
                         using (var memoryStream = new MemoryStream()) {
                             stream.CopyTo(memoryStream);
                             avatarData = memoryStream.ToArray();

--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -55,7 +55,7 @@ namespace OpenUtau.Core.DiffSinger {
             //Load Avatar
             if (Avatar != null && File.Exists(Avatar)) {
                 try {
-                    using (var stream = new FileStream(Avatar, FileMode.Open)) {
+                    using (var stream = new FileStream(Avatar, FileMode.Open, FileAccess.Read)) {
                         using (var memoryStream = new MemoryStream()) {
                             stream.CopyTo(memoryStream);
                             avatarData = memoryStream.ToArray();

--- a/OpenUtau.Core/Enunu/EnunuSinger.cs
+++ b/OpenUtau.Core/Enunu/EnunuSinger.cs
@@ -151,7 +151,7 @@ namespace OpenUtau.Core.Enunu {
 
             if (Avatar != null && File.Exists(Avatar)) {
                 try {
-                    using (var stream = new FileStream(Avatar, FileMode.Open)) {
+                    using (var stream = new FileStream(Avatar, FileMode.Open, FileAccess.Read)) {
                         using (var memoryStream = new MemoryStream()) {
                             stream.CopyTo(memoryStream);
                             avatarData = memoryStream.ToArray();

--- a/OpenUtau.Core/Format/OpusOggWaveReader.cs
+++ b/OpenUtau.Core/Format/OpusOggWaveReader.cs
@@ -14,7 +14,7 @@ namespace OpenUtau.Core.Format {
         byte[] wavData;
 
         public OpusOggWaveReader(string oggFile) {
-            using (FileStream fileStream = new FileStream(oggFile, FileMode.Open)) {
+            using (FileStream fileStream = new FileStream(oggFile, FileMode.Open, FileAccess.Read)) {
                 oggStream = new MemoryStream();
                 fileStream.CopyTo(oggStream);
             }


### PR DESCRIPTION
Open voicebank icon file read-only.

Fix an "[ERR] Failed to load avatar data" issue if current user can not open the file for writing.