### PR TITLE
Fix keyboard input: fix focus onMenuClose and fix some key bindings

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -9,6 +9,7 @@
         Icon="/Assets/open-utau.ico"
         Title="{Binding Title}" MinWidth="300" MinHeight="200"
         KeyDown="OnKeyDown" PointerPressed="OnPointerPressed" Closing="WindowClosing"
+        Focusable="True"
         TransparencyLevelHint="None"
         ExtendClientAreaToDecorationsHint="{Binding ExtendToFrame}">
   <Window.Styles>

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -9,6 +9,7 @@
         x:Class="OpenUtau.App.Views.PianoRollWindow"
         Icon="/Assets/open-utau.ico"
         Title="{Binding NotesViewModel.WindowTitle}" MinWidth="300" MinHeight="200" KeyDown="OnKeyDown" Closing="WindowClosing"
+        Focusable="True"
         TransparencyLevelHint="None"
         ExtendClientAreaToDecorationsHint="{Binding ExtendToFrame}" Deactivated="WindowDeactivated">
   <Window.Styles>

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1321,7 +1321,7 @@ namespace OpenUtau.App.Views {
                     }
                     // to view end
                     if (isShift) {
-                        playVm.MovePlayPos(notesVm.Part.position + (int)(notesVm.TickOffset));
+                        playVm.MovePlayPos(notesVm.Part.position + (int)(notesVm.TickOffset + notesVm.Bounds.Width / notesVm.TickWidth));
                         return true;
                     }
                     break;
@@ -1349,7 +1349,7 @@ namespace OpenUtau.App.Views {
                     }
                     // select none
                     if (isCtrl) {
-                        notesVm.SelectAllNotes();
+                        notesVm.DeselectNotes();
                         return true;
                     }
                     break;


### PR DESCRIPTION
Fix some keyboard input issues:

1. Fix some key bindings that do not match the comments:
`Ctrl+D`
`Shift+]`

2. Try to fix a focus issue when the user leave the Menu but the focus could still be on the MenuItem, making Home/End and other navigation keys do not work as expected (they still navigate in the menu region and can not move the playback or note position).

This issue could happen if the menu is closed when the mouse pointer is on the tool bar or if the user use Alt/Esc keys to navigate the menu.

I'm not sure whether not not it is a correct way to fix this by explicitly setting the main window focusable.