### PR TITLE
Add "no value" to expression

### DIFF
--- a/OpenUtau.Core/Commands/ExpCommands.cs
+++ b/OpenUtau.Core/Commands/ExpCommands.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
 
@@ -24,15 +23,15 @@ namespace OpenUtau.Core {
     public class SetNoteExpressionCommand : ExpCommand {
         public readonly UProject project;
         public readonly UTrack track;
-        public readonly float[] newValue;
-        public readonly float[] oldValue;
-        public SetNoteExpressionCommand(UProject project, UTrack track, UVoicePart part, UNote note, string abbr, float[] values) : base(part) {
+        public readonly float?[] newValue;
+        public readonly float?[] oldValue;
+        public SetNoteExpressionCommand(UProject project, UTrack track, UVoicePart part, UNote note, string abbr, float?[] values) : base(part) {
             this.project = project;
             this.track = track;
             this.Note = note;
             Key = abbr;
             newValue = values;
-            oldValue = note.GetExpression(project, track, abbr).Select(t => t.Item1).ToArray();
+            oldValue = note.GetExpressionNoteHas(project, track, abbr);
         }
         public override string ToString() => $"Set note expression {Key}";
         public override void Execute() => Note.SetExpression(project, track, Key, newValue);
@@ -47,21 +46,26 @@ namespace OpenUtau.Core {
         public readonly UProject project;
         public readonly UTrack track;
         public readonly UPhoneme phoneme;
-        public readonly float newValue;
-        public readonly float oldValue;
+        public readonly float? newValue;
+        public readonly float? oldValue;
         public override ValidateOptions ValidateOptions
             => new ValidateOptions {
                 SkipTiming = true,
                 Part = Part,
                 SkipPhonemizer = !needsPhonemizer.Contains(Key),
             };
-        public SetPhonemeExpressionCommand(UProject project, UTrack track, UVoicePart part, UPhoneme phoneme, string abbr, float value) : base(part) {
+        public SetPhonemeExpressionCommand(UProject project, UTrack track, UVoicePart part, UPhoneme phoneme, string abbr, float? value) : base(part) {
             this.project = project;
             this.track = track;
             this.phoneme = phoneme;
             Key = abbr;
             newValue = value;
-            oldValue = phoneme.GetExpression(project, track, abbr).Item1;
+            var oldExp = phoneme.GetExpression(project, track, abbr);
+            if (oldExp.Item2) {
+                oldValue = oldExp.Item1;
+            } else {
+                oldValue = null;
+            }
         }
         public override string ToString() => $"Set phoneme expression {Key}";
         public override void Execute() {

--- a/OpenUtau.Core/Editing/LyricBatchEdits.cs
+++ b/OpenUtau.Core/Editing/LyricBatchEdits.cs
@@ -138,7 +138,7 @@ namespace OpenUtau.Core.Editing {
                         docManager.ExecuteCmd(new ChangeNoteLyricCommand(part, note, lyric));
 
                         int index = colors.FirstOrDefault(c => c.Value == suffix).Key;
-                        docManager.ExecuteCmd(new SetNoteExpressionCommand(project, track, part, note, Format.Ustx.CLR, new float[] { index }));
+                        docManager.ExecuteCmd(new SetNoteExpressionCommand(project, track, part, note, Format.Ustx.CLR, new float?[] { index }));
                         break;
                     }
                 }

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -23,7 +23,7 @@ namespace OpenUtau.Core.Editing {
                 if (note.lyric != lyric && (note.Next == null || note.Next.position > note.End + 120)) {
                     var addNote = project.CreateNote(note.tone, note.End, 120);
                     foreach(var exp in note.phonemeExpressions.OrderBy(exp => exp.index)) {
-                        addNote.SetExpression(project, project.tracks[part.trackNo], exp.abbr, new float[] { exp.value });
+                        addNote.SetExpression(project, project.tracks[part.trackNo], exp.abbr, new float?[] { exp.value });
                     }
                     toAdd.Add(addNote);
                 }
@@ -99,7 +99,7 @@ namespace OpenUtau.Core.Editing {
                     }
                     var addNote = project.CreateNote(note.tone, note.position - duration, duration);
                     foreach (var exp in note.phonemeExpressions.Where(exp => exp.index == 0)) {
-                        addNote.SetExpression(project, project.tracks[part.trackNo], exp.abbr, new float[] { exp.value });
+                        addNote.SetExpression(project, project.tracks[part.trackNo], exp.abbr, new float?[] { exp.value });
                     }
                     toAdd.Add(addNote);
                 }

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -35,6 +35,7 @@ namespace OpenUtau.Core.Ustx {
         [YamlIgnore] public int RightBound => position + duration;
         [YamlIgnore] public bool Error { get; set; } = false;
         [YamlIgnore] public bool OverlapError { get; set; } = false;
+        [YamlIgnore] public List<UExpression> phonemizerExpressions = new List<UExpression>();
 
         public static UNote Create() {
             var note = new UNote();
@@ -165,38 +166,60 @@ namespace OpenUtau.Core.Ustx {
                 if (phonemeExp != null) {
                     list.Add(Tuple.Create(phonemeExp.value, true));
                 } else {
-                    list.Add(Tuple.Create(trackExp.value, false));
+                    var phonemizerExp = phonemizerExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                    if (phonemizerExp != null) {
+                        list.Add(Tuple.Create(phonemizerExp.value, false));
+                    } else {
+                        list.Add(Tuple.Create(trackExp.value, false));
+                    }
                 }
             }
             return list;
         }
 
-        public void SetExpression(UProject project, UTrack track, string abbr, float[] values) {
+        /// <summary>
+        /// Returns value if phoneme has expression, null otherwise.
+        /// </summary>
+        public float?[] GetExpressionNoteHas(UProject project, UTrack track, string abbr) {
+            var list = new List<float?>();
+            int indexes = (phonemeExpressions.Max(exp => exp.index) ?? 0) + 1;
+            for (int i = 0; i < indexes; i++) {
+                var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                if (phonemeExp != null) {
+                    list.Add(phonemeExp.value);
+                } else {
+                    list.Add(null);
+                }
+            }
+            return list.ToArray();
+        }
+
+        public void SetExpression(UProject project, UTrack track, string abbr, float?[] values) {
             if (!track.TryGetExpression(project, abbr, out UExpression trackExp)) {
                 return;
             }
             int indexes = (phonemeExpressions.Max(exp => exp.index) ?? 0) + 1;
 
             for (int i = 0; i < indexes; i++) {
-                float value;
+                float? value;
                 if (values.Length > i) {
                     value = values[i];
                 } else {
                     value = values.Last();
                 }
 
-                if (trackExp.value == value) {
+                if (value == null) {
                     phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == i);
                     continue;
                 }
                 var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
                 if (phonemeExp != null) {
                     phonemeExp.descriptor = trackExp.descriptor;
-                    phonemeExp.value = value;
+                    phonemeExp.value = (float)value;
                 } else {
                     phonemeExpressions.Add(new UExpression(trackExp.descriptor) {
                         index = i,
-                        value = value,
+                        value = (float)value,
                     });
                 }
             }

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -165,20 +165,22 @@ namespace OpenUtau.Core.Ustx {
             envelope.data[4] = p4;
         }
 
-        /**  
-            <summary>
-                If the phoneme does not have the corresponding expression, return the track's expression and false
-            </summary>
-        */
+        /// <summary>
+        /// If the phoneme does not have the corresponding expression, return the track's expression and false
+        /// <summary>
         public Tuple<float, bool> GetExpression(UProject project, UTrack track, string abbr) {
             track.TryGetExpression(project, abbr, out UExpression trackExp);
             var note = Parent.Extends ?? Parent;
-            var phonemeExp = note.phonemeExpressions.FirstOrDefault(
-                exp => exp.descriptor?.abbr == abbr && exp.index == index);
+            var phonemeExp = note.phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == index);
             if (phonemeExp != null) {
                 return Tuple.Create(phonemeExp.value, true);
             } else {
-                return Tuple.Create(trackExp.value, false);
+                var phonemizerExp = note.phonemizerExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == index);
+                if (phonemizerExp != null) {
+                    return Tuple.Create(phonemizerExp.value, false);
+                } else {
+                    return Tuple.Create(trackExp.value, false);
+                }
             }
         }
 
@@ -187,7 +189,7 @@ namespace OpenUtau.Core.Ustx {
                 return;
             }
             var note = Parent.Extends ?? Parent;
-            if (value == null || trackExp.value == value) {
+            if (value == null) {
                 note.phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == index);
             } else {
                 var phonemeExp = note.phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == index);

--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -172,7 +172,9 @@ namespace OpenUtau.App.Controls {
                         double y = optionHeight * (descriptor.options.Length - 1 - i + 0.5);
                         using (var state = context.PushTransform(Matrix.CreateTranslation(x1 + 4.5, y))) {
                             if ((int)value == i) {
-                                context.DrawGeometry(brush, null, pointGeometry);
+                                if (overriden) {
+                                    context.DrawGeometry(brush, null, pointGeometry);
+                                }
                                 context.DrawGeometry(null, hPen, circleGeometry);
                             } else {
                                 context.DrawGeometry(null, ThemeManager.NeutralAccentPenSemi, circleGeometry);

--- a/OpenUtau/Controls/NotePropertyExpression.axaml
+++ b/OpenUtau/Controls/NotePropertyExpression.axaml
@@ -5,7 +5,7 @@
              xmlns:vm="using:OpenUtau.App.ViewModels"
              x:Class="OpenUtau.App.Controls.NotePropertyExpression">
   <Grid ColumnDefinitions="143,7,50,20,*">
-    <Label Content="{Binding Name}" Grid.Column="0" VerticalAlignment="Center"/>
+    <Label Content="{Binding Name}" Grid.Column="0" VerticalAlignment="Center" FontWeight="{Binding NameFontWeight}"/>
     <TextBox Text="{Binding Value, Mode=OneWay}" Grid.Column="2" IsVisible="{Binding IsNumerical}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"
              GotFocus="OnTextBoxGotFocus" LostFocus="OnTextBoxLostFocus"/>
     <Slider Grid.Column="4" Classes="fader" Value="{Binding Value, Mode=OneWay}" Minimum="{Binding Min}" Maximum="{Binding Max}"

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -868,7 +868,7 @@ namespace OpenUtau.App.ViewModels {
                                     break;
                                 default:
                                     if (vm.Params[i].IsSelected) {
-                                        float[] values = copyNote.GetExpression(Project, track, vm.Params[i].Abbr).Select(t => t.Item1).ToArray();
+                                        float?[] values = copyNote.GetExpressionNoteHas(Project, track, vm.Params[i].Abbr);
                                         DocManager.Inst.ExecuteCmd(new SetNoteExpressionCommand(Project, track, Part, note, vm.Params[i].Abbr, values));
                                     }
                                     break;

--- a/OpenUtau/Views/NoteEditStates.cs
+++ b/OpenUtau/Views/NoteEditStates.cs
@@ -8,8 +8,8 @@ using Avalonia.Input;
 using OpenUtau.App.Controls;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
-using OpenUtau.Core.Util;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 
 namespace OpenUtau.App.Views {
     class KeyboardPlayState {
@@ -761,12 +761,11 @@ namespace OpenUtau.App.Views {
                 if (notesVm.Selection.Count > 0 && !notesVm.Selection.Contains(hit.phoneme.Parent)) {
                     continue;
                 }
-                float value = hit.phoneme.GetExpression(notesVm.Project, track, key).Item1;
-                if (value == descriptor.defaultValue) {
+                if (!hit.phoneme.GetExpression(notesVm.Project, track, key).Item2) {
                     continue;
                 }
                 DocManager.Inst.ExecuteCmd(new SetPhonemeExpressionCommand(
-                    notesVm.Project, track, notesVm.Part, hit.phoneme, key, descriptor.defaultValue));
+                    notesVm.Project, track, notesVm.Part, hit.phoneme, key, null));
             }
         }
         private void ResetCurveExp(IPointer pointer, Point point) {


### PR DESCRIPTION
In implementing track expression and phonemizer expression in the future, we need to clearly distinguish whether a phoneme has a value or not.

### Changes:
- To distinguish between "set value to 100" and "no value (default value of 100)", SetNote/PhonemeExpressionCommand will accept null as well as float.
- In the expression panel and properties panel, the presence or absence of a value can be visually determined.
![image](https://github.com/stakira/OpenUtau/assets/130257355/5f283bd3-7bef-423d-96dc-98ec3fcaf7bd)
- Implement logic for "phonemizerExpressions".

### What I want to implement in the future:
The ability for the phonemizer to recommend an expression(voicecolor, P flag, etc.) and for the user to override it.
https://github.com/stakira/OpenUtau/assets/130257355/85e0e071-bc48-4417-9661-0827158eb5e7
(prototype)
