### PR TITLE
fix bugged piano roll when first opened while the project is playing

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -92,7 +92,7 @@ namespace OpenUtau.App.ViewModels {
         public ReactiveCommand<int, Unit> SetKeyCommand { get; set; }
 
         // See the comments on TracksViewModel.playPosXToTickOffset
-        private double playPosXToTickOffset => ViewportTicks / Bounds.Width;
+        private double playPosXToTickOffset => Bounds.Width != 0 ? ViewportTicks / Bounds.Width : 0;
 
         private readonly ObservableAsPropertyHelper<double> viewportTicks;
         private readonly ObservableAsPropertyHelper<double> viewportTracks;

--- a/OpenUtau/ViewModels/TracksViewModel.cs
+++ b/OpenUtau/ViewModels/TracksViewModel.cs
@@ -85,7 +85,7 @@ namespace OpenUtau.App.ViewModels {
         // kinds of values.
         //
         // These values could be better named so as to make the code more readable.
-        private double playPosXToTickOffset => ViewportTicks / Bounds.Width;
+        private double playPosXToTickOffset => Bounds.Width != 0 ? ViewportTicks / Bounds.Width : 0;
 
         private readonly ObservableAsPropertyHelper<double> viewportTicks;
         private readonly ObservableAsPropertyHelper<double> viewportTracks;


### PR DESCRIPTION
adds a check to stop `playPosXToTickOffset` from becoming `NaN`

fixes a visual bug with the piano roll when first opened while the project is playing due to `NaN` propagating to `TickOffset`

![image](https://github.com/stakira/OpenUtau/assets/45115987/ce75d46d-c1e0-4bf7-93c7-aff830ca7424)


