### PR TITLE
Add phonemizer expression

### DIFF
--- a/OpenUtau.Core/Api/Phonemizer.cs
+++ b/OpenUtau.Core/Api/Phonemizer.cs
@@ -97,10 +97,21 @@ namespace OpenUtau.Api {
             public string voiceColor;
         }
 
+        public struct PhonemeExpression {
+            public string abbr;
+            public float value;
+        }
+
         /// <summary>
         /// The output struct that represents a phoneme.
         /// </summary>
         public struct Phoneme {
+            /// <summary>
+            /// Number to manage phonemes in note.
+            /// Optional. Whether to specify an index or not should be consistent within Phonemizer (All phonemes should be indexed, or all should be unindexed).
+            /// </summary>
+            public int? index;
+
             /// <summary>
             /// Phoneme name. Should match one of oto alias.
             /// Note that you don't have to return tone-mapped phonemes. OpenUtau will do it afterwards.
@@ -111,16 +122,14 @@ namespace OpenUtau.Api {
 
             /// <summary>
             /// Position of phoneme in note. Measured in ticks.
-            /// Use TickToMs() and MsToTick() to convert between ticks and milliseconds .
+            /// Use TickToMs() and MsToTick() to convert between ticks and milliseconds.
             /// </summary>
             public int position;
 
             /// <summary>
             /// Suggested attributes. May or may not be used eventually.
             /// </summary>
-            public PhonemeAttributes attributes;
-
-            public int? index;
+            public List<PhonemeExpression> expressions;
 
             public override string ToString() => $"\"{phoneme}\" pos:{position}";
         }
@@ -161,7 +170,7 @@ namespace OpenUtau.Api {
         /// </summary>
         public virtual bool LegacyMapping => false;
 
-        public virtual void SetUp(Note[][] notes) { }
+        public virtual void SetUp(Note[][] notes, UProject project, UTrack track) { }
 
         /// <summary>
         /// Phonemize a consecutive sequence of notes. This is the main logic of a phonemizer.

--- a/OpenUtau.Core/Api/Phonemizer.cs
+++ b/OpenUtau.Core/Api/Phonemizer.cs
@@ -127,7 +127,7 @@ namespace OpenUtau.Api {
             public int position;
 
             /// <summary>
-            /// Suggested attributes. May or may not be used eventually.
+            /// Suggested attributes. It may later be overwritten with a user-specified value.
             /// </summary>
             public List<PhonemeExpression> expressions;
 

--- a/OpenUtau.Core/Api/PhonemizerRunner.cs
+++ b/OpenUtau.Core/Api/PhonemizerRunner.cs
@@ -99,7 +99,7 @@ namespace OpenUtau.Api {
             phonemizer.SetSinger(request.singer);
             phonemizer.SetTiming(request.timeAxis);
             try {
-                phonemizer.SetUp(notes);
+                phonemizer.SetUp(notes, DocManager.Inst.Project, DocManager.Inst.Project.tracks[request.part.trackNo]);
             } catch (Exception e) {
                 Log.Error(e, $"phonemizer failed to setup.");
             }

--- a/OpenUtau.Core/BaseChinesePhonemizer.cs
+++ b/OpenUtau.Core/BaseChinesePhonemizer.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using OpenUtau.Core.G2p;
 using OpenUtau.Api;
+using OpenUtau.Core.G2p;
+using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core {
     public abstract class BaseChinesePhonemizer : Phonemizer {
@@ -43,7 +43,7 @@ namespace OpenUtau.Core {
             Enumerable.Zip(groups, ResultLyrics, ChangeLyric).Last();
         }
 
-        public override void SetUp(Note[][] groups) {
+        public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             RomanizeNotes(groups);
         }
     }

--- a/OpenUtau.Core/Enunu/EnunuKoreanPhonemizer.cs
+++ b/OpenUtau.Core/Enunu/EnunuKoreanPhonemizer.cs
@@ -394,7 +394,7 @@ namespace OpenUtau.Core.Enunu {
             
         Dictionary<Note[], Phoneme[]> partResult = new Dictionary<Note[], Phoneme[]>();
 
-        public override void SetUp(Note[][] notes) {
+        public override void SetUp(Note[][] notes, UProject project, UTrack track) {
             partResult.Clear();
             if (notes.Length == 0 || singer == null || !singer.Found) {
                 return;

--- a/OpenUtau.Core/Enunu/EnunuPhonemizer.cs
+++ b/OpenUtau.Core/Enunu/EnunuPhonemizer.cs
@@ -29,7 +29,7 @@ namespace OpenUtau.Core.Enunu {
             this.singer = singer as EnunuSinger;
         }
 
-        public override void SetUp(Note[][] notes) {
+        public override void SetUp(Note[][] notes, UProject project, UTrack track) {
             partResult.Clear();
             if (notes.Length == 0 || singer == null || !singer.Found) {
                 return;

--- a/OpenUtau.Core/MachineLearningPhonemizer.cs
+++ b/OpenUtau.Core/MachineLearningPhonemizer.cs
@@ -1,10 +1,10 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenUtau.Api;
+using OpenUtau.Core.Ustx;
 
-namespace OpenUtau.Core
-{
+namespace OpenUtau.Core {
     public abstract class MachineLearningPhonemizer : Phonemizer
     {
         //The results of the timing model are stored in partResult
@@ -15,7 +15,7 @@ namespace OpenUtau.Core
         //Called when the note is changed, and the entire song is passed into the SetUp function as long as the note is changed
         //groups is a two-dimensional array of Note, each Note[] represents a lyrical note and its following slur notes
         //Run phoneme timing model in sections to prevent butterfly effect
-        public override void SetUp(Note[][] groups) {
+        public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             if (groups.Length == 0) {
                 return;
             }

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -36,6 +36,7 @@ namespace OpenUtau.Core.Ustx {
         [YamlIgnore] public bool Error { get; set; } = false;
         [YamlIgnore] public bool OverlapError { get; set; } = false;
         [YamlIgnore] public List<UExpression> phonemizerExpressions = new List<UExpression>();
+        [YamlIgnore] public int[] phonemeIndexes { get; set; } = new int[0];
 
         public static UNote Create() {
             var note = new UNote();
@@ -159,18 +160,20 @@ namespace OpenUtau.Core.Ustx {
         public List<Tuple<float, bool>> GetExpression(UProject project, UTrack track, string abbr) {
             track.TryGetExpression(project, abbr, out UExpression trackExp);
             var list = new List<Tuple<float, bool>>();
-            int indexes = (phonemeExpressions.Max(exp => exp.index) ?? 0) + 1;
 
-            for (int i = 0; i < indexes; i++) {
-                var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
-                if (phonemeExp != null) {
-                    list.Add(Tuple.Create(phonemeExp.value, true));
-                } else {
-                    var phonemizerExp = phonemizerExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
-                    if (phonemizerExp != null) {
-                        list.Add(Tuple.Create(phonemizerExp.value, false));
+            if (phonemeIndexes != null && phonemeIndexes.Length > 0) {
+                int indexes = phonemeIndexes.LastOrDefault() + 1;
+                for (int i = 0; i < indexes; i++) {
+                    var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                    if (phonemeExp != null) {
+                        list.Add(Tuple.Create(phonemeExp.value, true));
                     } else {
-                        list.Add(Tuple.Create(trackExp.value, false));
+                        var phonemizerExp = phonemizerExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                        if (phonemizerExp != null) {
+                            list.Add(Tuple.Create(phonemizerExp.value, false));
+                        } else {
+                            list.Add(Tuple.Create(trackExp.value, false));
+                        }
                     }
                 }
             }
@@ -182,13 +185,20 @@ namespace OpenUtau.Core.Ustx {
         /// </summary>
         public float?[] GetExpressionNoteHas(UProject project, UTrack track, string abbr) {
             var list = new List<float?>();
-            int indexes = (phonemeExpressions.Max(exp => exp.index) ?? 0) + 1;
-            for (int i = 0; i < indexes; i++) {
-                var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
-                if (phonemeExp != null) {
-                    list.Add(phonemeExp.value);
-                } else {
-                    list.Add(null);
+
+            if (phonemeIndexes != null && phonemeIndexes.Length > 0) {
+                int indexes = phonemeIndexes.LastOrDefault() + 1;
+                UExpression? phonemeExp = null;
+
+                for (int i = 0; i < indexes; i++) {
+                    if (phonemeIndexes.Contains(i)) {
+                        phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                    }
+                    if (phonemeExp != null) {
+                        list.Add(phonemeExp.value);
+                    } else {
+                        list.Add(null);
+                    }
                 }
             }
             return list.ToArray();
@@ -198,29 +208,34 @@ namespace OpenUtau.Core.Ustx {
             if (!track.TryGetExpression(project, abbr, out UExpression trackExp)) {
                 return;
             }
-            int indexes = (phonemeExpressions.Max(exp => exp.index) ?? 0) + 1;
+            if (values.Length == 0) {
+                return;
+            }
 
+            int indexes = phonemeIndexes.LastOrDefault() + 1;
             for (int i = 0; i < indexes; i++) {
-                float? value;
-                if (values.Length > i) {
-                    value = values[i];
-                } else {
-                    value = values.Last();
-                }
+                if (i == 0 || phonemeIndexes.Contains(i)) {
+                    float? value;
+                    if (values.Length > i) {
+                        value = values[i];
+                    } else {
+                        value = values.Last();
+                    }
 
-                if (value == null) {
-                    phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == i);
-                    continue;
-                }
-                var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
-                if (phonemeExp != null) {
-                    phonemeExp.descriptor = trackExp.descriptor;
-                    phonemeExp.value = (float)value;
-                } else {
-                    phonemeExpressions.Add(new UExpression(trackExp.descriptor) {
-                        index = i,
-                        value = (float)value,
-                    });
+                    if (value == null) {
+                        phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                        continue;
+                    }
+                    var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
+                    if (phonemeExp != null) {
+                        phonemeExp.descriptor = trackExp.descriptor;
+                        phonemeExp.value = (float)value;
+                    } else {
+                        phonemeExpressions.Add(new UExpression(trackExp.descriptor) {
+                            index = i,
+                            value = (float)value,
+                        });
+                    }
                 }
             }
         }
@@ -235,6 +250,7 @@ namespace OpenUtau.Core.Ustx {
                 vibrato = vibrato.Clone(),
                 phonemeExpressions = phonemeExpressions.Select(exp => exp.Clone()).ToList(),
                 phonemeOverrides = phonemeOverrides.Select(o => o.Clone()).ToList(),
+                phonemeIndexes = (int[])phonemeIndexes.Clone()
             };
         }
     }

--- a/OpenUtau.Core/Ustx/UPart.cs
+++ b/OpenUtau.Core/Ustx/UPart.cs
@@ -145,13 +145,16 @@ namespace OpenUtau.Core.Ustx {
                         notes.ForEach(note => note.phonemizerExpressions.Clear());
 
                         for (int i = 0; i < resp.phonemes.Length; ++i) {
+                            var indexes = new List<int>();
+                            var note = notes.ElementAtOrDefault(resp.noteIndexes[i]);
                             for (int j = 0; j < resp.phonemes[i].Length; ++j) {
                                 var phoneme = new UPhoneme() {
                                     rawPosition = resp.phonemes[i][j].position - position,
                                     rawPhoneme = resp.phonemes[i][j].phoneme,
                                     index = resp.phonemes[i][j].index ?? j,
-                                    Parent = notes.ElementAtOrDefault(resp.noteIndexes[i]),
+                                    Parent = note
                                 };
+                                // Check for duplicate indexes
                                 if (phonemes.Any(p => p.Parent == phoneme.Parent && p.index == phoneme.index)) {
                                     try {
                                         throw new ArgumentException("Duplicate phoneme index.");
@@ -161,11 +164,12 @@ namespace OpenUtau.Core.Ustx {
                                     }
                                 }
                                 phonemes.Add(phoneme);
+                                indexes.Add(phoneme.index);
                                 if (resp.phonemes[i][j].expressions != null && resp.phonemes[i][j].expressions.Any()) {
                                     resp.phonemes[i][j].expressions.ForEach(exp => {
                                         if (track.TryGetExpDescriptor(project, exp.abbr, out var descriptor)) {
                                             if (descriptor.type != UExpressionType.Curve && descriptor.min <= exp.value && exp.value <= descriptor.max) {
-                                                phoneme.Parent.phonemizerExpressions.Add(new UExpression(descriptor) {
+                                                note.phonemizerExpressions.Add(new UExpression(descriptor) {
                                                     index = phoneme.index,
                                                     value = exp.value
                                                 });
@@ -174,6 +178,8 @@ namespace OpenUtau.Core.Ustx {
                                     });
                                 }
                             }
+                            indexes.Sort();
+                            note.phonemeIndexes = indexes.ToArray();
                         }
                         phonemesTimestamp = resp.timestamp;
                     }

--- a/OpenUtau.Core/Vogen/VogenBasePhonemizer.cs
+++ b/OpenUtau.Core/Vogen/VogenBasePhonemizer.cs
@@ -37,7 +37,7 @@ namespace OpenUtau.Core.Vogen {
                 duration = group[^1].position + group[^1].duration - group[0].position
             });
         }
-        public override void SetUp(Note[][] groups) {
+        public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             if (groups.Length == 0) {
                 return;
             }

--- a/OpenUtau.Plugin.Builtin/CantoneseSyoPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/CantoneseSyoPhonemizer.cs
@@ -70,7 +70,7 @@ namespace OpenUtau.Plugin.Builtin {
         /// Converts hanzi notes to jyutping phonemes.
         /// </summary>
         /// <param name="groups"></param>
-        public override void SetUp(Note[][] groups) {
+        public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             JyutpingConversion.RomanizeNotes(groups);
         }
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {

--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -244,7 +244,7 @@ namespace OpenUtau.Plugin.Builtin {
             Enumerable.Zip(groups, ResultLyrics, ChangeLyric).Last();
         }
 
-        public override void SetUp(Note[][] groups) {
+        public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             RomanizeNotes(groups);
         }
     }

--- a/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVPhonemizer.cs
@@ -1,13 +1,13 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenUtau.Api;
 using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
 using Serilog;
 
-namespace OpenUtau.Plugin.Builtin
-{
+namespace OpenUtau.Plugin.Builtin {
     /// <summary>
     /// Chinese 十月式整音扩张 CVV Phonemizer.
     /// <para>It works by spliting "duang" to "duang" + "_ang", to produce the proper tail sound.</para>
@@ -55,7 +55,7 @@ namespace OpenUtau.Plugin.Builtin
                 .ToDictionary(parts => parts[0], parts => parts[1].Split(','));
         }
 
-        public override void SetUp(Note[][] groups) {
+        public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             BaseChinesePhonemizer.RomanizeNotes(groups);
         }
     }

--- a/OpenUtau.Plugin.Builtin/EnunuOnnx/EnunuOnnxPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnunuOnnx/EnunuOnnxPhonemizer.cs
@@ -4,15 +4,15 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using OpenUtau.Core.Ustx;
-using OpenUtau.Api;
-using OpenUtau.Plugin.Builtin.EnunuOnnx.nnmnkwii.io.hts;
 using Microsoft.ML.OnnxRuntime;
-using OpenUtau.Plugin.Builtin.EnunuOnnx.nnmnkwii.frontend;
 using Microsoft.ML.OnnxRuntime.Tensors;
-using Serilog;
-using OpenUtau.Plugin.Builtin.EnunuOnnx;
+using OpenUtau.Api;
 using OpenUtau.Core;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Plugin.Builtin.EnunuOnnx;
+using OpenUtau.Plugin.Builtin.EnunuOnnx.nnmnkwii.frontend;
+using OpenUtau.Plugin.Builtin.EnunuOnnx.nnmnkwii.io.hts;
+using Serilog;
 
 //This phonemizer is a pure C# implemention of the ENUNU phonemizer,
 //which aims at providing all ML-based synthesizer developers with a useable phonemizer,
@@ -209,7 +209,7 @@ namespace OpenUtau.Plugin.Builtin {
             pitchIndices = Enumerable.Range(binaryDict.Count, 3).ToArray();
         }
 
-        public override void SetUp(Note[][] groups) {
+        public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             if (groups.Length == 0) {
                 return;
             }

--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -7,7 +7,7 @@ using OpenUtau.Api;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Plugin.Builtin {
-    [Phonemizer("Japanese presamp Phonemizer", "JA VCV & CVVC", "Maiko", language:"JA")]
+    [Phonemizer("Japanese presamp Phonemizer", "JA VCV & CVVC", "Maiko", language: "JA")]
     public class JapanesePresampPhonemizer : Phonemizer {
 
         // CV, VCV, CVVCを含むすべての日本語VBをサポートする予定です。Will support all Japanese VBs including CV, VCV, CVVC
@@ -16,6 +16,11 @@ namespace OpenUtau.Plugin.Builtin {
         // 喉切り"・"はpresamp.iniに書いてなくても動くようなんとかします。I'll try to make it work even if "・" are not written in presamp.ini
         // Supporting: [VOWEL][CONSONANT][PRIORITY][REPLACE][ALIAS(VCPAD,VCVPAD)]
         // Partial supporting: [NUM][APPEND][PITCH] -> Using to exclude useless characters in lyrics
+
+        private USinger singer;
+        private Presamp presamp;
+        private UProject project;
+        private UTrack track;
 
         // in case voicebank is missing certain symbols
         static readonly string[] substitution = new string[] {
@@ -33,8 +38,11 @@ namespace OpenUtau.Plugin.Builtin {
                 .ToDictionary(t => t.Item1, t => t.Item2);
         }
 
-        private USinger singer;
-        private Presamp presamp;
+        public override void SetUp(Note[][] groups, UProject project, UTrack track) {
+            this.project = project;
+            this.track = track;
+        }
+
         public override void SetSinger(USinger singer) {
             if (this.singer == singer) {
                 return;
@@ -47,7 +55,6 @@ namespace OpenUtau.Plugin.Builtin {
             presamp = new Presamp();
             presamp.ReadPresampIni(singer.Location, singer.TextFileEncoding);
         }
-
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             var result = new List<Phoneme>();
@@ -204,7 +211,7 @@ namespace OpenUtau.Plugin.Builtin {
                 && !currentLyric.Contains(vcvpad)
                 && presamp.PhonemeList.TryGetValue(currentAlias, out PresampPhoneme phoneme)
                 && phoneme.HasConsonant) {
-                if (checkOtoUntilHit(new List<string> { $"-{vcvpad}{phoneme.Consonant}" }, note, 2, out var coto)
+                if (checkOtoUntilHit(new List<string> { $"-{vcvpad}{phoneme.Consonant}" }, note, 2, out var cOto, out var color)
                     && checkOtoUntilHit(new List<string> { currentLyric }, note, out var oto)) {
 
                     var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
@@ -212,15 +219,19 @@ namespace OpenUtau.Plugin.Builtin {
 
                     if (prevNeighbour != null) {
                         cLength = Math.Min(prevNeighbour.Value.duration / 2, cLength);
-                    } else if(prev != null) {
+                    } else if (prev != null) {
                         cLength = Math.Min(note.position - prev.Value.position - prev.Value.duration, cLength);
                     }
 
                     result.Insert(0, new Phoneme() {
-                        phoneme = coto.Alias,
+                        phoneme = cOto.Alias,
                         position = Convert.ToInt32(- cLength),
-                        index = 2
+                        index = 2,
+                        expressions = new List<PhonemeExpression>()
                     });
+                    if (color != null) {
+                        result[0].expressions.Add(new PhonemeExpression() { abbr = Core.Format.Ustx.CLR, value = (int)color });
+                    }
                 }
             }
 
@@ -239,6 +250,7 @@ namespace OpenUtau.Plugin.Builtin {
                 }
                 string nextAlias = presamp.ParseAlias(nextLyric)[1]; // exclude useless characters
                 string vcPhoneme;
+                int? vcColorIndex;
 
                 // Without current vowel, VC cannot be created
                 if (!presamp.PhonemeList.TryGetValue(currentAlias, out PresampPhoneme currentPhoneme) || !currentPhoneme.HasVowel) {
@@ -259,14 +271,15 @@ namespace OpenUtau.Plugin.Builtin {
                                 return new Result { phonemes = result.ToArray() };
                             }
                             // next is VCV (VC is not needed)
-                            var tests = new List<string>{ $"{vowel}{vcvpad}{vowelUpper}・", $"{vowel}{vcvpad}・{vowelUpper}" };
+                            var tests = new List<string> { $"{vowel}{vcvpad}{vowelUpper}・", $"{vowel}{vcvpad}・{vowelUpper}" };
                             if (checkOtoUntilHit(tests, (Note)nextNeighbour, out var oto1) && oto1.Alias.Contains(vcvpad)) {
                                 return new Result { phonemes = result.ToArray() };
                             }
                             // next is CV (VC is needed)
                             tests = new List<string> { $"{vowel}{vcpad}・" };
-                            if (checkOtoUntilHit(tests, note, 1, out oto1)) {
+                            if (checkOtoUntilHit(tests, note, 1, out oto1, out var color)) {
                                 vcPhoneme = oto1.Alias;
+                                vcColorIndex = color;
                             } else {
                                 return new Result { phonemes = result.ToArray() };
                             }
@@ -284,7 +297,7 @@ namespace OpenUtau.Plugin.Builtin {
                         if (!nextPhoneme.IsPriority) {
                             var nextVCV = $"{vowel}{vcvpad}{nextAlias}";
                             var nextVC = $"{vowel}{vcpad}{nextAlias}";
-                            var tests = new List<string>{ nextVCV, nextVC, nextAlias };
+                            var tests = new List<string> { nextVCV, nextVC, nextAlias };
                             if (checkOtoUntilHit(tests, nextNeighbour.Value, out var oto1)
                                 && (Regex.IsMatch(oto1.Alias, "[aiueonN]" + vcvpad) || Regex.IsMatch(oto1.Alias, "[aiueonN]" + vcpad))) {
                                 return new Result { phonemes = result.ToArray() };
@@ -298,14 +311,15 @@ namespace OpenUtau.Plugin.Builtin {
                         if (substituteLookup.TryGetValue(consonant ?? string.Empty, out var con)) {
                             vcPhonemes.Add($"{vowel}{vcpad}{con}");
                         }
-                        if (checkOtoUntilHit(vcPhonemes, note, 1, out var oto)) {
+                        if (checkOtoUntilHit(vcPhonemes, note, 1, out var oto, out var color)) {
                             vcPhoneme = oto.Alias;
+                            vcColorIndex = color;
                         } else {
                             return new Result { phonemes = result.ToArray() };
                         }
                     }
                 }
-                if(!string.IsNullOrEmpty(vcPhoneme)) {
+                if (!string.IsNullOrEmpty(vcPhoneme)) {
                     int vcLength = 120;
                     var nextAttr = nextNeighbour.Value.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
                     if (singer.TryGetMappedOto(nextLyric, nextNeighbour.Value.tone + nextAttr.toneShift, nextAttr.voiceColor, out var nextOto)) {
@@ -322,8 +336,12 @@ namespace OpenUtau.Plugin.Builtin {
                     result.Add(new Phoneme() {
                         phoneme = vcPhoneme,
                         position = totalDuration - vcLength,
-                        index = 1
+                        index = 1,
+                        expressions = new List<PhonemeExpression>()
                     });
+                    if (vcColorIndex != null) {
+                        result.First(p => p.index == 1).expressions.Add(new PhonemeExpression() { abbr = Core.Format.Ustx.CLR, value = (int)vcColorIndex });
+                    }
                 }
             }
 
@@ -332,26 +350,54 @@ namespace OpenUtau.Plugin.Builtin {
 
         // make it quicker to check multiple oto occurrences at once rather than spamming if else if
         private bool checkOtoUntilHit(List<string> input, Note note, out UOto oto) {
-            return checkOtoUntilHit(input, note, 0, out oto);
-        }
-
-        private bool checkOtoUntilHit(List<string> input, Note note, int index, out UOto oto) {
             oto = default;
-            var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == index) ?? default;
+            var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+            // track.TryGetExpression(project, Core.Format.Ustx.CLR, out var trackExp);
+            // string color = attr.voiceColor ?? trackExp.descriptor.options[(int)trackExp.value];
+            string color = attr.voiceColor ?? string.Empty;
 
             var otos = new List<UOto>();
             foreach (string test in input) {
-                if (singer.TryGetMappedOto(test + attr.alternate, note.tone + attr.toneShift, attr.voiceColor, out var otoAlt)) {
+                if (singer.TryGetMappedOto(test + attr.alternate, note.tone + attr.toneShift, color, out var otoAlt)) {
                     otos.Add(otoAlt);
-                } else if (singer.TryGetMappedOto(test, note.tone + attr.toneShift, attr.voiceColor, out var otoCandidacy)) {
+                } else if (singer.TryGetMappedOto(test, note.tone + attr.toneShift, color, out var otoCandidacy)) {
                     otos.Add(otoCandidacy);
                 }
             }
 
-            string color = attr.voiceColor ?? "";
             if (otos.Count > 0) {
                 if (otos.Any(oto => (oto.Color ?? string.Empty) == color)) {
                     oto = otos.Find(oto => (oto.Color ?? string.Empty) == color);
+                    return true;
+                } else {
+                    oto = otos.First();
+                    return true;
+                }
+            }
+            return false;
+        }
+        private bool checkOtoUntilHit(List<string> input, Note note, int index, out UOto oto, out int? colorIndex) {
+            oto = default;
+            colorIndex = null;
+            var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == index) ?? default;
+            var attr0 = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+            string color = attr.voiceColor ?? attr0.voiceColor ?? string.Empty;
+
+            var otos = new List<UOto>();
+            foreach (string test in input) {
+                if (singer.TryGetMappedOto(test + attr.alternate, note.tone + attr.toneShift, color, out var otoAlt)) {
+                    otos.Add(otoAlt);
+                } else if (singer.TryGetMappedOto(test, note.tone + attr.toneShift, color, out var otoCandidacy)) {
+                    otos.Add(otoCandidacy);
+                }
+            }
+
+            if (otos.Count > 0) {
+                if (otos.Any(oto => (oto.Color ?? string.Empty) == color)) {
+                    oto = otos.Find(oto => (oto.Color ?? string.Empty) == color);
+                    if (track.VoiceColorExp.options.Contains(color)) {
+                        colorIndex = Array.IndexOf(track.VoiceColorExp.options, color);
+                    }
                     return true;
                 } else {
                     oto = otos.First();

--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -121,8 +121,13 @@ namespace OpenUtau.Plugin.Builtin {
                     if (checkOtoUntilHit(glottalCVtests, note, out var oto)) {
                         currentLyric = oto.Alias;
                     }
+                } else if (prevLyric.Contains("っ")) {
+                    // try CV
+                    var tests = new List<string> { currentLyric, initial };
+                    if (checkOtoUntilHit(tests, note, out var oto)) {
+                        currentLyric = oto.Alias;
+                    }
                 } else if (presamp.PhonemeList.TryGetValue(prevAlias, out PresampPhoneme prevPhoneme)) {
-
                     if (currentLyric.Contains("・")) {
                         // Glottal stop
                         var tests = new List<string>();

--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -399,7 +399,7 @@ namespace OpenUtau.Plugin.Builtin {
                         colorIndex = Array.IndexOf(track.VoiceColorExp.options, color);
                     }
                     return true;
-                } else {
+                } else if (index != 1) {
                     oto = otos.First();
                     return true;
                 }

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -1276,7 +1276,6 @@ namespace OpenUtau.App.Views {
                     }
                 }
             }
-
         }
 
         public async void WindowClosing(object? sender, WindowClosingEventArgs e) {


### PR DESCRIPTION
New Feature:
- Phonemizer expression:
Phonemizer can suggest expressions such as flags and volumes. Expressions specified in the UI will always take precedence over those suggested by the phonemizer.
If phonemizer suggest an expression that is not in the project, it will be ignored.

Changes:
- Phonemizers can optionally get projects and tracks: Phonemizer.SetUp()
It is possible to get voice colors, and to get the track expression when it is implemented in the future.
- JA VCV&CVVC Phonemizer
The color of VC will be that of CV unless otherwise specified. In the future I would like to adjust the volume of consonants.

Fix:
- Fixed a bug in the Paste Selected Parameters menu where it would only paste to the first phoneme when the note to paste to had no expression: UNote.cs int[] phonemeIndexes
This was probably there before.