### PR TITLE
fix strings startswith "\t- " in yaml

### DIFF
--- a/OpenUtau.Core/OpenUtau.Core.csproj
+++ b/OpenUtau.Core/OpenUtau.Core.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="UTF.Unknown" Version="2.5.1" />
     <PackageReference Include="Vortice.DXGI" Version="2.4.2" />
     <PackageReference Include="WanaKana-net" Version="1.0.0" />
-    <PackageReference Include="YamlDotNet" Version="13.1.0" />
+    <PackageReference Include="YamlDotNet" Version="15.1.2" />
     <PackageReference Include="NetMQ" Version="4.0.1.12" />
   </ItemGroup>
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">

--- a/OpenUtau.Test/Core/USTx/UstxYamlTest.cs
+++ b/OpenUtau.Test/Core/USTx/UstxYamlTest.cs
@@ -84,6 +84,10 @@ phoneme_overrides: []
             yaml = Yaml.DefaultSerializer.Serialize(new UNote() { lyric = "-," });
             actual = Yaml.DefaultDeserializer.Deserialize<UNote>(yaml);
             Assert.Equal("-,", actual.lyric);
+
+            yaml = Yaml.DefaultSerializer.Serialize(new UNote() { lyric = "\t- asdf" });
+            actual = Yaml.DefaultDeserializer.Deserialize<UNote>(yaml);
+            Assert.Equal("\t- asdf", actual.lyric);
         }
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/stakira/OpenUtau/issues/1040 where strings startswith "\t- " can't be written into yaml file correctly
- update yamldotnet to 15.1.2
- add unit test