### PR TITLE
[DONT MERGE] EN VCCV G2P Prep

### DIFF
--- a/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
@@ -190,7 +190,8 @@ namespace OpenUtau.Plugin.Builtin {
                         }
                         phonemes.Add(vc);
                     }
-
+                    if (!HasOto(basePhoneme, syllable.vowelTone))
+                        basePhoneme = $"{v}";
                 }
                 // --------------------------- STARTING CV ------------------------------- //
             } else if (syllable.IsStartingCVWithOneConsonant) {

--- a/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
@@ -31,8 +31,10 @@ namespace OpenUtau.Plugin.Builtin {
                 {"i ng","1 ng"},
                 {"ing","1ng"},
                 {"ing-","1ng-"},
+                {"0 r","0r-"},
                 {"9r","0r"},
                 {"9r-","0r-"},
+                {"9 r","0r-"},
                 {"er-","Ar-" },
                 //{"e r","Ar-"},
                 {"er","Ar"},
@@ -46,6 +48,9 @@ namespace OpenUtau.Plugin.Builtin {
                 {"@ng","Ang"},
                 {"ang","9ng"},
                 {"ang-","9ng-"},
+                {"al","9l"},
+                {"al-","9l-"},
+                //{"a l","9l"},
                 //{"O l","0l"},
                 {"0 l","0l-"},
                 {"Ol","0l"},
@@ -332,8 +337,10 @@ namespace OpenUtau.Plugin.Builtin {
                                         }
                                     }
                                 // sp fix
-                                if ($"{cc[0]}" == "s" && $"{cc[1]}" == "p") {
+                                if (!HasOto ($"sp", syllable.vowelTone)) {
+                                    if ($"{cc[0]}" == "s" && $"{cc[1]}" == "p") {
                                     parsingVCC = $"{prevV} sp";
+                                    }
                                 }
                                 phonemes.Add(parsingVCC);
                                 phonemes.Add(parsingCC);
@@ -354,8 +361,10 @@ namespace OpenUtau.Plugin.Builtin {
                                 }
 
                                     // sp fix
-                                    if ($"{cc[0]}" == "s" && $"{cc[1]}" == "p") {
+                                    if (!HasOto ($"sp", syllable.vowelTone)) {
+                                        if ($"{cc[0]}" == "s" && $"{cc[1]}" == "p") {
                                         parsingVCC = $"{prevV} sp";
+                                        }
                                     }
                                     phonemes.Add(parsingVCC);
                                     phonemes.Add(parsingCC);
@@ -363,8 +372,10 @@ namespace OpenUtau.Plugin.Builtin {
                                     // backpack [@k] + [p@]
 
                                     // sp fix
-                                    if ($"{cc[0]}" == "s" && $"{cc[1]}" == "p") {
+                                    if (!HasOto ($"sp", syllable.vowelTone)) {
+                                        if ($"{cc[0]}" == "s" && $"{cc[1]}" == "p") {
                                         parsingVCC = $"{prevV} sp";
+                                        }
                                     } else
                                     parsingVCC = $"{prevV}{cc[0]}";
                                     phonemes.Add(parsingVCC);

--- a/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
@@ -30,14 +30,14 @@ namespace OpenUtau.Plugin.Builtin {
             new Dictionary<string, string>() {
                 {"i ng","1 ng"},
                 {"ing","1ng"},
-                {"0 r","0r-"},
-                {"9 r","0r-"},
+                {"ing-","1ng-"},
                 {"9r","0r"},
                 {"9r-","0r-"},
                 {"er-","Ar-" },
-                //{"e r","Ar"},
+                //{"e r","Ar-"},
                 {"er","Ar"},
                 //{"@ m","&m"},
+                //{"@ n","&n"},
                 {"@m","&m"},
                 {"@n","&n"},
                 {"@m-","&m-"},
@@ -45,10 +45,11 @@ namespace OpenUtau.Plugin.Builtin {
                 {"@ ng","Ang-"},
                 {"@ng","Ang"},
                 {"ang","9ng"},
-                {"a ng","9ng-"},
+                {"ang-","9ng-"},
                 //{"O l","0l"},
                 {"0 l","0l-"},
                 {"Ol","0l"},
+                {"Ol-","0l-"},
                 //{"6 l","6l"},
                 //{"i r","Er"},
                 {"ir","Er"},
@@ -346,8 +347,10 @@ namespace OpenUtau.Plugin.Builtin {
                                 if (HasOto(parsingCC, syllable.vowelTone)){
                                 //if (HasOto(parsingCC, syllable.vowelTone) && lastCPrevWord !=2) {
                                     if (!HasOto(parsingVCC, syllable.vowelTone)) {
-                                    parsingVCC = $"{prevV} {cc[0]}";
                                     parsingVCC = CheckVCExceptions(parsingVCC);
+                                        if (!HasOto(parsingVCC, syllable.vowelTone)) {
+                                        parsingVCC = $"{prevV} {cc[0]}";
+                                    }
                                 }
 
                                     // sp fix


### PR DESCRIPTION
Adds things necessary for a VCCV G2P in the Phonemizer, such as [l-], [r-] and vcVowels. The vcVowels include, [9l], [Ang], [8n], [1ng] (While [1ng] isn't technically a vcVowel in VCCV Core American English, for the sake of consistency with [Ang] I made it behave as one. Using [1 ng] will still work).