### PR TITLE
Fix plugin failing to run when OU path contains space

### DIFF
--- a/OpenUtau.Core/Classic/Plugin.cs
+++ b/OpenUtau.Core/Classic/Plugin.cs
@@ -18,7 +18,7 @@ namespace OpenUtau.Classic {
             }
             var startInfo = new ProcessStartInfo() {
                 FileName = Executable,
-                Arguments = tempFile,
+                Arguments = $"\"{tempFile}\"",
                 WorkingDirectory = Path.GetDirectoryName(Executable),
                 UseShellExecute = UseShell,
             };


### PR DESCRIPTION
I have only been able to test it on Windows, so please let me know if there are any problems on a Mac.