### PR TITLE
Diffsinger: fix openutau unable to load the other voicebanks if one diffsinger has mistake.

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -76,12 +76,30 @@ namespace OpenUtau.Core.DiffSinger {
 
             //Load diffsinger config of a voicebank
             string configPath = Path.Combine(Location, "dsconfig.yaml");
-            dsConfig = Core.Yaml.DefaultDeserializer.Deserialize<DsConfig>(
-                File.ReadAllText(configPath, TextFileEncoding));
+            if(configPath != null && File.Exists(configPath)){
+                try {
+                    dsConfig = Core.Yaml.DefaultDeserializer.Deserialize<DsConfig>(
+                        File.ReadAllText(configPath, Encoding.UTF8));
+                } catch (Exception e) {
+                    Log.Error(e, $"Failed to load dsconfig.yaml for {Name} from {configPath}");
+                    dsConfig = new DsConfig();
+                }
+            } else {
+                Log.Error($"dsconfig.yaml not found for {Name} at {configPath}");
+                dsConfig = new DsConfig();
+            }
 
             //Load phoneme list
             string phonemesPath = Path.Combine(Location, dsConfig.phonemes);
-            phonemes = File.ReadLines(phonemesPath,TextFileEncoding).ToList();
+            if(phonemesPath != null && File.Exists(phonemesPath)){
+                try {
+                    phonemes = File.ReadLines(phonemesPath, TextFileEncoding).ToList();
+                } catch (Exception e){
+                    Log.Error(e, $"Failed to load phoneme list for {Name} from {phonemesPath}");
+                }
+            } else {
+                Log.Error($"phonemes file not found for {Name} at {phonemesPath}");
+            }
 
             var dummyOtoSet = new UOtoSet(new OtoSet(), Location);
             foreach (var phone in phonemes) {


### PR DESCRIPTION
Before this PR, if one diffsinger voicebank has mistake (for example, its dsconfig.yaml is invalid, or the phonemes.txt file doesn't exist), OpenUtau will fail to load all the voicebanks.