### PR TITLE
Fix singer name translation

### DIFF
--- a/OpenUtau.Core/Ustx/USinger.cs
+++ b/OpenUtau.Core/Ustx/USinger.cs
@@ -259,21 +259,22 @@ namespace OpenUtau.Core.Ustx {
 
         private string name;
 
-        public string DisplayName { get { return Found ? name : $"[Missing] {name}"; } }
-
         public string LocalizedName { 
             get {
                 if(LocalizedNames == null) {
-                    return Name;
+                    return Found ? Name : $"[Missing] {Name}";
                 }
                 string language = Preferences.Default.SortingOrder;
-                if(String.IsNullOrEmpty(language)){
+                if (language == null) {
                     language = Preferences.Default.Language;
                 }
-                if(LocalizedNames.TryGetValue(language, out var localizedName)){
-                    return localizedName;
+                if (language == string.Empty) { // InvariantCulture
+                    return Found ? Name : $"[Missing] {Name}";
+                }
+                if (LocalizedNames.TryGetValue(language, out var localizedName)) {
+                    return Found ? localizedName : $"[Missing] {localizedName}";
                 } else {
-                    return Name;
+                    return Found ? Name : $"[Missing] {Name}";
                 }
             }
         }
@@ -295,7 +296,7 @@ namespace OpenUtau.Core.Ustx {
         public virtual IEnumerable<UOto> GetSuggestions(string text) { return emptyOtos; }
         public virtual byte[] LoadPortrait() => null;
         public virtual byte[] LoadSample() => null;
-        public override string ToString() => Name;
+        public override string ToString() => LocalizedName;
         public bool Equals(USinger other) {
             // Tentative: Since only the singer's Id is recorded in ustx and preferences, singers with the same Id are considered identical.
             // Singer with the same directory name in different locations may be identical.

--- a/OpenUtau.Core/Ustx/UTrack.cs
+++ b/OpenUtau.Core/Ustx/UTrack.cs
@@ -85,8 +85,6 @@ namespace OpenUtau.Core.Ustx {
         }
         [YamlIgnore] public Phonemizer Phonemizer { get; set; } = PhonemizerFactory.Get(typeof(DefaultPhonemizer)).Create();
         [YamlIgnore] public string PhonemizerTag => Phonemizer.Tag;
-
-        [YamlIgnore] public string SingerName => Singer != null ? Singer.DisplayName : "[No Singer]";
         [YamlIgnore] public int TrackNo { set; get; }
         public string TrackName { get; set; } = "New Track";
         public string TrackColor { get; set; } = "Blue";

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -145,7 +145,7 @@ namespace OpenUtau.Core.Util {
             public int DiffsingerSpeedup = 50;
             public int DiffSingerDepth = 1000;
             public string Language = string.Empty;
-            public string SortingOrder = string.Empty;
+            public string? SortingOrder = null;
             public List<string> RecentFiles = new List<string>();
             public string SkipUpdate = string.Empty;
             public string AdditionalSingerPath = string.Empty;

--- a/OpenUtau/App.axaml
+++ b/OpenUtau/App.axaml
@@ -7,6 +7,7 @@
   </Application.DataTemplates>
   <Application.Resources>
     <ResourceDictionary>
+      <ResourceInclude x:Key="strings-en-US" Source="/Strings/Strings.axaml"/>
       <ResourceInclude x:Key="strings-de-DE" Source="/Strings/Strings.de-DE.axaml"/>
       <ResourceInclude x:Key="strings-es-ES" Source="/Strings/Strings.es-ES.axaml"/>
       <ResourceInclude x:Key="strings-es-MX" Source="/Strings/Strings.es-MX.axaml"/>
@@ -24,7 +25,6 @@
       <ResourceInclude x:Key="strings-zh-CN" Source="/Strings/Strings.zh-CN.axaml"/>
       <ResourceInclude x:Key="strings-zh-TW" Source="/Strings/Strings.zh-TW.axaml"/>
       <ResourceInclude x:Key="strings-th-TH" Source="/Strings/Strings.th-TH.axaml"/>
-      <ResourceInclude x:Key="strings-en-US" Source="/Strings/Strings.axaml"/>
       <ResourceInclude x:Key="themes-dark" Source="/Colors/DarkTheme.axaml"/>
       <ResourceInclude x:Key="themes-light" Source="/Colors/LightTheme.axaml"/>
       <ResourceDictionary.MergedDictionaries>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -83,6 +83,7 @@
   <system:String x:Key="languages.en">English</system:String>
   <system:String x:Key="languages.es">Spanish</system:String>
   <system:String x:Key="languages.fr">French</system:String>
+  <system:String x:Key="languages.invariant">Not translating</system:String>
   <system:String x:Key="languages.it">Italian</system:String>
   <system:String x:Key="languages.ja">Japanese</system:String>
   <system:String x:Key="languages.ko">Korean</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -83,6 +83,7 @@
   <system:String x:Key="languages.en">英語</system:String>
   <system:String x:Key="languages.es">スペイン語</system:String>
   <system:String x:Key="languages.fr">フランス語</system:String>
+  <system:String x:Key="languages.invariant">翻訳しない</system:String>
   <system:String x:Key="languages.it">イタリア語</system:String>
   <system:String x:Key="languages.ja">日本語</system:String>
   <system:String x:Key="languages.ko">韓国語</system:String>

--- a/OpenUtau/ViewModels/Converters.cs
+++ b/OpenUtau/ViewModels/Converters.cs
@@ -5,7 +5,12 @@ using Avalonia.Data.Converters;
 
 namespace OpenUtau.App.ViewModels {
     public class CultureNameConverter : IValueConverter {
-        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => (value as CultureInfo)?.NativeName ?? string.Empty;
+        public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) {
+            if (value is CultureInfo cultureInfo) {
+                return cultureInfo == CultureInfo.InvariantCulture ? ThemeManager.GetString("languages.invariant") : cultureInfo.NativeName;
+            }
+            return string.Empty;
+        }
         public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
     }
 

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -127,8 +127,8 @@ namespace OpenUtau.App.ViewModels {
                 : CultureInfo.GetCultureInfo(Preferences.Default.Language);
             SortingOrders = Languages.ToList();
             SortingOrders.Insert(0, CultureInfo.InvariantCulture);
-            SortingOrder = string.IsNullOrEmpty(Preferences.Default.SortingOrder)
-                ? Language
+            SortingOrder = Preferences.Default.SortingOrder == null ? Language
+                : Preferences.Default.SortingOrder == string.Empty ? CultureInfo.InvariantCulture
                 : CultureInfo.GetCultureInfo(Preferences.Default.SortingOrder);
             PreRender = Preferences.Default.PreRender;
             DefaultRendererOptions = Renderers.getRendererOptions();
@@ -219,7 +219,7 @@ namespace OpenUtau.App.ViewModels {
                 });
             this.WhenAnyValue(vm => vm.SortingOrder)
                 .Subscribe(so => {
-                    Preferences.Default.SortingOrder = so?.Name ?? string.Empty;
+                    Preferences.Default.SortingOrder = so?.Name ?? null;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.Theme)

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -120,12 +120,13 @@ namespace OpenUtau.App.ViewModels {
             Languages = App.GetLanguages().Keys
                 .Select(lang => CultureInfo.GetCultureInfo(lang))
                 .ToList();
+            Languages.Remove(CultureInfo.GetCultureInfo("en-US"));
             Languages.Insert(0, CultureInfo.GetCultureInfo("en-US"));
             Language = string.IsNullOrEmpty(Preferences.Default.Language)
                 ? null
                 : CultureInfo.GetCultureInfo(Preferences.Default.Language);
             SortingOrders = Languages.ToList();
-            SortingOrders.Insert(1, CultureInfo.InvariantCulture);
+            SortingOrders.Insert(0, CultureInfo.InvariantCulture);
             SortingOrder = string.IsNullOrEmpty(Preferences.Default.SortingOrder)
                 ? Language
                 : CultureInfo.GetCultureInfo(Preferences.Default.SortingOrder);

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -120,8 +120,6 @@ namespace OpenUtau.App.ViewModels {
             Languages = App.GetLanguages().Keys
                 .Select(lang => CultureInfo.GetCultureInfo(lang))
                 .ToList();
-            Languages.Remove(CultureInfo.GetCultureInfo("en-US"));
-            Languages.Insert(0, CultureInfo.GetCultureInfo("en-US"));
             Language = string.IsNullOrEmpty(Preferences.Default.Language)
                 ? null
                 : CultureInfo.GetCultureInfo(Preferences.Default.Language);


### PR DESCRIPTION
- Fixed two English choices for language in preferences
- Fixed untranslated singer names on tracks
- Remove unused properties: USinger.DisplayName, UTrack.SingerName
- Fixed to not translating when the singer's translation language is invariant culture
  - Voicebank authors can provide the default name of the non-English singer along with the English name.