### PR TITLE
Fix UPhonemeOverride.phoneme

### DIFF
--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -502,11 +502,11 @@ namespace OpenUtau.Core {
 
         public override void Execute() {
             var o = note.GetPhonemeOverride(index);
-            o.phoneme = string.IsNullOrWhiteSpace(newAlias) ? string.Empty : newAlias;
+            o.phoneme = string.IsNullOrWhiteSpace(newAlias) ? null : newAlias;
         }
         public override void Unexecute() {
             var o = note.GetPhonemeOverride(index);
-            o.phoneme = string.IsNullOrWhiteSpace(oldAlias) ? string.Empty : oldAlias;
+            o.phoneme = string.IsNullOrWhiteSpace(oldAlias) ? null : oldAlias;
         }
         public override string ToString() => "Change phoneme alias";
     }

--- a/OpenUtau.Core/Ustx/UPart.cs
+++ b/OpenUtau.Core/Ustx/UPart.cs
@@ -185,7 +185,7 @@ namespace OpenUtau.Core.Ustx {
                     var o = note.phonemeOverrides.FirstOrDefault(o => o.index == phoneme.index);
                     if (o != null) {
                         phoneme.position += o.offset ?? 0;
-                        phoneme.phoneme = o.phoneme ?? phoneme.rawPhoneme;
+                        phoneme.phoneme = !string.IsNullOrWhiteSpace(o.phoneme) ? o.phoneme : phoneme.rawPhoneme;
                         phoneme.preutterDelta = o.preutterDelta;
                         phoneme.overlapDelta = o.overlapDelta;
                     }

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -250,13 +250,13 @@ namespace OpenUtau.Core.Ustx {
 
     public class UPhonemeOverride {
         public int index;
-        public string phoneme;
+        public string? phoneme;
         public int? offset;
         public float? preutterDelta;
         public float? overlapDelta;
 
         [YamlIgnore]
-        public bool IsEmpty => string.IsNullOrEmpty(phoneme) && !offset.HasValue
+        public bool IsEmpty => string.IsNullOrWhiteSpace(phoneme) && !offset.HasValue
             && !preutterDelta.HasValue && !overlapDelta.HasValue;
 
         public UPhonemeOverride Clone() {


### PR DESCRIPTION
Fixed a bug in which phoneme override was misjudged as being present because resetting a phoneme of PhonemeOverride would result in string.Empty instead of null.