### PR TITLE
Part duration enhancement

### DIFF
--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -95,18 +95,35 @@ namespace OpenUtau.Core {
     }
 
     public class ResizeNoteCommand : NoteCommand {
+        readonly int NewPartDuration;
+        readonly int OldPartDuration;
         readonly int DeltaDur;
         public ResizeNoteCommand(UVoicePart part, UNote note, int deltaDur) : base(part, note) {
             DeltaDur = deltaDur;
+            OldPartDuration = part.Duration;
+            DocManager.Inst.Project.timeAxis.TickPosToBarBeat(note.End + deltaDur, out int bar, out int beat, out int remainingTicks);
+            int minDurTick = DocManager.Inst.Project.timeAxis.BarBeatToTickPos(bar + 2, 0) - part.position;
+            if (part.Duration < minDurTick) {
+                NewPartDuration = minDurTick;
+            }
         }
         public ResizeNoteCommand(UVoicePart part, List<UNote> notes, int deltaDur) : base(part, notes) {
             DeltaDur = deltaDur;
+            OldPartDuration = part.Duration;
+            DocManager.Inst.Project.timeAxis.TickPosToBarBeat((Notes.LastOrDefault()?.End ?? 1) + deltaDur, out int bar, out int beat, out int remainingTicks);
+            int minDurTick = DocManager.Inst.Project.timeAxis.BarBeatToTickPos(bar + 2, 0) - part.position;
+            if (part.Duration < minDurTick) {
+                NewPartDuration = minDurTick;
+            }
         }
         public override string ToString() { return $"Change {Notes.Count()} notes duration"; }
         public override void Execute() {
             lock (Part) {
                 foreach (var note in Notes) {
                     note.duration += DeltaDur;
+                }
+                if (NewPartDuration > 0) {
+                    Part.Duration = NewPartDuration;
                 }
             }
         }
@@ -115,6 +132,7 @@ namespace OpenUtau.Core {
                 foreach (var note in Notes) {
                     note.duration -= DeltaDur;
                 }
+                Part.Duration = OldPartDuration;
             }
         }
     }

--- a/OpenUtau.Core/Ustx/UPart.cs
+++ b/OpenUtau.Core/Ustx/UPart.cs
@@ -36,6 +36,8 @@ namespace OpenUtau.Core.Ustx {
     }
 
     public class UVoicePart : UPart {
+        public int duration;
+
         [YamlMember(Order = 100)]
         public SortedSet<UNote> notes = new SortedSet<UNote>();
         [YamlMember(Order = 101)]
@@ -55,14 +57,12 @@ namespace OpenUtau.Core.Ustx {
         [YamlIgnore] public ISignalSource Mix => mix;
 
         public override string DisplayName => name;
+        public override int Duration { get => duration; set => duration = value; }
 
         public override int GetMinDurTick(UProject project) {
             int endTicks = position + (notes.LastOrDefault()?.End ?? 1);
             project.timeAxis.TickPosToBarBeat(endTicks, out int bar, out int beat, out int remainingTicks);
-            if (remainingTicks > 0) {
-                beat++;
-            }
-            return project.timeAxis.BarBeatToTickPos(bar, beat) - position;
+            return project.timeAxis.BarBeatToTickPos(bar, beat + 1) - position;
         }
 
         public override void BeforeSave(UProject project, UTrack track) {

--- a/OpenUtau/ViewModels/TracksViewModel.cs
+++ b/OpenUtau/ViewModels/TracksViewModel.cs
@@ -372,7 +372,11 @@ namespace OpenUtau.App.ViewModels {
 
         public void OnNext(UCommand cmd, bool isUndo) {
             if (cmd is NoteCommand noteCommand) {
-                MessageBus.Current.SendMessage(new PartRedrawEvent(noteCommand.Part));
+                if (noteCommand is ResizeNoteCommand) {
+                    MessageBus.Current.SendMessage(new PartRefreshEvent(noteCommand.Part));
+                } else {
+                    MessageBus.Current.SendMessage(new PartRedrawEvent(noteCommand.Part));
+                }
             } else if (cmd is PartCommand partCommand) {
                 if (partCommand is AddPartCommand) {
                     if (!isUndo) {


### PR DESCRIPTION
- Added storing the length of the part in ustx.
- When entering and resizing notes, the part is automatically extended by one measure when the length of the part is less than one measure remaining.
- The interval between the end of note and the end of part is now non-zero.

https://github.com/stakira/OpenUtau/assets/130257355/60fc422d-975f-4fa6-bf2b-a1266063860a