### PR TITLE
Reset preset combo box in the note properties panel

### DIFF
--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -111,6 +111,8 @@ namespace OpenUtau.App.ViewModels {
         // note -> panel
         private void OnSelectNotes() {
             this.RaisePropertyChanged(nameof(Title));
+            ApplyPortamentoPreset = null;
+            ApplyVibratoPreset = null;
 
             if (selectedNotes.Count > 0) {
                 IsNoteSelected = true;


### PR DESCRIPTION
The combo box is reset each time a note is selected, making it easier to select a preset.