### PR TITLE
Improved view position when pasting note

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -833,7 +833,10 @@ namespace OpenUtau.App.ViewModels {
                     Selection.Select(notes);
                     MessageBus.Current.SendMessage(new NotesSelectionEvent(Selection));
 
-                    TickOffset = left - Part.position;
+                    var note = notes.First();
+                    if (left < TickOffset || TickOffset + ViewportTicks < note.position + note.duration + Part.position) {
+                        TickOffset = TickOffset = Math.Clamp(note.position + note.duration * 0.5 - ViewportTicks * 0.5, 0, HScrollBarMax);
+                    }
                 }
             }
         }

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -835,7 +835,7 @@ namespace OpenUtau.App.ViewModels {
 
                     var note = notes.First();
                     if (left < TickOffset || TickOffset + ViewportTicks < note.position + note.duration + Part.position) {
-                        TickOffset = TickOffset = Math.Clamp(note.position + note.duration * 0.5 - ViewportTicks * 0.5, 0, HScrollBarMax);
+                        TickOffset = Math.Clamp(note.position + note.duration * 0.5 - ViewportTicks * 0.5, 0, HScrollBarMax);
                     }
                 }
             }
@@ -921,7 +921,7 @@ namespace OpenUtau.App.ViewModels {
         }
 
         private void FocusNote(UNote note) {
-            TickOffset = TickOffset = Math.Clamp(note.position + note.duration * 0.5 - ViewportTicks * 0.5, 0, HScrollBarMax);
+            TickOffset = Math.Clamp(note.position + note.duration * 0.5 - ViewportTicks * 0.5, 0, HScrollBarMax);
             TrackOffset = Math.Clamp(ViewConstants.MaxTone - note.tone + 2 - ViewportTracks * 0.5, 0, VScrollBarMax);
         }
 


### PR DESCRIPTION
Fixed that the playback position is close to the left edge of the window when notes are pasted.
The view is recentered only when the note is off-screen.