### PR TITLE
Add overwrite option to DrawPitchTool

### DIFF
--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -133,6 +133,7 @@ namespace OpenUtau.Core.Util {
             public bool ShowTips = true;
             public int Theme;
             public bool PenPlusDefault = false;
+            public bool OverwritePitchDrawTool = false;
             public int DegreeStyle;
             public bool UseTrackColor = false;
             public bool ClearCacheOnQuit = false;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -123,9 +123,11 @@
   <system:String x:Key="menu.edit.lockunselectednotes.pitchpoints">Pitch Points</system:String>
   <system:String x:Key="menu.edit.lockunselectednotes.vibrato">Vibrato</system:String>
   <system:String x:Key="menu.edit.lockunselectednotes.expressions">Expressions</system:String>
+  <system:String x:Key="menu.edit.overwritepitchdrawtool">Draw Pitch Tool to overwrite vibrato or MOD+</system:String>
   <system:String x:Key="menu.edit.paste">Paste</system:String>
   <system:String x:Key="menu.edit.redo">Redo</system:String>
   <system:String x:Key="menu.edit.selectall">Select All</system:String>
+  <system:String x:Key="menu.edit.tooloptions">Tool Options</system:String>
   <system:String x:Key="menu.edit.undo">Undo</system:String>
   <system:String x:Key="menu.file">File</system:String>
   <system:String x:Key="menu.file.exit">Exit</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -123,9 +123,11 @@
   <system:String x:Key="menu.edit.lockunselectednotes.pitchpoints">ピッチ点</system:String>
   <system:String x:Key="menu.edit.lockunselectednotes.vibrato">ビブラート</system:String>
   <system:String x:Key="menu.edit.lockunselectednotes.expressions">表情</system:String>
+  <system:String x:Key="menu.edit.overwritepitchdrawtool">ピッチ描画ツールでビブラートやMOD+を上書きする</system:String>
   <system:String x:Key="menu.edit.paste">貼り付け</system:String>
   <system:String x:Key="menu.edit.redo">やり直す</system:String>
   <system:String x:Key="menu.edit.selectall">全て選択</system:String>
+  <system:String x:Key="menu.edit.tooloptions">ツールオプション</system:String>
   <system:String x:Key="menu.edit.undo">元に戻す</system:String>
   <system:String x:Key="menu.file">ファイル</system:String>
   <system:String x:Key="menu.file.exit">OpenUTAUを終了</system:String>

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -51,6 +51,7 @@ namespace OpenUtau.App.ViewModels {
         public bool LockPitchPoints { get => Preferences.Default.LockUnselectedNotesPitch; }
         public bool LockVibrato { get => Preferences.Default.LockUnselectedNotesVibrato; }
         public bool LockExpressions { get => Preferences.Default.LockUnselectedNotesExpressions; }
+        public bool OverwritePitchDrawTool { get => Preferences.Default.OverwritePitchDrawTool; }
         public bool ShowPortrait { get => Preferences.Default.ShowPortrait; }
         public bool ShowIcon { get => Preferences.Default.ShowIcon; }
         public bool ShowGhostNotes { get => Preferences.Default.ShowGhostNotes; }

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -225,6 +225,13 @@
                   </MenuItem.Icon>
                 </MenuItem>
               </MenuItem>
+              <MenuItem Header="{DynamicResource menu.edit.tooloptions}">
+                <MenuItem Header="{DynamicResource menu.edit.overwritepitchdrawtool}" Click="OnMenuOverwritePitchDrawTool">
+                  <MenuItem.Icon>
+                    <CheckBox IsChecked="{Binding OverwritePitchDrawTool}" />
+                  </MenuItem.Icon>
+                </MenuItem>
+              </MenuItem>
             </MenuItem>
           
             <MenuItem Header="{DynamicResource menu.view}">

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -102,6 +102,11 @@ namespace OpenUtau.App.Views {
             Preferences.Save();
             ViewModel.RaisePropertyChanged(nameof(ViewModel.LockExpressions));
         }
+        void OnMenuOverwritePitchDrawTool(object sender, RoutedEventArgs args) {
+            Preferences.Default.OverwritePitchDrawTool = !Preferences.Default.OverwritePitchDrawTool;
+            Preferences.Save();
+            ViewModel.RaisePropertyChanged(nameof(ViewModel.OverwritePitchDrawTool));
+        }
 
         // View menu
         void OnMenuShowPortrait(object sender, RoutedEventArgs args) {


### PR DESCRIPTION
This is an improved version of #1069.
- Add "Draw Pitch Tool to overwrite vibrato or MOD+" option to edit menu
Pitch curves with vibrato or MOD+ applied can be modified with the Draw Pitch tool.

https://github.com/stakira/OpenUtau/assets/130257355/0b6acfba-353a-4117-9d2f-9ae147e5a9ef

