### PR TITLE
Fix deleting expressions

### DIFF
--- a/OpenUtau.Core/Commands/ProjectCommands.cs
+++ b/OpenUtau.Core/Commands/ProjectCommands.cs
@@ -167,6 +167,7 @@ namespace OpenUtau.Core {
         public override string ToString() => "Configure expressions";
         public override void Execute() {
             project.expressions = newDescriptors.ToDictionary(descriptor => descriptor.abbr);
+            Format.Ustx.AddDefaultExpressions(project);
             project.parts
                 .Where(part => part is UVoicePart)
                 .ToList()
@@ -175,6 +176,7 @@ namespace OpenUtau.Core {
         }
         public override void Unexecute() {
             project.expressions = oldDescriptors.ToDictionary(descriptor => descriptor.abbr);
+            Format.Ustx.AddDefaultExpressions(project);
             project.parts
                 .Where(part => part is UVoicePart)
                 .ToList()

--- a/OpenUtau.Core/Commands/ProjectCommands.cs
+++ b/OpenUtau.Core/Commands/ProjectCommands.cs
@@ -167,7 +167,8 @@ namespace OpenUtau.Core {
         public override string ToString() => "Configure expressions";
         public override void Execute() {
             project.expressions = newDescriptors.ToDictionary(descriptor => descriptor.abbr);
-            Format.Ustx.AddDefaultExpressions(project);
+            // TODO: Measures to be taken when a default expression is removed, and when adding it duplicates the flag.
+            // Format.Ustx.AddDefaultExpressions(project);
             project.parts
                 .Where(part => part is UVoicePart)
                 .ToList()
@@ -176,7 +177,7 @@ namespace OpenUtau.Core {
         }
         public override void Unexecute() {
             project.expressions = oldDescriptors.ToDictionary(descriptor => descriptor.abbr);
-            Format.Ustx.AddDefaultExpressions(project);
+            // Format.Ustx.AddDefaultExpressions(project);
             project.parts
                 .Where(part => part is UVoicePart)
                 .ToList()

--- a/OpenUtau.Core/Commands/ProjectCommands.cs
+++ b/OpenUtau.Core/Commands/ProjectCommands.cs
@@ -167,8 +167,6 @@ namespace OpenUtau.Core {
         public override string ToString() => "Configure expressions";
         public override void Execute() {
             project.expressions = newDescriptors.ToDictionary(descriptor => descriptor.abbr);
-            // TODO: Measures to be taken when a default expression is removed, and when adding it duplicates the flag.
-            // Format.Ustx.AddDefaultExpressions(project);
             project.parts
                 .Where(part => part is UVoicePart)
                 .ToList()
@@ -177,7 +175,6 @@ namespace OpenUtau.Core {
         }
         public override void Unexecute() {
             project.expressions = oldDescriptors.ToDictionary(descriptor => descriptor.abbr);
-            // Format.Ustx.AddDefaultExpressions(project);
             project.parts
                 .Where(part => part is UVoicePart)
                 .ToList()

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -106,7 +106,7 @@ namespace OpenUtau.Core.Render {
 
             resampler = track.RendererSettings.resampler;
             int eng = (int)phoneme.GetExpression(project, track, Format.Ustx.ENG).Item1;
-            if (project.expressions.TryGetValue(Format.Ustx.ENG, out var descriptor)
+            if (track.TryGetExpDescriptor(project, Format.Ustx.ENG, out var descriptor)
                 && eng >= 0 && eng < descriptor.options.Length
                 && !string.IsNullOrEmpty(descriptor.options[eng])) {
                 resampler = descriptor.options[eng];

--- a/OpenUtau.Core/Ustx/UExpression.cs
+++ b/OpenUtau.Core/Ustx/UExpression.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using YamlDotNet.Serialization;
 
 namespace OpenUtau.Core.Ustx {
@@ -9,7 +10,7 @@ namespace OpenUtau.Core.Ustx {
         Curve = 2,
     }
 
-    public class UExpressionDescriptor {
+    public class UExpressionDescriptor : IEquatable<UExpressionDescriptor> {
         public string name;
         public string abbr;
         public UExpressionType type;
@@ -66,6 +67,18 @@ namespace OpenUtau.Core.Ustx {
         }
 
         public override string ToString() => $"{abbr.ToUpper()}: {name}";
+
+        public bool Equals(UExpressionDescriptor other) {
+            return this.name == other.name &&
+                this.abbr == other.abbr &&
+                this.type == other.type &&
+                this.min == other.min &&
+                this.max == other.max &&
+                this.defaultValue == other.defaultValue &&
+                this.isFlag == other.isFlag &&
+                this.flag == other.flag &&
+                ((this.options == null && other.options == null) || this.options.SequenceEqual(other.options));
+        }
     }
 
     public class UExpression {

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -63,10 +63,11 @@ namespace OpenUtau.Core.Ustx {
 
         public void AfterLoad(UProject project, UTrack track, UVoicePart part) {
             foreach (var exp in phonemeExpressions) {
-                if (project.expressions.TryGetValue(exp.abbr, out var descriptor)) {
+                if (track.TryGetExpDescriptor(project, exp.abbr, out var descriptor)) {
                     exp.descriptor = descriptor;
                 }
             }
+            phonemeExpressions = phonemeExpressions.Where(exp => exp.descriptor != null).ToList();
         }
 
         public void BeforeSave(UProject project, UTrack track, UVoicePart part) {

--- a/OpenUtau.Core/Ustx/UTrack.cs
+++ b/OpenUtau.Core/Ustx/UTrack.cs
@@ -144,22 +144,23 @@ namespace OpenUtau.Core.Ustx {
             var trackExp = TrackExpressions.FirstOrDefault(e => e.descriptor.abbr == abbr);
             if (trackExp != null) {
                 expression = trackExp.Clone();
-                expression.descriptor = descriptor;
             } else {
                 expression = new UExpression(descriptor) { value = descriptor.defaultValue };
             }
             return true;
         }
 
-        public void SetTrackExpression(string abbr, float? value) {
-            if (!TryGetExpDescriptor(DocManager.Inst.Project, abbr, out var descriptor)) {
+        // May be used in the future
+        public void SetTrackExpression(UExpressionDescriptor descriptor, float? value) {
+            if (!TryGetExpDescriptor(DocManager.Inst.Project, descriptor.abbr, out var pDescriptor)) {
+                TrackExpressions.RemoveAll(exp => exp.descriptor?.abbr == descriptor.abbr);
                 return;
             }
 
-            if (value == null || descriptor.defaultValue == value) {
-                TrackExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr);
+            if (value == null || (descriptor.Equals(pDescriptor) && pDescriptor.defaultValue == value)) {
+                TrackExpressions.RemoveAll(exp => exp.descriptor?.abbr == descriptor.abbr);
             } else {
-                var trackExp = TrackExpressions.FirstOrDefault(e => e.descriptor.abbr == abbr);
+                var trackExp = TrackExpressions.FirstOrDefault(e => e.descriptor.abbr == descriptor.abbr);
                 if (trackExp != null) {
                     trackExp.descriptor = descriptor;
                     trackExp.value = (float)value;

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -162,12 +162,12 @@ namespace OpenUtau.App.ViewModels {
             Expressions.Clear();
             if (part != null && part is UVoicePart) {
                 this.Part = part as UVoicePart;
+                var track = DocManager.Inst.Project.tracks[part.trackNo];
 
                 foreach (KeyValuePair<string, UExpressionDescriptor> pair in DocManager.Inst.Project.expressions) {
-                    if (pair.Value.type != UExpressionType.Curve) {
-                        var viewModel = new NotePropertyExpViewModel(pair.Value, this);
-                        if (pair.Value.abbr == Ustx.CLR) {
-                            var track = DocManager.Inst.Project.tracks[part.trackNo];
+                    if (track.TryGetExpDescriptor(DocManager.Inst.Project, pair.Key, out var descriptor) && descriptor.type != UExpressionType.Curve) {
+                        var viewModel = new NotePropertyExpViewModel(descriptor, this);
+                        if (descriptor.abbr == Ustx.CLR) {
                             if (track.VoiceColorExp != null && track.VoiceColorExp.options.Length > 0) {
                                 viewModel.Options.Clear();
                                 track.VoiceColorExp.options.ForEach(opt => viewModel.Options.Add(opt));

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -971,7 +971,7 @@ namespace OpenUtau.App.ViewModels {
             if (track.RendererSettings.Renderer == null) {
                 return true;
             }
-            if (Project.expressions.TryGetValue(expKey, out var descriptor)) {
+            if (track.TryGetExpDescriptor(Project, expKey, out var descriptor)) {
                 return track.RendererSettings.Renderer.SupportsExpression(descriptor);
             }
             if (expKey == track.VoiceColorExp.abbr) {


### PR DESCRIPTION
- When ustx is loaded, expressions that have been deleted from the project are also deleted from the note (because a null expression descriptor in the note causes an error): UNote
- Some expressions that was getting directly from the project are now getting via track (Supplement to #1017)
- ~~When expressions are deleted in ExpressionsDialog, the default required expressions are added again: ProjectCommand
Pending as I don't have a solution for duplicate flags.~~