### PR TITLE
[DiffSinger] Migrate to continuous acceleration profiles

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerConfig.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerConfig.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using YamlDotNet.Serialization;
 
 namespace OpenUtau.Core.DiffSinger {
-
     [Serializable]
     public class RandomPitchShifting {
         public float[] range;
@@ -27,8 +27,24 @@ namespace OpenUtau.Core.DiffSinger {
         public bool useVoicingEmbed = false;
         public bool useTensionEmbed = false;
         public AugmentationArgs augmentationArgs;
-        public bool useShallowDiffusion = false;
-        public int maxDepth = -1;
+        public bool useContinuousAcceleration = false;
+        [YamlMember(Alias = "use_shallow_diffusion")] public bool? _useShallowDiffusion;
+        [YamlMember(Alias = "use_variable_depth")] public bool? _useVariableDepth;
+        [YamlIgnore]
+        public bool useVariableDepth {
+            get {
+                // coalesce _useDepth and _useShallowDiffusion
+                if (_useVariableDepth.HasValue) {
+                    return _useVariableDepth.Value;
+                }
+                if (_useShallowDiffusion.HasValue) {
+                    return _useShallowDiffusion.Value;
+                }
+                return false;
+            }
+        }
+        [YamlMember(Alias = "max_depth")] public double _maxDepth;
+        [YamlIgnore] public double maxDepth => useContinuousAcceleration ? _maxDepth : _maxDepth / 1000.0;
         public string dur;
         public string linguistic;
         public string pitch;
@@ -49,7 +65,8 @@ namespace OpenUtau.Core.DiffSinger {
         public double mel_fmax = 16000;
         public string mel_base = "10";  // or "e"
         public string mel_scale = "slaney";  // or "htk"
-        public float frameMs(){
+
+        public float frameMs() {
             return 1000f * hop_size / sample_rate;
         }
     }

--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -209,7 +209,6 @@ namespace OpenUtau.Core.DiffSinger
             note_dur[^1]=totalFrames-note_dur.Sum();
             var pitch = Enumerable.Repeat(60f, totalFrames).ToArray();
             var retake = Enumerable.Repeat(true, totalFrames).ToArray();
-            var speedup = Preferences.Default.DiffsingerSpeedup;
             var pitchInputs = new List<NamedOnnxValue>();
             pitchInputs.Add(NamedOnnxValue.CreateFromTensor("encoder_out", encoder_out));
             pitchInputs.Add(NamedOnnxValue.CreateFromTensor("note_midi",
@@ -227,8 +226,19 @@ namespace OpenUtau.Core.DiffSinger
             pitchInputs.Add(NamedOnnxValue.CreateFromTensor("retake",
                 new DenseTensor<bool>(retake, new int[] { retake.Length }, false)
                 .Reshape(new int[] { 1, retake.Length })));
-            pitchInputs.Add(NamedOnnxValue.CreateFromTensor("speedup",
-                new DenseTensor<long>(new long[] { speedup }, new int[] { 1 },false)));
+            var steps = Preferences.Default.DiffSingerSteps;
+            if (dsConfig.useContinuousAcceleration) {
+                pitchInputs.Add(NamedOnnxValue.CreateFromTensor("steps",
+                    new DenseTensor<long>(new long[] { steps }, new int[] { 1 }, false)));
+            } else {
+                // find a largest integer speedup that are less than 1000 / steps and is a factor of 1000
+                long speedup = Math.Max(1, 1000 / steps);
+                while (1000 % speedup != 0 && speedup > 1) {
+                    speedup--;
+                }
+                pitchInputs.Add(NamedOnnxValue.CreateFromTensor("speedup",
+                    new DenseTensor<long>(new long[] { speedup }, new int[] { 1 },false)));
+            }
 
             //expressiveness
             if (dsConfig.use_expr) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -12,6 +12,7 @@ using OpenUtau.Core.Format;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.SignalChain;
 using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
 using Serilog;
 
 namespace OpenUtau.Core.DiffSinger {
@@ -77,22 +78,22 @@ namespace OpenUtau.Core.DiffSinger {
                     var result = Layout(phrase);
 
                     // calculate real depth
-                    int speedup = Core.Util.Preferences.Default.DiffsingerSpeedup;
                     var singer = (DiffSingerSinger) phrase.singer;
-                    int depth = Core.Util.Preferences.Default.DiffSingerDepth;
-                    if (singer.dsConfig.useShallowDiffusion) {
-                        int kStep = singer.dsConfig.maxDepth;
-                        if (kStep < 0) {
+                    double depth = Preferences.Default.DiffSingerDepth;
+                    int steps = Preferences.Default.DiffSingerSteps;
+                    if (singer.dsConfig.useVariableDepth) {
+                        double maxDepth = singer.dsConfig.maxDepth;
+                        if (maxDepth < 0) {
                             throw new InvalidDataException("Max depth is unset or is negative.");
                         }
-                        depth = Math.Min(depth, kStep);  // make sure depth <= K_step
-                        depth = depth / speedup * speedup;  // make sure depth can be divided by speedup
+                        depth = Math.Min(depth, maxDepth);  // make sure depth <= K_step
                     }
-                    var wavName = singer.dsConfig.useShallowDiffusion
-                        ? $"ds-{phrase.hash:x16}-depth{depth}-{speedup}x.wav"  // if the depth changes, phrase should be re-rendered
-                        : $"ds-{phrase.hash:x16}-{speedup}x.wav";  // preserve this for not invalidating cache from older versions
+                    // format depth with 3 decimal places
+                    var wavName = singer.dsConfig.useVariableDepth
+                        ? $"ds-{phrase.hash:x16}-depth{depth:f2}-steps{steps}.wav"  // if the depth changes, phrase should be re-rendered
+                        : $"ds-{phrase.hash:x16}-steps{steps}.wav";  // preserve this for models without depth
                     var wavPath = Path.Join(PathManager.Inst.CachePath, wavName);
-                    string progressInfo = $"Track {trackNo + 1}: {this}{speedup}x \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
+                    string progressInfo = $"Track {trackNo + 1}: {this} depth={depth:f2} steps={steps} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
                     if (File.Exists(wavPath)) {
                         try {
                             using (var waveStream = Wave.OpenFile(wavPath)) {
@@ -103,7 +104,7 @@ namespace OpenUtau.Core.DiffSinger {
                         }
                     }
                     if (result.samples == null) {
-                        result.samples = InvokeDiffsinger(phrase, depth, speedup, cancellation);
+                        result.samples = InvokeDiffsinger(phrase, depth, steps, cancellation);
                         if (result.samples != null) {
                             var source = new WaveSource(0, 0, 0, 1);
                             source.SetSamples(result.samples);
@@ -124,7 +125,7 @@ namespace OpenUtau.Core.DiffSinger {
         leadingMs、positionMs、estimatedLengthMs: timeaxis layout in Ms, double
          */
 
-        float[] InvokeDiffsinger(RenderPhrase phrase, int depth, int speedup, CancellationTokenSource cancellation) {
+        float[] InvokeDiffsinger(RenderPhrase phrase, double depth, int steps, CancellationTokenSource cancellation) {
             var singer = phrase.singer as DiffSingerSinger;
             //Check if dsconfig.yaml is correct
             if(String.IsNullOrEmpty(singer.dsConfig.vocoder) ||
@@ -233,12 +234,31 @@ namespace OpenUtau.Core.DiffSinger {
             acousticInputs.Add(NamedOnnxValue.CreateFromTensor("f0",f0tensor));
 
             // sampling acceleration related
-            if (singer.dsConfig.useShallowDiffusion) {
-                acousticInputs.Add(NamedOnnxValue.CreateFromTensor("depth",
-                    new DenseTensor<long>(new long[] { depth }, new int[] { 1 }, false)));
+            if (singer.dsConfig.useContinuousAcceleration) {
+                if (singer.dsConfig.useVariableDepth) {
+                    acousticInputs.Add(NamedOnnxValue.CreateFromTensor("depth",
+                        new DenseTensor<float>(new float[] {(float)depth}, new int[] { 1 }, false)));
+                }
+                acousticInputs.Add(NamedOnnxValue.CreateFromTensor("steps",
+                    new DenseTensor<long>(new long[] { steps }, new int[] { 1 }, false)));
+            } else {
+                long speedup;
+                if (singer.dsConfig.useVariableDepth) {
+                    long int64Depth = (long) Math.Round(depth * 1000);
+                    speedup = Math.Max(1, int64Depth / steps);
+                    int64Depth = int64Depth / speedup * speedup;  // make sure depth can be divided by speedup
+                    acousticInputs.Add(NamedOnnxValue.CreateFromTensor("depth",
+                        new DenseTensor<long>(new long[] { int64Depth }, new int[] { 1 }, false)));
+                } else {
+                    // find a largest integer speedup that are less than 1000 / steps and is a factor of 1000
+                    speedup = Math.Max(1, 1000 / steps);
+                    while (1000 % speedup != 0 && speedup > 1) {
+                        speedup--;
+                    }
+                }
+                acousticInputs.Add(NamedOnnxValue.CreateFromTensor("speedup",
+                    new DenseTensor<long>(new long[] { speedup }, new int[] { 1 }, false)));
             }
-            acousticInputs.Add(NamedOnnxValue.CreateFromTensor("speedup",
-                new DenseTensor<long>(new long[] { speedup }, new int[] { 1 },false)));
 
             //speaker
             if(singer.dsConfig.speakers != null) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -79,19 +79,18 @@ namespace OpenUtau.Core.DiffSinger {
 
                     // calculate real depth
                     var singer = (DiffSingerSinger) phrase.singer;
-                    double depth = Preferences.Default.DiffSingerDepth;
+                    double depth;
                     int steps = Preferences.Default.DiffSingerSteps;
                     if (singer.dsConfig.useVariableDepth) {
                         double maxDepth = singer.dsConfig.maxDepth;
                         if (maxDepth < 0) {
                             throw new InvalidDataException("Max depth is unset or is negative.");
                         }
-                        depth = Math.Min(depth, maxDepth);  // make sure depth <= K_step
+                        depth = Math.Min(Preferences.Default.DiffSingerDepth, maxDepth);
+                    } else {
+                        depth = 1.0;
                     }
-                    // format depth with 3 decimal places
-                    var wavName = singer.dsConfig.useVariableDepth
-                        ? $"ds-{phrase.hash:x16}-depth{depth:f2}-steps{steps}.wav"  // if the depth changes, phrase should be re-rendered
-                        : $"ds-{phrase.hash:x16}-steps{steps}.wav";  // preserve this for models without depth
+                    var wavName = $"ds-{phrase.hash:x16}-depth{depth:f2}-steps{steps}.wav";
                     var wavPath = Path.Join(PathManager.Inst.CachePath, wavName);
                     string progressInfo = $"Track {trackNo + 1}: {this} depth={depth:f2} steps={steps} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
                     if (File.Exists(wavPath)) {

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -142,8 +142,8 @@ namespace OpenUtau.Core.Util {
             public int WorldlineR = 0;
             public string OnnxRunner = string.Empty;
             public int OnnxGpu = 0;
-            public int DiffsingerSpeedup = 50;
-            public int DiffSingerDepth = 1000;
+            public double DiffSingerDepth = 1.0;
+            public int DiffSingerSteps = 20;
             public bool SkipRenderingMutedTracks = false;
             public string Language = string.Empty;
             public string? SortingOrder = null;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -368,7 +368,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>
+  <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>
   <system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>
   <system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>

--- a/OpenUtau/Strings/Strings.de-DE.axaml
+++ b/OpenUtau/Strings/Strings.de-DE.axaml
@@ -364,7 +364,7 @@ Warnung: Diese Option entfernt alle benutzerdefinierten Einstellungen.</system:S
   <!--<system:String x:Key="prefs.rendering">Rendering</system:String>-->
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <system:String x:Key="prefs.rendering.onnxrunner">Machinelles Lernen Runner</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">Phasenkompensation</system:String>

--- a/OpenUtau/Strings/Strings.es-ES.axaml
+++ b/OpenUtau/Strings/Strings.es-ES.axaml
@@ -364,7 +364,7 @@ Warning: this option removes custom presets.</system:String>-->
   <!--<system:String x:Key="prefs.rendering">Rendering</system:String>-->
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <!--<system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>-->

--- a/OpenUtau/Strings/Strings.es-MX.axaml
+++ b/OpenUtau/Strings/Strings.es-MX.axaml
@@ -360,7 +360,7 @@ Advertencia: Esta opción eliminará las bases personalizadas.</system:String>
   <system:String x:Key="prefs.rendering">Renderización</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">Compensación de fase</system:String>

--- a/OpenUtau/Strings/Strings.fi-FI.axaml
+++ b/OpenUtau/Strings/Strings.fi-FI.axaml
@@ -364,7 +364,7 @@ Warning: this option removes custom presets.</system:String>-->
   <system:String x:Key="prefs.rendering">Renderöi</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <!--<system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>-->

--- a/OpenUtau/Strings/Strings.fr-FR.axaml
+++ b/OpenUtau/Strings/Strings.fr-FR.axaml
@@ -360,7 +360,7 @@ Attention: cela va effacer le préréglage.</system:String>
   <system:String x:Key="prefs.rendering">En train de rendre...</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">Compensation de phase</system:String>

--- a/OpenUtau/Strings/Strings.id-ID.axaml
+++ b/OpenUtau/Strings/Strings.id-ID.axaml
@@ -366,7 +366,7 @@ Peringatan: opsi ini menghapus prasetel khusus.</system:String>
   <system:String x:Key="prefs.rendering">Merender</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Perender bawaan (untuk voicebank klasik)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">Kedalaman Render DiffSinger</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerspeedup">Kecepatan Render DiffSinger</system:String>
+  <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <system:String x:Key="prefs.rendering.onnxrunner">Penjalan Pembelajaran Mesin</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">Kompensasi Fase</system:String>

--- a/OpenUtau/Strings/Strings.it-IT.axaml
+++ b/OpenUtau/Strings/Strings.it-IT.axaml
@@ -364,7 +364,7 @@ Tieni premuto Ctrl per selezionare</system:String>
   <system:String x:Key="prefs.rendering">Renderizzazione</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">Compensazione di Fase</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -368,7 +368,7 @@
   <system:String x:Key="prefs.rendering">レンダリング</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Classic UTAU音源のデフォルトレンダラー</system:String>
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">位相補正</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -364,7 +364,7 @@
   <system:String x:Key="prefs.rendering">렌더링</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">기본 렌더러 (Classic 음원용)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger 렌더링 깊이(Depth)</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger 렌더링 가속</system:String>
+  <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>
   <system:String x:Key="prefs.rendering.onnxgpu">그래픽 카드(GPU)</system:String>
   <system:String x:Key="prefs.rendering.onnxrunner">머신러닝 실행 장치</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">위상 보정</system:String>

--- a/OpenUtau/Strings/Strings.nl-NL.axaml
+++ b/OpenUtau/Strings/Strings.nl-NL.axaml
@@ -360,7 +360,7 @@ Ctrl ingedrukt houden om te selecteren</system:String>
   <system:String x:Key="prefs.rendering">Renderen</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">Fase Compensatie</system:String>

--- a/OpenUtau/Strings/Strings.pl-PL.axaml
+++ b/OpenUtau/Strings/Strings.pl-PL.axaml
@@ -364,7 +364,7 @@ Warning: this option removes custom presets.</system:String>-->
   <system:String x:Key="prefs.rendering">Renderowanie</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <!--<system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>-->

--- a/OpenUtau/Strings/Strings.pt-BR.axaml
+++ b/OpenUtau/Strings/Strings.pt-BR.axaml
@@ -360,7 +360,7 @@ Segure Ctrl para selecionar</system:String>
   <system:String x:Key="prefs.rendering">Renderização</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">Compensação de Fase</system:String>

--- a/OpenUtau/Strings/Strings.ru-RU.axaml
+++ b/OpenUtau/Strings/Strings.ru-RU.axaml
@@ -360,7 +360,7 @@
   <system:String x:Key="prefs.rendering">Рендеринг</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Рендерер по-умолчанию (для классических войсбанков)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">Глубина рендеринга DiffSinger</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerspeedup">Ускорение рендеринга DiffSinger</system:String>
+  <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>
   <system:String x:Key="prefs.rendering.onnxgpu">Графический процессор</system:String>
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">Фазовая компенсация</system:String>

--- a/OpenUtau/Strings/Strings.th-TH.axaml
+++ b/OpenUtau/Strings/Strings.th-TH.axaml
@@ -360,7 +360,7 @@
   <system:String x:Key="prefs.rendering">กำลังประมวลผล</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">การชดเชย Phase</system:String>

--- a/OpenUtau/Strings/Strings.vi-VN.axaml
+++ b/OpenUtau/Strings/Strings.vi-VN.axaml
@@ -360,7 +360,7 @@ Nhấn giữ Ctrl để chọn nhiều nốt</system:String>
   <system:String x:Key="prefs.rendering">Render</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <!--<system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>-->

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -360,7 +360,7 @@
   <system:String x:Key="prefs.rendering">渲染</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">传统音源的默认渲染器</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger 渲染深度</system:String>
-  <system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger 渲染加速</system:String>
+  <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger 渲染步数</system:String>
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <system:String x:Key="prefs.rendering.onnxrunner">机器学习运行器</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">相位修正</system:String>

--- a/OpenUtau/Strings/Strings.zh-TW.axaml
+++ b/OpenUtau/Strings/Strings.zh-TW.axaml
@@ -360,7 +360,7 @@
   <system:String x:Key="prefs.rendering">算繪</system:String>
   <!--<system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>-->
   <!--<system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>-->
-  <!--<system:String x:Key="prefs.rendering.diffsingerspeedup">DiffSinger Render Speedup</system:String>-->
+  <!--<system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>-->
   <!--<system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>-->
   <system:String x:Key="prefs.rendering.phasecomp">相位補償</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -39,9 +39,9 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public string OnnxRunner { get; set; }
         public List<GpuInfo> OnnxGpuOptions { get; set; }
         [Reactive] public GpuInfo OnnxGpu { get; set; }
-        public List<int> DiffsingerSpeedupOptions { get; } = new List<int> { 1, 5, 10, 20, 50, 100 };
-        [Reactive] public int DiffSingerDepth { get; set; }
-        [Reactive] public int DiffsingerSpeedup { get; set; }
+        public List<int> DiffSingerStepsOptions { get; } = new List<int> { 2, 5, 10, 20, 50, 100, 200, 500, 1000 };
+        [Reactive] public double DiffSingerDepth { get; set; }
+        [Reactive] public int DiffSingerSteps { get; set; }
         [Reactive] public bool SkipRenderingMutedTracks { get; set; }
         [Reactive] public bool HighThreads { get; set; }
         [Reactive] public int Theme { get; set; }
@@ -139,8 +139,8 @@ namespace OpenUtau.App.ViewModels {
                OnnxRunnerOptions[0] : Preferences.Default.OnnxRunner;
             OnnxGpuOptions = Onnx.getGpuInfo();
             OnnxGpu = OnnxGpuOptions.FirstOrDefault(x => x.deviceId == Preferences.Default.OnnxGpu, OnnxGpuOptions[0]);
-            DiffSingerDepth = Preferences.Default.DiffSingerDepth;
-            DiffsingerSpeedup = Preferences.Default.DiffsingerSpeedup;
+            DiffSingerDepth = Preferences.Default.DiffSingerDepth * 100;
+            DiffSingerSteps = Preferences.Default.DiffSingerSteps;
             SkipRenderingMutedTracks = Preferences.Default.SkipRenderingMutedTracks;
             Theme = Preferences.Default.Theme;
             PenPlusDefault = Preferences.Default.PenPlusDefault;
@@ -325,14 +325,14 @@ namespace OpenUtau.App.ViewModels {
                     Preferences.Default.ClearCacheOnQuit = index;
                     Preferences.Save();
                 });
-            this.WhenAnyValue(vm => vm.DiffsingerSpeedup)
+            this.WhenAnyValue(vm => vm.DiffSingerSteps)
                 .Subscribe(index => {
-                    Preferences.Default.DiffsingerSpeedup = index;
+                    Preferences.Default.DiffSingerSteps = index;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.DiffSingerDepth)
                 .Subscribe(index => {
-                    Preferences.Default.DiffSingerDepth = index;
+                    Preferences.Default.DiffSingerDepth = index / 100;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.SkipRenderingMutedTracks)

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -130,19 +130,19 @@
             <TextBlock Text="{DynamicResource prefs.rendering.onnxgpu}" Margin="0,10,0,0"/>
             <ComboBox ItemsSource="{Binding OnnxGpuOptions}" SelectedItem="{Binding OnnxGpu}"/>
             <TextBlock Classes="restart"/>
-            <TextBlock Text="{DynamicResource prefs.rendering.diffsingerspeedup}" Margin="0,10,0,0"/>
-            <ComboBox HorizontalAlignment="Stretch"  ItemsSource="{Binding DiffsingerSpeedupOptions}" SelectedItem="{Binding DiffsingerSpeedup}"/>
+            <TextBlock Text="{DynamicResource prefs.rendering.diffsingersteps}" Margin="0,10,0,0"/>
+            <ComboBox HorizontalAlignment="Stretch"  ItemsSource="{Binding DiffSingerStepsOptions}" SelectedItem="{Binding DiffSingerSteps}"/>
             <Grid ColumnDefinitions="Auto,8,40,8,*" Margin="0,10,0,0">
                 <TextBlock Grid.Column="0" Text="{DynamicResource prefs.rendering.diffsingerdepth}"/>
                 <TextBlock Grid.Column="2">
                     <TextBlock.Text>
-                        <MultiBinding StringFormat="{}{0:#0}">
+                        <MultiBinding StringFormat="{}{0:#0}%">
                             <Binding Path="DiffSingerDepth"/>
                         </MultiBinding>
                     </TextBlock.Text>
                 </TextBlock>
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding DiffSingerDepth}" Minimum="0" Maximum="1000"
-                        TickPlacement="BottomRight" TickFrequency="20" IsSnapToTickEnabled="true"/>
+                <Slider Grid.Column="4" Classes="fader" Value="{Binding DiffSingerDepth}" Minimum="0" Maximum="100"
+                        TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
             </Grid>
             <Grid>
               <TextBlock Text="{DynamicResource prefs.rendering.skipmuted}" HorizontalAlignment="Left"/>


### PR DESCRIPTION
This PR adds support for the next DiffSinger release of Rectified Flow models. This is also a migration from the previous discrete acceleration to the new continuous acceleration.

Major changes:

- DiffSinger rendering depth becomes a float ratio instead of a integer step. This value is 1/1000 of the former value for discrete acceleration.
- DiffSinger speedup is replaced by sampling steps. Old preferences will not be inherited because its definition has changed.
- The `use_shallow_diffusion` key in dsconfig.yaml is renamed to `use_variable_depth`. The old key still takes effects.
- A new `use_continuous_acceleration` key is added into dsconfig.yaml.
- The `max_depth` key in dsconfig.yaml becomes a float for models with continuous acceleration profiles.
- Old cache files will expire due to changes in the filename pattern.