### PR TITLE
Improved translation of error messages for more flexibility

### DIFF
--- a/OpenUtau.Core/Classic/Frq.cs
+++ b/OpenUtau.Core/Classic/Frq.cs
@@ -135,7 +135,8 @@ namespace OpenUtau.Classic {
                 }
                 return true;
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.load", ": frq file", e));
+                var customEx = new MessageCustomizableException("Failed to load frq file", "<translate:errors.failed.load>: frq file", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 return false;
             }
         }

--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -23,21 +23,17 @@ namespace OpenUtau.Core {
             this.message = message;
             this.e = e;
         }
-        public override string ToString() => $"Error message: {message} {e}";
-    }
-
-    public class ErrorMessageNotificationWithTranslation : ErrorMessageNotification {
-        public readonly string stringKey = string.Empty;
-        public ErrorMessageNotificationWithTranslation(string stringKey) : base(string.Empty) {
-            this.stringKey = stringKey;
+        public override string ToString() {
+            if (e is MessageCustomizableException mce) {
+                if (string.IsNullOrWhiteSpace(mce.Message)) {
+                    return $"Error message: {mce.SubstanceException.Message} {mce.SubstanceException}";
+                } else {
+                    return $"Error message: {mce.Message} {mce.SubstanceException}";
+                }
+            } else {
+                return $"Error message: {message} {e}";
+            }
         }
-        public ErrorMessageNotificationWithTranslation(string stringKey, Exception e) : base(e) {
-            this.stringKey = stringKey;
-        }
-        public ErrorMessageNotificationWithTranslation(string stringKey, string additionalMessage, Exception e) : base(additionalMessage, e) {
-            this.stringKey = stringKey;
-        }
-        public override string ToString() => $"Error message: {stringKey}{message} {e}";
     }
 
     public class LoadingNotification : UNotification {

--- a/OpenUtau.Core/DiffSinger/DiffSingerVocoder.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVocoder.cs
@@ -29,7 +29,7 @@ namespace OpenUtau.Core.DiffSinger {
                 model = File.ReadAllBytes(Path.Combine(Location, config.model));
             }
             catch (Exception ex) {
-                throw new Exception($"Error loading vocoder {name}. Please download vocoder from https://github.com/xunmengshe/OpenUtau/wiki/Vocoders");
+                throw new MessageCustomizableException($"Error loading vocoder {name}", $"<translate:errors.diffsinger.downloadvocoder1>{name}<translate:errors.diffsinger.downloadvocoder2>https://github.com/xunmengshe/OpenUtau/wiki/Vocoders", new Exception($"Error loading vocoder {name}"));
             }
             session = Onnx.getInferenceSession(model);
         }

--- a/OpenUtau.Core/PlaybackManager.cs
+++ b/OpenUtau.Core/PlaybackManager.cs
@@ -132,7 +132,8 @@ namespace OpenUtau.Core {
                 } catch (Exception e) {
                     Log.Error(e, "Failed to render.");
                     StopPlayback();
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.render", e));
+                    var customEx = new MessageCustomizableException("Failed to render.", "<translate:errors.failed.render>", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 }
             });
         }
@@ -161,10 +162,12 @@ namespace OpenUtau.Core {
                     WaveFileWriter.CreateWaveFile16(exportPath, new ExportAdapter(projectMix).ToMono(1, 0));
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exported to {exportPath}."));
                 } catch (IOException ioe) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.export", $": {exportPath}", ioe));
+                    var customEx = new MessageCustomizableException($"Failed to export {exportPath}.", $"<translate:errors.failed.export>: {exportPath}", ioe);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Failed to export {exportPath}."));
                 } catch (Exception e) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.render", e));
+                    var customEx = new MessageCustomizableException("Failed to render.", $"<translate:errors.failed.render>: {exportPath}", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Failed to render."));
                 }
             });
@@ -189,10 +192,12 @@ namespace OpenUtau.Core {
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exported to {file}."));
                     }
                 } catch (IOException ioe) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.export", $": {file}", ioe));
+                    var customEx = new MessageCustomizableException($"Failed to export {file}.", $"<translate:errors.failed.export>: {file}", ioe);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Failed to export {file}."));
                 } catch (Exception e) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.render", e));
+                    var customEx = new MessageCustomizableException("Failed to render.", "<translate:errors.failed.render>", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Failed to render."));
                 }
             });

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -107,7 +107,8 @@ namespace OpenUtau.Core.Render {
                 if (task.IsFaulted && !wait) {
                     Log.Error(task.Exception.Flatten(), "Failed to render.");
                     PlaybackManager.Inst.StopPlayback();
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.render", task.Exception));
+                    var customEx = new MessageCustomizableException("Failed to render.", "<translate:errors.failed.render>", task.Exception);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 }
             }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, uiScheduler);
             if (wait) {

--- a/OpenUtau.Core/Util/MessageCustomizableException.cs
+++ b/OpenUtau.Core/Util/MessageCustomizableException.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace OpenUtau.Core {
+    public class MessageCustomizableException : Exception {
+
+        public override string Message { get; } = string.Empty;
+        public string TranslatableMessage { get; set; } = string.Empty;
+        public Exception SubstanceException { get; }
+        public bool ShowStackTrace { get; } = true;
+
+        /// <summary>
+        /// This allows the use of translatable messages and the hiding of stack traces in the message box.
+        /// <summary>
+        /// <paramref name="message">untranslated message</paramref>
+        /// <paramref name="translatableMessage">By enclosing the resource key with a tag like "<translate:key>", only that part will be translated.</paramref>
+        /// <paramref name="e">underlying exception</paramref>
+        public MessageCustomizableException(string message, string translatableMessage, Exception e) {
+            Message = message;
+            TranslatableMessage = translatableMessage;
+            SubstanceException = e;
+        }
+
+        /// <summary>
+        /// This allows the use of translatable messages and the hiding of stack traces in the message box.
+        /// <summary>
+        /// <paramref name="message">untranslated message</paramref>
+        /// <paramref name="translatableMessage">By enclosing the resource key with a tag like "<translate:key>", only that part will be translated.</paramref>
+        /// <paramref name="e">underlying exception</paramref>
+        /// <paramref name="showStackTrace">Can be omitted. Default is true.</paramref>
+        public MessageCustomizableException(string message, string translatableMessage, Exception e, bool showStackTrace) {
+            Message = message;
+            TranslatableMessage = translatableMessage;
+            SubstanceException = e;
+            ShowStackTrace = showStackTrace;
+        }
+    }
+}

--- a/OpenUtau.Core/Util/MessageCustomizableException.cs
+++ b/OpenUtau.Core/Util/MessageCustomizableException.cs
@@ -33,5 +33,9 @@ namespace OpenUtau.Core {
             SubstanceException = e;
             ShowStackTrace = showStackTrace;
         }
+
+        public override string ToString() {
+            return SubstanceException.ToString();
+        }
     }
 }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -62,13 +62,27 @@
 
   <system:String x:Key="errors.caption">Error</system:String>
   <system:String x:Key="errors.details">Error Details</system:String>
+  <system:String x:Key="errors.diffsinger.downloadvocoder1">Error loading vocoder </system:String>
+  <system:String x:Key="errors.diffsinger.downloadvocoder2">. Please download vocoder from </system:String>
+  <system:String x:Key="errors.expression.abbrlong">Abbreviation must be between 1 and 4 characters long</system:String>
+  <system:String x:Key="errors.expression.abbrset">Abbreviation must be set</system:String>
+  <system:String x:Key="errors.expression.abbrunique">Abbreviations must be unique</system:String>
+  <system:String x:Key="errors.expression.default">Default value must be between min and max</system:String>
+  <system:String x:Key="errors.expression.flagunique">Flags must be unique</system:String>
+  <system:String x:Key="errors.expression.min">Min must be smaller than max</system:String>
+  <system:String x:Key="errors.expression.name">Name must be set</system:String>
   <system:String x:Key="errors.failed.export">Failed to export</system:String>
+  <system:String x:Key="errors.failed.importfiles">Failed to import files</system:String>
+  <system:String x:Key="errors.failed.importaudio">Failed to import audio</system:String>
+  <system:String x:Key="errors.failed.importmidi">Failed to import midi</system:String>
   <system:String x:Key="errors.failed.load">Failed to load</system:String>
-  <system:String x:Key="errors.failed.open">Failed to open</system:String>
-  <system:String x:Key="errors.failed.render">Failed to render.</system:String>
-  <system:String x:Key="errors.failed.runeditingmacro">Failed to run editing macro.</system:String>
+  <system:String x:Key="errors.failed.loadprefs">Failed to load prefs. Initialize it.</system:String>
+  <system:String x:Key="errors.failed.openfile">Failed to open</system:String>
+  <system:String x:Key="errors.failed.openlocation">Failed to open location</system:String>
+  <system:String x:Key="errors.failed.render">Failed to render</system:String>
+  <system:String x:Key="errors.failed.runeditingmacro">Failed to run editing macro</system:String>
   <system:String x:Key="errors.failed.save">Failed to save</system:String>
-  <system:String x:Key="errors.failed.savesingerconfig">Failed to save singer config file.</system:String>
+  <system:String x:Key="errors.failed.savesingerconfig">Failed to save singer config file</system:String>
 
   <system:String x:Key="exps.abbr">Abbreviation</system:String>
   <system:String x:Key="exps.apply">Apply</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -62,13 +62,27 @@
 
   <system:String x:Key="errors.caption">エラー</system:String>
   <system:String x:Key="errors.details">エラーの詳細</system:String>
+  <system:String x:Key="errors.diffsinger.downloadvocoder1">ボコーダー </system:String>
+  <system:String x:Key="errors.diffsinger.downloadvocoder2"> のロードに失敗しました。未インストールの場合、以下のURLからダウンロードしてください: </system:String>
+  <system:String x:Key="errors.expression.abbrlong">パラメータの略称は1～4文字で入力してください</system:String>
+  <system:String x:Key="errors.expression.abbrset">パラメータの略称を入力してください</system:String>
+  <system:String x:Key="errors.expression.abbrunique">パラメータの略称が重複しています</system:String>
+  <system:String x:Key="errors.expression.default">デフォルト値は最小値以上、最大値以下にしてください</system:String>
+  <system:String x:Key="errors.expression.flagunique">フラグが重複しています</system:String>
+  <system:String x:Key="errors.expression.min">最小値は最大値より小さくしてください</system:String>
+  <system:String x:Key="errors.expression.name">表情名を入力してください</system:String>
   <system:String x:Key="errors.failed.export">エクスポートに失敗しました</system:String>
+  <system:String x:Key="errors.failed.importfiles">ファイルのインポートに失敗しました</system:String>
+  <system:String x:Key="errors.failed.importaudio">オーディオのインポートに失敗しました</system:String>
+  <system:String x:Key="errors.failed.importmidi">MIDIのインポートに失敗しました</system:String>
   <system:String x:Key="errors.failed.load">読み込みに失敗しました</system:String>
-  <system:String x:Key="errors.failed.open">読み込みに失敗しました</system:String>
-  <system:String x:Key="errors.failed.render">レンダリングに失敗しました。</system:String>
-  <system:String x:Key="errors.failed.runeditingmacro">一括処理に失敗しました。</system:String>
+  <system:String x:Key="errors.failed.loadprefs">環境設定の読み込みに失敗しました。設定を初期化します。</system:String>
+  <system:String x:Key="errors.failed.openfile">読み込みに失敗しました</system:String>
+  <system:String x:Key="errors.failed.openlocation">フォルダを開けませんでした</system:String>
+  <system:String x:Key="errors.failed.render">レンダリングに失敗しました</system:String>
+  <system:String x:Key="errors.failed.runeditingmacro">一括処理に失敗しました</system:String>
   <system:String x:Key="errors.failed.save">保存に失敗しました</system:String>
-  <system:String x:Key="errors.failed.savesingerconfig">シンガー設定の保存に失敗しました。</system:String>
+  <system:String x:Key="errors.failed.savesingerconfig">シンガー設定の保存に失敗しました</system:String>
 
   <system:String x:Key="exps.abbr">パラメータの略称</system:String>
   <system:String x:Key="exps.apply">適用</system:String>

--- a/OpenUtau/ViewModels/EditSubbanksViewModel.cs
+++ b/OpenUtau/ViewModels/EditSubbanksViewModel.cs
@@ -109,7 +109,8 @@ namespace OpenUtau.App.ViewModels {
                 }
                 SelectedColor = Colors[0];
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.load", ": subbanks", e));
+                var customEx = new MessageCustomizableException("Failed to load subbanks", "<translate:errors.failed.load>: subbanks", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
         }
 
@@ -184,7 +185,8 @@ namespace OpenUtau.App.ViewModels {
                     bankConfig.Save(stream);
                 }
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.save", ": subbanks", e));
+                var customEx = new MessageCustomizableException("Failed to save subbanks", "<translate:errors.failed.save>: subbanks", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
             LoadSubbanks();
         }

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -63,7 +63,8 @@ namespace OpenUtau.App.ViewModels {
                 try {
                     OpenProject(new[] { file });
                 } catch (Exception e) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.open", ": recent project", e));
+                    var customEx = new MessageCustomizableException("Failed to open recent", "<translate:errors.failed.openfile>: recent project", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 }
             });
             OpenTemplateCommand = ReactiveCommand.Create<string>(file => {
@@ -72,7 +73,8 @@ namespace OpenUtau.App.ViewModels {
                     DocManager.Inst.Project.Saved = false;
                     DocManager.Inst.Project.FilePath = string.Empty;
                 } catch (Exception e) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.open", ": project template", e));
+                    var customEx = new MessageCustomizableException("Failed to open template", "<translate:errors.failed.openfile>: project template", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 }
             });
             PartDeleteCommand = ReactiveCommand.Create<UPart>(part => {
@@ -111,7 +113,8 @@ namespace OpenUtau.App.ViewModels {
                     DocManager.Inst.Project.FilePath = string.Empty;
                     return;
                 } catch (Exception e) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.load", ": default template", e));
+                    var customEx = new MessageCustomizableException("Failed to load default template", "<translate:errors.failed.load>: default template", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 }
             }
             DocManager.Inst.ExecuteCmd(new LoadProjectNotification(Core.Format.Ustx.Create()));

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -171,7 +171,8 @@ namespace OpenUtau.App.ViewModels {
                     try{
                         edit.Run(NotesViewModel.Project, NotesViewModel.Part, NotesViewModel.Selection.ToList(), DocManager.Inst);
                     } catch (Exception e) {
-                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.runeditingmacro", e));
+                        var customEx = new MessageCustomizableException("Failed to run editing macro", "<translate:errors.failed.runeditingmacro>", e);
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                     }
                 }
             });

--- a/OpenUtau/ViewModels/SingersViewModel.cs
+++ b/OpenUtau/ViewModels/SingersViewModel.cs
@@ -159,7 +159,8 @@ namespace OpenUtau.App.ViewModels {
                 ModifyConfig(Singer, config => config.TextFileEncoding = encoding.WebName);
                 Refresh();
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.savesingerconfig", e));
+                var customEx = new MessageCustomizableException("Failed to save singer config", "<translate:errors.failed.savesingerconfig>", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
         }
 
@@ -171,7 +172,8 @@ namespace OpenUtau.App.ViewModels {
                 ModifyConfig(Singer, config => config.Image = filepath);
                 Refresh();
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.savesingerconfig", e));
+                var customEx = new MessageCustomizableException("Failed to save singer config", "<translate:errors.failed.savesingerconfig>", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
         }
 
@@ -183,7 +185,8 @@ namespace OpenUtau.App.ViewModels {
                 ModifyConfig(Singer, config => config.Portrait = filepath);
                 Refresh();
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.savesingerconfig", e));
+                var customEx = new MessageCustomizableException("Failed to save singer config", "<translate:errors.failed.savesingerconfig>", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
         }
 
@@ -195,7 +198,8 @@ namespace OpenUtau.App.ViewModels {
                 ModifyConfig(Singer, config => config.SingerType = singerType);
                 Refresh();
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.savesingerconfig", e));
+                var customEx = new MessageCustomizableException("Failed to save singer config", "<translate:errors.failed.savesingerconfig>", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
         }
 
@@ -207,7 +211,8 @@ namespace OpenUtau.App.ViewModels {
                 ModifyConfig(Singer, config => config.DefaultPhonemizer = factory.type.FullName ?? string.Empty);
                 Refresh();
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.savesingerconfig", e));
+                var customEx = new MessageCustomizableException("Failed to save singer config", "<translate:errors.failed.savesingerconfig>", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
         }
 
@@ -219,7 +224,8 @@ namespace OpenUtau.App.ViewModels {
                 ModifyConfig(Singer, config => config.UseFilenameAsAlias = !this.UseFilenameAsAlias);
                 Refresh();
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.savesingerconfig", e));
+                var customEx = new MessageCustomizableException("Failed to save singer config", "<translate:errors.failed.savesingerconfig>", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
         }
 
@@ -338,7 +344,8 @@ namespace OpenUtau.App.ViewModels {
             try {
                 Subbanks.AddRange(Singer.Subbanks);
             } catch (Exception e) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.load", ": subbanks", e));
+                var customEx = new MessageCustomizableException("Failed to load subbanks", "<translate:errors.failed.load>: subbanks", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
             }
         }
 

--- a/OpenUtau/Views/EditSubbanksDialog.axaml.cs
+++ b/OpenUtau/Views/EditSubbanksDialog.axaml.cs
@@ -83,7 +83,8 @@ namespace OpenUtau.App.Views {
                         }
                     }
                 } catch (Exception e) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.load", ": prefix map", e));
+                    var customEx = new MessageCustomizableException("Failed to load prefix map", "<translate:errors.failed.load>: prefix map", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 }
             }
         }
@@ -102,7 +103,8 @@ namespace OpenUtau.App.Views {
                             }
                         }
                     } catch (Exception e) {
-                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.save", ": prefix map", e));
+                        var customEx = new MessageCustomizableException("Failed to save prefix map", "<translate:errors.failed.save>: prefix map", e);
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                     }
                 }
             }

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -174,8 +174,8 @@ namespace OpenUtau.App.Views {
                         DocManager.Inst.EndUndoGroup();
                     }
                 } catch (Exception e) {
-                    Log.Error(e, "Failed to open project location.");
-                    MessageBox.ShowError(this, e);
+                    Log.Error(e, "Failed to open project location");
+                    MessageBox.ShowError(this, new MessageCustomizableException("Failed to open project location", "<translate:errors.failed.openlocation>: project location", e));
                 }
             };
             dialog.ShowDialog(this);
@@ -229,7 +229,7 @@ namespace OpenUtau.App.Views {
                 viewModel.OpenProject(files);
             } catch (Exception e) {
                 Log.Error(e, $"Failed to open files {string.Join("\n", files)}");
-                _ = await MessageBox.ShowError(this, e);
+                _ = await MessageBox.ShowError(this, new MessageCustomizableException($"Failed to open files {string.Join("\n", files)}", $"<translate:errors.failed.openfile>:\n{string.Join("\n", files)}", e));
             }
         }
 
@@ -265,7 +265,7 @@ namespace OpenUtau.App.Views {
                 }
             } catch (Exception e) {
                 Log.Error(e, "Failed to open project location.");
-                MessageBox.ShowError(this, e);
+                MessageBox.ShowError(this, new MessageCustomizableException("Failed to open project location.", "<translate:errors.failed.openlocation>: project location", e));
             }
         }
 
@@ -351,7 +351,7 @@ namespace OpenUtau.App.Views {
                 viewModel.ImportTracks(loadedProjects, importTempo);
             } catch (Exception e) {
                 Log.Error(e, $"Failed to import files");
-                _ = await MessageBox.ShowError(this, e);
+                _ = await MessageBox.ShowError(this, new MessageCustomizableException("Failed to import files", "<translate:errors.failed.importfiles>", e));
             }
             ValidateTracksVoiceColor();
         }
@@ -366,7 +366,7 @@ namespace OpenUtau.App.Views {
                 viewModel.ImportAudio(file);
             } catch (Exception e) {
                 Log.Error(e, "Failed to import audio");
-                _ = await MessageBox.ShowError(this, e);
+                _ = await MessageBox.ShowError(this, new MessageCustomizableException("Failed to import audio", "<translate:errors.failed.importaudio>", e));
             }
         }
 
@@ -380,7 +380,7 @@ namespace OpenUtau.App.Views {
                 viewModel.ImportMidi(file, UseDrywetmidi);
             } catch (Exception e) {
                 Log.Error(e, "Failed to import midi");
-                _ = await MessageBox.ShowError(this, e);
+                _ = await MessageBox.ShowError(this, new MessageCustomizableException("Failed to import midi", "<translate:errors.failed.importmidi>", e));
             }
         }
 
@@ -594,15 +594,16 @@ namespace OpenUtau.App.Views {
             if (file == null) {
                 return;
             }
-            if (file.EndsWith(Core.Vogen.VogenSingerInstaller.FileExt)) {
-                Core.Vogen.VogenSingerInstaller.Install(file);
-                return;
-            }
-            if (file.EndsWith(DependencyInstaller.FileExt)) {
-                DependencyInstaller.Install(file);
-                return;
-            }
             try {
+                if (file.EndsWith(Core.Vogen.VogenSingerInstaller.FileExt)) {
+                    Core.Vogen.VogenSingerInstaller.Install(file);
+                    return;
+                }
+                if (file.EndsWith(DependencyInstaller.FileExt)) {
+                    DependencyInstaller.Install(file);
+                    return;
+                }
+
                 var setup = new SingerSetupDialog() {
                     DataContext = new SingerSetupViewModel() {
                         ArchiveFilePath = file,
@@ -635,7 +636,7 @@ namespace OpenUtau.App.Views {
                 dataContext = new PreferencesViewModel();
             } catch (Exception e) {
                 Log.Error(e, "Failed to load prefs. Initialize it.");
-                MessageBox.ShowError(this, e);
+                MessageBox.ShowError(this, new MessageCustomizableException("Failed to load prefs. Initialize it.", "<translate:errors.failed.loadprefs>", e));
                 Preferences.Reset();
                 dataContext = new PreferencesViewModel();
             }
@@ -841,14 +842,14 @@ namespace OpenUtau.App.Views {
                     viewModel.OpenProject(new string[] { file });
                 } catch (Exception e) {
                     Log.Error(e, $"Failed to open file {file}");
-                    _ = await MessageBox.ShowError(this, e);
+                    _ = await MessageBox.ShowError(this, new MessageCustomizableException($"Failed to open file {file}", $"<translate:errors.failed.openfile>: {file}", e));
                 }
             } else if (ext == ".mid" || ext == ".midi") {
                 try {
                     viewModel.ImportMidi(file);
                 } catch (Exception e) {
                     Log.Error(e, "Failed to import midi");
-                    _ = await MessageBox.ShowError(this, e);
+                    _ = await MessageBox.ShowError(this, new MessageCustomizableException("Failed to import midi", "<translate:errors.failed.importmidi>", e));
                 }
             } else if (ext == ".zip" || ext == ".rar" || ext == ".uar") {
                 var setup = new SingerSetupDialog() {
@@ -893,7 +894,7 @@ namespace OpenUtau.App.Views {
                     viewModel.ImportAudio(file);
                 } catch (Exception e) {
                     Log.Error(e, "Failed to import audio");
-                    _ = await MessageBox.ShowError(this, e);
+                    _ = await MessageBox.ShowError(this, new MessageCustomizableException("Failed to import audio", "<translate:errors.failed.importaudio>", e));
                 }
             } else {
                 _ = await MessageBox.Show(
@@ -1328,11 +1329,7 @@ namespace OpenUtau.App.Views {
                            MessageBox.MessageBoxButtons.Ok);
                         break;
                     default:
-                        if (notif is ErrorMessageNotificationWithTranslation translatedNotif) {
-                            MessageBox.ShowError(this, ThemeManager.GetString(translatedNotif.stringKey) + translatedNotif.message, translatedNotif.e);
-                        } else {
-                            MessageBox.ShowError(this, notif.message, notif.e);
-                        }
+                        MessageBox.ShowError(this, notif.message, notif.e);
                         break;
                 }
             } else if (cmd is LoadingNotification loadingNotif && loadingNotif.window == typeof(MainWindow)) {

--- a/OpenUtau/Views/MessageBox.axaml.cs
+++ b/OpenUtau/Views/MessageBox.axaml.cs
@@ -55,8 +55,18 @@ namespace OpenUtau.App.Views {
                     builder.AppendLine(ae.InnerExceptions.First().Message);
                     builder.AppendLine();
                     builder.Append(ae.ToString());
-                    if (string.IsNullOrEmpty(text)) {
-                        text = ae.InnerExceptions.First().Message;
+
+                    if (!string.IsNullOrWhiteSpace(text)) {
+                        text += "\n";
+                    }
+                    if (ae.InnerExceptions.First() is MessageCustomizableException innnerMce) {
+                        if (!string.IsNullOrEmpty(innnerMce.TranslatableMessage)) {
+                            var matches = Regex.Matches(innnerMce.TranslatableMessage, "<translate:(.*?)>");
+                            matches.ForEach(m => innnerMce.TranslatableMessage = innnerMce.TranslatableMessage.Replace(m.Value, ThemeManager.GetString(m.Groups[1].Value)));
+                            text += innnerMce.TranslatableMessage;
+                        } else {
+                            text += ae.InnerExceptions.First().Message;
+                        }
                     }
                 } else {
                     builder.AppendLine(e.Message);

--- a/OpenUtau/Views/MessageBox.axaml.cs
+++ b/OpenUtau/Views/MessageBox.axaml.cs
@@ -6,7 +6,9 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
+using OpenUtau.Core;
 using Serilog;
+using SharpCompress;
 
 namespace OpenUtau.App.Views {
     public partial class MessageBox : Window {
@@ -31,6 +33,20 @@ namespace OpenUtau.App.Views {
 
         public static Task<MessageBoxResult> ShowError(Window parent, string message, Exception? e) {
             string text = message;
+            string title = ThemeManager.GetString("errors.caption");
+
+            if (e is MessageCustomizableException mce) {
+                if (!string.IsNullOrEmpty(mce.TranslatableMessage)) {
+                    var matches = Regex.Matches(mce.TranslatableMessage, "<translate:(.*?)>");
+                    matches.ForEach(m => mce.TranslatableMessage = mce.TranslatableMessage.Replace(m.Value, ThemeManager.GetString(m.Groups[1].Value)));
+                    text = mce.TranslatableMessage;
+                    e = mce.SubstanceException;
+                }
+
+                if (!mce.ShowStackTrace) {
+                    return Show(parent, text, null, title, MessageBoxButtons.Ok);
+                }
+            }
 
             var builder = new StringBuilder();
             if (e != null) {
@@ -54,7 +70,6 @@ namespace OpenUtau.App.Views {
             builder.AppendLine();
             builder.AppendLine();
             builder.AppendLine(System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "Unknown Version");
-            string title = ThemeManager.GetString("errors.caption");
 
             return Show(parent, text, builder.ToString(), title, MessageBoxButtons.OkCopy);
         }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -245,7 +245,8 @@ namespace OpenUtau.App.Views {
                         try {
                             edit.Run(notesVM.Project, notesVM.Part, notesVM.Selection.ToList(), DocManager.Inst);
                         } catch (Exception e) {
-                            DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.runeditingmacro", e));
+                            var customEx = new MessageCustomizableException("Failed to run editing macro", "<translate:errors.failed.runeditingmacro>", e);
+                            DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                         }
                     }
                 }
@@ -273,7 +274,8 @@ namespace OpenUtau.App.Views {
                 try {
                     edit.Run(notesVM.Project, notesVM.Part, notesVM.Selection.ToList(), DocManager.Inst);
                 } catch (Exception e) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotificationWithTranslation("errors.failed.runeditingmacro", e));
+                    var customEx = new MessageCustomizableException("Failed to run editing macro", "<translate:errors.failed.runeditingmacro>", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 }
             };
             dialog.ShowDialog(this);


### PR DESCRIPTION
Improvement points
- Parts that were not translatable at #1086 can now be translated!
- Added option to hide stack traces (only if seriously unnecessary)

Changes:
- Changed the way to throw translation messages: ErrorMessageNotificationWithTranslation -> MessageCustomizableException
- It is now possible to translate only a part of the text
![image](https://github.com/stakira/OpenUtau/assets/130257355/a7836fc0-d067-4fca-aa10-e865be9ede00)


I have not yet translated all messages.