### PR TITLE
[WIP don't merge] Load custom plugins from singer folders

### DIFF
--- a/OpenUtau.Core/DocManager.cs
+++ b/OpenUtau.Core/DocManager.cs
@@ -77,6 +77,9 @@ namespace OpenUtau.Core {
                     File.Delete(oldBuiltin);
                 }
                 files.AddRange(Directory.EnumerateFiles(PathManager.Inst.PluginsPath, "*.dll", SearchOption.AllDirectories));
+                // Load plugins from singer folders; useful for custom phonemizers and/or other custom supported plugins
+                files.AddRange(Directory.EnumerateFiles(PathManager.Inst.SingersPath, "*.dll", SearchOption.AllDirectories));
+                files.AddRange(Directory.EnumerateFiles(PathManager.Inst.AdditionalSingersPath, "*.dll", SearchOption.AllDirectories));
             } catch (Exception e) {
                 Log.Error(e, "Failed to search plugins.");
             }


### PR DESCRIPTION
Adds the ability to load plugins from the singer folders, e.g. custom phonemizers. This might make it easier to use plugins specifically tailored to one specific voicebank.

I'm not entirely sure if this function will fit within the scope of the software; there has certainly been demand, but I'm okay with it if it's not desired.

**TODO:** Avoid loading duplicate files? (Still researching)