### PR TITLE
fix tool selection bug when default pen is pen plus

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -206,13 +206,8 @@ namespace OpenUtau.App.ViewModels {
             KnifeTool = false;
             SelectToolCommand = ReactiveCommand.Create<string>(index => {
                 CursorTool = index == "1";
-                if (Preferences.Default.PenPlusDefault) {
-                    PenPlusTool = index == "2";
-                    PenTool = index == "2+";
-                } else {
-                    PenTool = index == "2";
-                    PenPlusTool = index == "2+";
-                }
+                PenTool = index == "2";
+                PenPlusTool = index == "2+";
                 EraserTool = index == "3";
                 DrawPitchTool = index == "4";
                 KnifeTool = index == "5";

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -997,6 +997,9 @@ namespace OpenUtau.App.Views {
                 return true;
             }
 
+            string mainPenIdx = Preferences.Default.PenPlusDefault ? "2+" : "2";
+            string altPenIdx = Preferences.Default.PenPlusDefault ? "2" : "2+";
+
             switch (args.Key) {
                 #region document keys
                 case Key.Space:
@@ -1060,7 +1063,7 @@ namespace OpenUtau.App.Views {
                     break;
                 case Key.D2:
                     if (isNone) {
-                        notesVm.SelectToolCommand?.Execute("2").Subscribe();
+                        notesVm.SelectToolCommand?.Execute(mainPenIdx).Subscribe();
                         return true;
                     }
                     if (isAlt) {
@@ -1068,7 +1071,7 @@ namespace OpenUtau.App.Views {
                         return true;
                     }
                     if (isCtrl) {
-                        notesVm.SelectToolCommand?.Execute("2+").Subscribe();
+                        notesVm.SelectToolCommand?.Execute(altPenIdx).Subscribe();
                         return true;
                     }
                     break;


### PR DESCRIPTION
moves the selection logic for default pen to `OnKeyExtendedHandler`

fixes buggy behavior when clicking on the pen tools with the default pen as pen plus