### PR TITLE
Fix loading and error dialog

### DIFF
--- a/OpenUtau.Core/SingerManager.cs
+++ b/OpenUtau.Core/SingerManager.cs
@@ -45,7 +45,8 @@ namespace OpenUtau.Core {
                 stopWatch.Stop();
                 Log.Information($"Search all singers: {stopWatch.Elapsed}");
             } catch (Exception e) {
-                Log.Error(e, "Failed to search singers.");
+                var customEx = new MessageCustomizableException("Failed to search singers", "<translate:errors.failed.searchsinger>", e);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 Singers = new Dictionary<string, USinger>();
             }
         }

--- a/OpenUtau.Core/SingerManager.cs
+++ b/OpenUtau.Core/SingerManager.cs
@@ -45,14 +45,18 @@ namespace OpenUtau.Core {
                 stopWatch.Stop();
                 Log.Information($"Search all singers: {stopWatch.Elapsed}");
             } catch (Exception e) {
-                var customEx = new MessageCustomizableException("Failed to search singers", "<translate:errors.failed.searchsinger>", e);
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
+                if (InitializationTask.Status == TaskStatus.Running) {
+                    Log.Error(e, "Failed to search singers.");
+                } else {
+                    var customEx = new MessageCustomizableException("Failed to search singers.", "<translate:errors.failed.searchsinger>", e);
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
+                }
                 Singers = new Dictionary<string, USinger>();
             }
         }
 
         public USinger GetSinger(string name) {
-            Log.Information(name);
+            Log.Information($"Attach singer to track: {name}");
             name = name.Replace("%VOICE%", "");
             if (Singers.ContainsKey(name)) {
                 return Singers[name];

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -83,6 +83,7 @@
   <system:String x:Key="errors.failed.runeditingmacro">Failed to run editing macro</system:String>
   <system:String x:Key="errors.failed.save">Failed to save</system:String>
   <system:String x:Key="errors.failed.savesingerconfig">Failed to save singer config file</system:String>
+  <system:String x:Key="errors.failed.searchsinger">Failed to search singers</system:String>
 
   <system:String x:Key="exps.abbr">Abbreviation</system:String>
   <system:String x:Key="exps.apply">Apply</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -83,6 +83,7 @@
   <system:String x:Key="errors.failed.runeditingmacro">一括処理に失敗しました</system:String>
   <system:String x:Key="errors.failed.save">保存に失敗しました</system:String>
   <system:String x:Key="errors.failed.savesingerconfig">シンガー設定の保存に失敗しました</system:String>
+  <system:String x:Key="errors.failed.searchsinger">シンガーの取得に失敗しました</system:String>
 
   <system:String x:Key="exps.abbr">パラメータの略称</system:String>
   <system:String x:Key="exps.apply">適用</system:String>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -557,7 +557,7 @@ namespace OpenUtau.App.Views {
                 return;
             }
 
-            DocManager.Inst.ExecuteCmd(new LoadingNotification(typeof(MainWindow), true, "singers window"));
+            MessageBox.ShowLoading(this);
             var dialog = lifetime.Windows.FirstOrDefault(w => w is SingersDialog);
             try {
                 if (dialog == null) {
@@ -581,7 +581,7 @@ namespace OpenUtau.App.Views {
             } catch (Exception e) {
                 DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(e));
             } finally {
-                DocManager.Inst.ExecuteCmd(new LoadingNotification(typeof(MainWindow), false, "singers window"));
+                MessageBox.CloseLoading();
             }
             if (dialog != null) {
                 dialog.Activate();
@@ -1078,12 +1078,12 @@ namespace OpenUtau.App.Views {
             var control = canvas.InputHitTest(args.GetPosition(canvas));
             if (control is PartControl partControl && partControl.part is UVoicePart) {
                 if (pianoRollWindow == null) {
-                    DocManager.Inst.ExecuteCmd(new LoadingNotification(typeof(MainWindow), true, "pianoroll window"));
+                    MessageBox.ShowLoading(this);
                     pianoRollWindow = new PianoRollWindow() {
                         MainWindow = this,
                     };
                     pianoRollWindow.ViewModel.PlaybackViewModel = viewModel.PlaybackViewModel;
-                    DocManager.Inst.ExecuteCmd(new LoadingNotification(typeof(MainWindow), false, "pianoroll window"));
+                    MessageBox.CloseLoading();
                 }
                 // Workaround for new window losing focus.
                 openPianoRollWindow = true;

--- a/OpenUtau/Views/PreferencesDialog.axaml.cs
+++ b/OpenUtau/Views/PreferencesDialog.axaml.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
@@ -26,16 +26,13 @@ namespace OpenUtau.App.Views {
             }
         }
 
-        void ReloadSingers(object sender, RoutedEventArgs e) {
-            DocManager.Inst.ExecuteCmd(new LoadingNotification(typeof(PreferencesDialog), true, "singer"));
-            try {
+        async void ReloadSingers(object sender, RoutedEventArgs e) {
+            MessageBox.ShowLoading(this);
+            await Task.Run(() => {
                 SingerManager.Inst.SearchAllSingers();
-                DocManager.Inst.ExecuteCmd(new SingersRefreshedNotification());
-            } catch (Exception ex) {
-                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
-            } finally {
-                DocManager.Inst.ExecuteCmd(new LoadingNotification(typeof(PreferencesDialog), false, "singer"));
-            }
+            });
+            DocManager.Inst.ExecuteCmd(new SingersRefreshedNotification());
+            MessageBox.CloseLoading();
         }
 
         void ResetVLabelerPath(object sender, RoutedEventArgs e) {


### PR DESCRIPTION
- Fixed singer loading dialog not displaying in preference window.
   - When a loading dialog is shown, notification is not used if it is not needed.
- Added error dialog when failed to search singer.
- Changed log message when attaching a singer to a track.