### PR TITLE
Add flag marge function

### DIFF
--- a/OpenUtau.Core/Commands/ProjectCommands.cs
+++ b/OpenUtau.Core/Commands/ProjectCommands.cs
@@ -167,6 +167,7 @@ namespace OpenUtau.Core {
         public override string ToString() => "Configure expressions";
         public override void Execute() {
             project.expressions = newDescriptors.ToDictionary(descriptor => descriptor.abbr);
+            Format.Ustx.AddDefaultExpressions(project);
             project.parts
                 .Where(part => part is UVoicePart)
                 .ToList()
@@ -175,6 +176,7 @@ namespace OpenUtau.Core {
         }
         public override void Unexecute() {
             project.expressions = oldDescriptors.ToDictionary(descriptor => descriptor.abbr);
+            Format.Ustx.AddDefaultExpressions(project);
             project.parts
                 .Where(part => part is UVoicePart)
                 .ToList()

--- a/OpenUtau.Core/Format/USTx.cs
+++ b/OpenUtau.Core/Format/USTx.cs
@@ -59,6 +59,32 @@ namespace OpenUtau.Core.Format {
             project.RegisterExpression(new UExpressionDescriptor("tone shift (curve)", SHFC, -1200, 1200, 0) { type = UExpressionType.Curve });
             project.RegisterExpression(new UExpressionDescriptor("tension (curve)", TENC, -100, 100, 0) { type = UExpressionType.Curve });
             project.RegisterExpression(new UExpressionDescriptor("voicing (curve)", VOIC, 0, 100, 100) { type = UExpressionType.Curve });
+
+            string message = string.Empty;
+            if (ValidateExpression(project, "g", GEN)) {
+                message += $"\ng flag -> gender";
+            }
+            if (ValidateExpression(project, "B", BRE)) {
+                message += $"\nB flag -> {BRE}";
+            }
+            if (ValidateExpression(project, "H", LPF)) {
+                message += $"\nH flag-> {LPF}";
+            }
+            if (ValidateExpression(project, "P", NORM)) {
+                message += $"\nP flag-> normalize";
+            }
+            if (message != string.Empty) {
+                var e = new MessageCustomizableException("Expressions have been merged due to duplicate flags", $"<translate:errors.expression.marge>:{message}", new Exception(), false);
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(e));
+            }
+        }
+        private static bool ValidateExpression(UProject project, string flag, string abbr) {
+            if (project.expressions.Any(e => e.Value.flag == flag && e.Value.abbr != abbr)) {
+                var oldExp = project.expressions.First(e => e.Value.flag == flag && e.Value.abbr != abbr);
+                project.MargeExpression(oldExp.Value.abbr, abbr);
+                return true;
+            }
+            return false;
         }
 
         public static UProject Create() {

--- a/OpenUtau.Core/Ustx/UProject.cs
+++ b/OpenUtau.Core/Ustx/UProject.cs
@@ -86,23 +86,29 @@ namespace OpenUtau.Core.Ustx {
         }
 
         public void MargeExpression(string oldAbbr, string newAbbr) {
-            parts.Where(p => p is UVoicePart)
-                .OfType<UVoicePart>()
-                .ForEach(p => p.notes.ForEach(n => {
-                if (n.phonemeExpressions.Any(e => e.abbr == oldAbbr)) {
-                    n.phonemeExpressions.ForEach(oldExp => {
-                        if (!n.phonemeExpressions.Any(newExp => newExp.abbr == newAbbr && newExp.index == oldExp.index)) {
+            if (parts != null && parts.Count > 0) {
+                parts.Where(p => p is UVoicePart)
+                    .OfType<UVoicePart>()
+                    .ForEach(p => p.notes.ForEach(n => ConvertNoteExp(n, tracks[p.trackNo])));
+            } else if (voiceParts != null &&voiceParts.Count > 0) {
+                voiceParts.ForEach(p => p.notes.ForEach(n => ConvertNoteExp(n, tracks[p.trackNo])));
+            }
+            expressions.Remove(oldAbbr);
+
+            void ConvertNoteExp(UNote note, UTrack track) {
+                if (note.phonemeExpressions.Any(e => e.abbr == oldAbbr)) {
+                    note.phonemeExpressions.ForEach(oldExp => {
+                        if (!note.phonemeExpressions.Any(newExp => newExp.abbr == newAbbr && newExp.index == oldExp.index)) {
                             oldExp.abbr = newAbbr;
-                            if (tracks[p.trackNo].TryGetExpDescriptor(this, newAbbr, out var descriptor)) {
+                            if (track.TryGetExpDescriptor(this, newAbbr, out var descriptor)) {
                                 oldExp.descriptor = descriptor;
                             }
                         } else {
-                            n.phonemeExpressions.Remove(oldExp);
+                            note.phonemeExpressions.Remove(oldExp);
                         }
                     });
                 }
-            }));
-            expressions.Remove(oldAbbr);
+            }
         }
 
         public UNote CreateNote() {

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -69,6 +69,7 @@
   <system:String x:Key="errors.expression.abbrunique">Abbreviations must be unique</system:String>
   <system:String x:Key="errors.expression.default">Default value must be between min and max</system:String>
   <system:String x:Key="errors.expression.flagunique">Flags must be unique</system:String>
+  <system:String x:Key="errors.expression.marge">The following expressions have been merged due to duplicate flags</system:String>
   <system:String x:Key="errors.expression.min">Min must be smaller than max</system:String>
   <system:String x:Key="errors.expression.name">Name must be set</system:String>
   <system:String x:Key="errors.failed.export">Failed to export</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -69,6 +69,7 @@
   <system:String x:Key="errors.expression.abbrunique">パラメータの略称が重複しています</system:String>
   <system:String x:Key="errors.expression.default">デフォルト値は最小値以上、最大値以下にしてください</system:String>
   <system:String x:Key="errors.expression.flagunique">フラグが重複しています</system:String>
+  <system:String x:Key="errors.expression.marge">フラグが重複しているため、以下の表情は統合されました</system:String>
   <system:String x:Key="errors.expression.min">最小値は最大値より小さくしてください</system:String>
   <system:String x:Key="errors.expression.name">表情名を入力してください</system:String>
   <system:String x:Key="errors.failed.export">エクスポートに失敗しました</system:String>


### PR DESCRIPTION
Background:
If the P flag was used in an older project, when opened in a newer version of the OU, the normalize expression is added and the P flag is duplicated.

This function is run automatically and allows us to format old projects without loss of expression.