### PR TITLE
Fixed bug in KoreanPhonemizerUtil, KO CBNN Phonemizer

### DIFF
--- a/OpenUtau.Core/Enunu/EnunuKoreanPhonemizer.cs
+++ b/OpenUtau.Core/Enunu/EnunuKoreanPhonemizer.cs
@@ -393,7 +393,7 @@ namespace OpenUtau.Core.Enunu {
             }
             
         Dictionary<Note[], Phoneme[]> partResult = new Dictionary<Note[], Phoneme[]>();
-
+        
         public override void SetUp(Note[][] notes, UProject project, UTrack track) {
             partResult.Clear();
             if (notes.Length == 0 || singer == null || !singer.Found) {
@@ -484,7 +484,7 @@ namespace OpenUtau.Core.Enunu {
         }
 
         protected override EnunuNote[] NoteGroupsToEnunu(Note[][] notes) {
-            KoreanPhonemizerUtil.RomanizeNotes(notes, FirstConsonants, MiddleVowels, LastConsonants, semivowelSep);
+            KoreanPhonemizerUtil.RomanizeNotes(notes, true, FirstConsonants, MiddleVowels, LastConsonants, semivowelSep);
             var result = new List<EnunuNote>();
             int position = 0;
             int index = 0;
@@ -513,69 +513,6 @@ namespace OpenUtau.Core.Enunu {
             return result.ToArray();
         }
 
-        // public void AdjustPos(Phoneme[] phonemes, Note[] prevNote){
-        //     //TODO
-        //     Phoneme? prevPhone = null;
-        //     Phoneme? nextPhone = null;
-        //     Phoneme currPhone;
-
-        //     int length = phonemes.Last().position;
-        //     int prevLength;
-        //     if (prevNote == null){
-        //         prevLength = length;
-        //     }
-        //     else{
-        //         prevLength = MsToTick(prevNote.Sum(n => n.duration));
-        //     }
-
-        //     for (int i=0; i < phonemes.Length; i++) {
-        //         currPhone = phonemes[i];
-        //         if (i < phonemes.Length - 1){
-        //             nextPhone = phonemes[i+1];
-        //         }
-        //         else{
-        //             nextPhone = null;
-        //         }
-
-        //         if (i == 0){
-        //             // TODO 받침 + 자음 오면 받침길이 + 자음길이 / 2의 위치에 자음이 오도록 하기
-        //             if (isPlainVowel(phonemes[i].phoneme)) {
-        //                 phonemes[i].position = 0;
-        //             }
-        //             else if (nextPhone != null && ! isPlainVowel(((Phoneme)nextPhone).phoneme) && ! isSemivowel(((Phoneme)nextPhone).phoneme) && isPlainVowel(((Phoneme)nextPhone).phoneme) && isSemivowel(currPhone.phoneme)) {
-        //                 phonemes[i + 1].position = length / 10;
-        //             }
-        //             else if (nextPhone != null && isSemivowel(((Phoneme)nextPhone).phoneme)){
-        //                 if (i + 2 < phonemes.Length){
-        //                     phonemes[i + 2].position = length / 10;
-        //                 }
-                        
-        //             }
-        //         }
-        //         prevPhone = currPhone;
-        //     }
-        // }
-
-        // private bool isPlainVowel(string phoneme){
-        //     if (phoneme == koreanENUNUSetting.GetPlainVowelPhoneme("ㅏ") || phoneme == koreanENUNUSetting.GetPlainVowelPhoneme("ㅣ") || phoneme == koreanENUNUSetting.GetPlainVowelPhoneme("ㅜ") || phoneme == koreanENUNUSetting.GetPlainVowelPhoneme("ㅔ") || phoneme == koreanENUNUSetting.GetPlainVowelPhoneme("ㅗ") || phoneme == koreanENUNUSetting.GetPlainVowelPhoneme("ㅡ") || phoneme == koreanENUNUSetting.GetPlainVowelPhoneme("ㅓ")){
-        //         return true;
-        //     }
-        //     return false;
-        // }
-
-        // private bool isBatchim(string phoneme){
-        //     if (phoneme == koreanENUNUSetting.GetFinalConsonantPhoneme("ㄱ") || phoneme == koreanENUNUSetting.GetFinalConsonantPhoneme("ㄴ") || phoneme == koreanENUNUSetting.GetFinalConsonantPhoneme("ㄷ") || phoneme == koreanENUNUSetting.GetFinalConsonantPhoneme("ㄹ") || phoneme == koreanENUNUSetting.GetFinalConsonantPhoneme("ㅁ") || phoneme == koreanENUNUSetting.GetFinalConsonantPhoneme("ㅂ") || phoneme == koreanENUNUSetting.GetFinalConsonantPhoneme("ㅇ")){
-        //         return true;
-        //     }
-        //     return false;
-        // }
-
-        // private bool isSemivowel(string phoneme) {
-        //     if (phoneme == koreanENUNUSetting.GetSemiVowelPhoneme("w") || phoneme == koreanENUNUSetting.GetSemiVowelPhoneme("y")){
-        //         return true;
-        //     }
-        //     return false;
-        // }
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevs) {
             if (partResult.TryGetValue(notes, out var phonemes)) {
                 var phonemes_ = phonemes.Select(p => {
@@ -584,7 +521,6 @@ namespace OpenUtau.Core.Enunu {
                         return p;
                     }).ToArray();
 
-                //AdjustPos(phonemes_, prevs);
                 return new Result {
                     phonemes = phonemes_,
                 };

--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -371,7 +371,7 @@ namespace OpenUtau.Core {
                 nextFirstConsonant = "ㅇ";
             }
 
-            if ((!firstLastConsonant.Equals("")) && nextFirstConsonant.Equals("ㅇ") && (!firstLastConsonant.Equals("ㅇ"))) {
+            if ((!firstLastConsonant.Equals(" ")) && nextFirstConsonant.Equals("ㅇ") && (!firstLastConsonant.Equals("ㅇ"))) {
                 // 연음 2
                 nextFirstConsonant = firstLastConsonant == " " ? "ㅇ" : firstLastConsonant;
                 firstLastConsonant = " ";

--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -373,7 +373,7 @@ namespace OpenUtau.Core {
 
             if ((!firstLastConsonant.Equals(" ")) && nextFirstConsonant.Equals("ㅇ") && (!firstLastConsonant.Equals("ㅇ"))) {
                 // 연음 2
-                nextFirstConsonant = firstLastConsonant == " " ? "ㅇ" : firstLastConsonant;
+                nextFirstConsonant = firstLastConsonant;
                 firstLastConsonant = " ";
             }
 

--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -8,7 +8,6 @@ using OpenUtau.Core.Ustx;
 using OpenUtau.Classic;
 using Serilog;
 using static OpenUtau.Api.Phonemizer;
-using OpenUtau.Api;
 
 namespace OpenUtau.Core {
     /// <summary>
@@ -374,7 +373,7 @@ namespace OpenUtau.Core {
 
             if ((!firstLastConsonant.Equals("")) && nextFirstConsonant.Equals("ㅇ") && (!firstLastConsonant.Equals("ㅇ"))) {
                 // 연음 2
-                nextFirstConsonant = firstLastConsonant;
+                nextFirstConsonant = firstLastConsonant == " " ? "ㅇ" : firstLastConsonant;
                 firstLastConsonant = " ";
             }
 

--- a/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
@@ -141,7 +141,7 @@ namespace OpenUtau.Plugin.Builtin {
             }
             string frontCV;
             string batchim;
-            string VC = $"{thisMidVowelTail} {FIRST_CONSONANTS[nextLyric[0]]}";
+            string VC = $"{thisMidVowelTail} {FIRST_CONSONANTS[nextLyric[0]]}{MIDDLE_VOWELS[nextLyric[1]][1]}";
             string VV = $"{MIDDLE_VOWELS[prevLyric[1]][2]} {thisMidVowelTail}";
             string VSv = $"{thisMidVowelTail} {MIDDLE_VOWELS[nextLyric[1]][1]}";
             isItNeedsVSv = thisLyric[2] == " " && nextLyric[0] == "ㅇ" && !PLAIN_VOWELS.Contains(nextLyric[1]) && FindInOto(VSv, note, true) != null;

--- a/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
@@ -214,26 +214,22 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
 
-        private string HandleEmptyFirstConsonant(string lyric) {
-            return lyric == " " ? "ㅇ" : lyric;
-        }
-
         public override Result ConvertPhonemes(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             Note note = notes[0];
 
             Hashtable lyrics = KoreanPhonemizerUtil.Variate(prevNeighbour, note, nextNeighbour);
             string[] prevLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
-                HandleEmptyFirstConsonant((string)lyrics[0]), 
+                (string)lyrics[0], 
                 (string)lyrics[1], 
                 (string)lyrics[2]
                 };
             string[] thisLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
-                HandleEmptyFirstConsonant((string)lyrics[3]), 
+                (string)lyrics[3], 
                 (string)lyrics[4], 
                 (string)lyrics[5]
                 };
             string[] nextLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
-                HandleEmptyFirstConsonant((string)lyrics[6]), 
+                (string)lyrics[6], 
                 (string)lyrics[7], 
                 (string)lyrics[8]
                 };
@@ -257,7 +253,7 @@ namespace OpenUtau.Plugin.Builtin {
             Hashtable lyrics = KoreanPhonemizerUtil.Separate(prevNeighbour_.lyric);
 
             string[] prevLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
-                HandleEmptyFirstConsonant((string)lyrics[0]), 
+                (string)lyrics[0], 
                 (string)lyrics[1], 
                 (string)lyrics[2]
                 };

--- a/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCBNNPhonemizer.cs
@@ -145,13 +145,22 @@ namespace OpenUtau.Plugin.Builtin {
             string VV = $"{MIDDLE_VOWELS[prevLyric[1]][2]} {thisMidVowelTail}";
             string VSv = $"{thisMidVowelTail} {MIDDLE_VOWELS[nextLyric[1]][1]}";
             isItNeedsVSv = thisLyric[2] == " " && nextLyric[0] == "ㅇ" && !PLAIN_VOWELS.Contains(nextLyric[1]) && FindInOto(VSv, note, true) != null;
-            isItNeedsVC = thisLyric[2] == " " && nextLyric[0] != "ㅇ" && nextLyric[0] != "null" && FindInOto(VC, note, true) != null;
+            isItNeedsVC = thisLyric[2] == " " && nextLyric[0] != "ㅇ" && nextLyric[0] != "null";
 
             frontCV = $"- {CV}";
             if (FindInOto(frontCV, note, true) == null) {
                 frontCV = $"-{CV}";
                 if (FindInOto(frontCV, note, true) == null) {
                     frontCV = CV;
+                }
+            }
+
+            if (FindInOto(VC, note, true) == null) {
+                if (VC.EndsWith("w") || VC.EndsWith("y")) {
+                    VC = VC.Substring(0, VC.Length - 1);
+                }
+                if (FindInOto(VC, note, true) == null) {
+                    isItNeedsVC = false;
                 }
             }
 

--- a/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/KoreanCVPhonemizer.cs
@@ -232,26 +232,22 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
 
-        private string HandleEmptyFirstConsonant(string lyric) {
-            return lyric == " " ? "ㅇ" : lyric;
-        }
-
         public override Result ConvertPhonemes(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevNeighbours) {
             Note note = notes[0];
 
             Hashtable lyrics = KoreanPhonemizerUtil.Variate(prevNeighbour, note, nextNeighbour);
             string[] prevLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
-                HandleEmptyFirstConsonant((string)lyrics[0]), 
+                (string)lyrics[0], 
                 (string)lyrics[1], 
                 (string)lyrics[2]
                 };
             string[] thisLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
-                HandleEmptyFirstConsonant((string)lyrics[3]), 
+                (string)lyrics[3], 
                 (string)lyrics[4], 
                 (string)lyrics[5]
                 };
             string[] nextLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
-                HandleEmptyFirstConsonant((string)lyrics[6]), 
+                (string)lyrics[6], 
                 (string)lyrics[7], 
                 (string)lyrics[8]
                 };
@@ -275,7 +271,7 @@ namespace OpenUtau.Plugin.Builtin {
             Hashtable lyrics = KoreanPhonemizerUtil.Separate(prevNeighbour_.lyric);
 
             string[] prevLyric = new string[]{ // "ㄴ", "ㅑ", "ㅇ"
-                HandleEmptyFirstConsonant((string)lyrics[0]), 
+                (string)lyrics[0], 
                 (string)lyrics[1], 
                 (string)lyrics[2]
                 };


### PR DESCRIPTION
- Fixed bug in KoreanPhonemizerUtil that generates first consonant " " when have to generate "ㅇ". (in Yeoneum process)
*HandleEmptyFirstConsonant()* in KO CV & KO CBNN Phonemizers became deprecated, so deleted that function.
- Fixed bug in KoreanCBNNPhonemizer that not generates VC with semivowels, like [a gy].

- Should be merged after #1120 