### PR TITLE
Fix openutau unable to play if the first note starts at 0 tick

### DIFF
--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -88,7 +88,7 @@ namespace OpenUtau.Core.Render {
             tone = note.tone;
             tempos = project.timeAxis.TemposBetweenTicks(part.position + phoneme.position - leading, part.position + phoneme.End);
             UTempo[] noteTempos = project.timeAxis.TemposBetweenTicks(part.position + phoneme.position, part.position + phoneme.End);
-            tempo = noteTempos[0].bpm;
+            tempo = noteTempos.Length > 0 ? noteTempos[0].bpm : project.tempos[0].bpm;
 
             double actualTickDuration = 0;
             for (int i = 0; i < noteTempos.Length; i++) {
@@ -316,7 +316,7 @@ namespace OpenUtau.Core.Render {
                         }
                         var frq = phoneme.oto.Frq;
                         UTempo[] noteTempos = project.timeAxis.TemposBetweenTicks(part.position + phoneme.position, part.position + phoneme.End);
-                        var tempo = noteTempos[0].bpm; // compromise 妥協！
+                        var tempo = noteTempos.Length > 0 ? noteTempos[0].bpm : project.tempos[0].bpm; // compromise 妥協！
                         var frqIntervalTick = MusicMath.TempoMsToTick(tempo, (double)1 * 1000 / 44100 * frq.hopSize);
                         double consonantStretch = Math.Pow(2f, 1.0f - phoneme.GetExpression(project, track, Format.Ustx.VEL).Item1 / 100f);
 


### PR DESCRIPTION
If there are phonemes starting before 0 tick, TemposBetweenTicks will return empty result. After this fix, in this case it will use the tempo of the first tempo marker in the project