### PR TITLE
Fix importing project into an unsaved project

### DIFF
--- a/OpenUtau.Core/Ustx/UPart.cs
+++ b/OpenUtau.Core/Ustx/UPart.cs
@@ -401,7 +401,13 @@ namespace OpenUtau.Core.Ustx {
         }
 
         public override void AfterLoad(UProject project, UTrack track) {
-            FilePath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(project.FilePath), relativePath ?? ""));
+            try {
+                FilePath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(project.FilePath), relativePath ?? ""));
+            } catch {
+                if (string.IsNullOrWhiteSpace(FilePath)) {
+                    throw;
+                }
+            }
             Load(project);
         }
     }


### PR DESCRIPTION
Fixed an failure to get the relative path from an unsaved project to a wave part when trying to track import with wave part into an unsaved project. Ignore this exception if already got the relative path from the original project.