### PR TITLE
Fix spaces being ignored in presamp.ini VCPAD

### DIFF
--- a/OpenUtau.Core/Classic/Ini.cs
+++ b/OpenUtau.Core/Classic/Ini.cs
@@ -20,12 +20,17 @@ namespace OpenUtau.Classic {
     }
 
     public static class Ini {
-        public static List<IniBlock> ReadBlocks(StreamReader reader, string file, string headerPattern) {
+        public static List<IniBlock> ReadBlocks(StreamReader reader, string file, string headerPattern, bool trim = true) {
             var headerRegex = new Regex(headerPattern);
             var blocks = new List<IniBlock>();
             var lineNumber = -1;
             while (!reader.EndOfStream) {
-                var line = reader.ReadLine().Trim();
+                string line;
+                if (trim) {
+                    line = reader.ReadLine().Trim();
+                } else {
+                    line = reader.ReadLine();
+                }
                 lineNumber++;
                 if (string.IsNullOrEmpty(line)) {
                     continue;

--- a/OpenUtau.Core/Classic/Ini.cs
+++ b/OpenUtau.Core/Classic/Ini.cs
@@ -57,7 +57,7 @@ namespace OpenUtau.Classic {
         public static bool TryGetLines(List<IniBlock> blocks, string header, out List<IniLine> lines) {
             if (blocks.Any(block => block.header == header)) {
                 lines = blocks.Find(block => block.header == header).lines;
-                if (lines == null || lines.Count <= 0) {
+                if (lines == null || lines.Count < 0) {
                     return false;
                 } else {
                     return true;

--- a/OpenUtau.Core/Classic/Presamp.cs
+++ b/OpenUtau.Core/Classic/Presamp.cs
@@ -73,7 +73,9 @@ namespace Classic {
 
                     if (Ini.TryGetLines(blocks, "[PRIORITY]", out List<IniLine> priority)) {
                         Priorities.Clear();
-                        Priorities.AddRange(priority[0].line.Split(','));
+                        if (priority.Count > 0) {
+                            Priorities.AddRange(priority[0].line.Split(','));
+                        }
                     }
 
                     if (Ini.TryGetLines(blocks, "[REPLACE]", out List<IniLine> replace)) {

--- a/OpenUtau.Core/Classic/Presamp.cs
+++ b/OpenUtau.Core/Classic/Presamp.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using OpenUtau.Classic;
@@ -59,19 +60,15 @@ namespace Classic {
 
                     List<IniBlock> blocks;
                     using (var reader = new StreamReader(iniPath, textFileEncoding)) {
-                        blocks = Ini.ReadBlocks(reader, iniPath, @"\[\w+\]");
+                        blocks = Ini.ReadBlocks(reader, iniPath, @"\[\w+\]", false);
                     }
 
                     if (Ini.TryGetLines(blocks, "[VOWEL]", out List<IniLine> vowelLines)) {
-                        var list = new List<string>();
-                        vowelLines.ForEach(l => list.Add(l.line));
-                        SetVowels(list);
+                        SetVowels(vowelLines.Select(l => l.line).ToList());
                     }
 
                     if (Ini.TryGetLines(blocks, "[CONSONANT]", out List<IniLine> consonantLines)) {
-                        var list = new List<string>();
-                        consonantLines.ForEach(l => list.Add(l.line));
-                        SetConsonants(list);
+                        SetConsonants(consonantLines.Select(l => l.line).ToList());
                     }
 
                     if (Ini.TryGetLines(blocks, "[PRIORITY]", out List<IniLine> priority)) {


### PR DESCRIPTION
Fixed a problem in which spaces were not recognized in the “VCPAD= ” line of presamp.ini.