### PR TITLE
fix "Collection was modified; enumeration operation may not execute." on expression merge

### DIFF
--- a/OpenUtau.Core/Ustx/UProject.cs
+++ b/OpenUtau.Core/Ustx/UProject.cs
@@ -97,6 +97,7 @@ namespace OpenUtau.Core.Ustx {
 
             void ConvertNoteExp(UNote note, UTrack track) {
                 if (note.phonemeExpressions.Any(e => e.abbr == oldAbbr)) {
+                    var toRemove = new List<UExpression>();
                     note.phonemeExpressions.ForEach(oldExp => {
                         if (!note.phonemeExpressions.Any(newExp => newExp.abbr == newAbbr && newExp.index == oldExp.index)) {
                             oldExp.abbr = newAbbr;
@@ -104,9 +105,12 @@ namespace OpenUtau.Core.Ustx {
                                 oldExp.descriptor = descriptor;
                             }
                         } else {
-                            note.phonemeExpressions.Remove(oldExp);
+                            toRemove.Add(oldExp);
                         }
                     });
+                    foreach(var exp in toRemove){
+                        note.phonemeExpressions.Remove(exp);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Sometimes old projects may fail to open and show "Collection was modified; enumeration operation may not execute." error. This PR fixes it. 

I need some ustx files to test it.

In dotnet, you can't modify a list when running ForEach on itself.