### PR TITLE
[JA Presamp Phonemizer] Some starting consonant fixes/adjustments

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -215,7 +215,9 @@ namespace OpenUtau.Plugin.Builtin {
                 && preCFlag
                 && !currentLyric.Contains(vcvpad)
                 && presamp.PhonemeList.TryGetValue(currentAlias, out PresampPhoneme phoneme)
-                && phoneme.HasConsonant) {
+                && phoneme.HasConsonant
+                && !presamp.Priorities.Contains(phoneme.Consonant)) {
+                var consonant = phoneme.Consonant;
                 if (checkOtoUntilHit(new List<string> { $"-{vcvpad}{phoneme.Consonant}" }, note, 2, out var cOto, out var color)
                     && checkOtoUntilHit(new List<string> { currentLyric }, note, out var oto)) {
 
@@ -404,7 +406,7 @@ namespace OpenUtau.Plugin.Builtin {
                         colorIndex = Array.IndexOf(track.VoiceColorExp.options, color);
                     }
                     return true;
-                } else if (index != 1) {
+                } else if (index != 1 && index != 2) {
                     oto = otos.First();
                     return true;
                 }

--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -219,9 +219,9 @@ namespace OpenUtau.Plugin.Builtin {
                 && !presamp.Priorities.Contains(phoneme.Consonant)) {
                 if (checkOtoUntilHit(new List<string> { $"-{vcvpad}{phoneme.Consonant}" }, note, 2, out var cOto, out var color)
                     && checkOtoUntilHit(new List<string> { currentLyric }, note, out var oto)) {
-
+                    int endTick = notes[^1].position + notes[^1].duration;
                     var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
-                    var cLength = Math.Max(30, MsToTick(oto.Preutter) * (attr.consonantStretchRatio ?? 1));
+                    var cLength = Math.Max(30, -MsToTickAt(-oto.Preutter, endTick) * (attr.consonantStretchRatio ?? 1));
 
                     if (prevNeighbour != null) {
                         cLength = Math.Min(prevNeighbour.Value.duration / 2, cLength);
@@ -327,13 +327,14 @@ namespace OpenUtau.Plugin.Builtin {
                 }
                 if (!string.IsNullOrEmpty(vcPhoneme)) {
                     int vcLength = 120;
+                    int endTick = notes[^1].position + notes[^1].duration;
                     var nextAttr = nextNeighbour.Value.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
                     if (singer.TryGetMappedOto(nextLyric, nextNeighbour.Value.tone + nextAttr.toneShift, nextAttr.voiceColor, out var nextOto)) {
                         // If overlap is a negative value, vcLength is longer than Preutter
                         if (nextOto.Overlap < 0) {
-                            vcLength = MsToTick(nextOto.Preutter - nextOto.Overlap);
+                            vcLength = -MsToTickAt(-(nextOto.Preutter - nextOto.Overlap), endTick);
                         } else {
-                            vcLength = MsToTick(nextOto.Preutter);
+                            vcLength = -MsToTickAt(-nextOto.Preutter, endTick);
                         }
                     }
                     // Minimam is 30 tick, maximum is half of note
@@ -411,6 +412,18 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             }
             return false;
+        }
+
+        /// <summary>
+        /// Convert ms to tick at a given reference tick position
+        /// </summary>
+        /// <param name="offsetMs">Duration in ms</param>
+        /// <param name="refTick">Reference tick position</param>
+        /// <returns>Duration in ticks</returns>
+        public int MsToTickAt(double offsetMs, int refTick) {
+            return timeAxis.TicksBetweenMsPos(
+                timeAxis.TickPosToMsPos(refTick),
+                timeAxis.TickPosToMsPos(refTick) + offsetMs);
         }
     }
 }

--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -217,7 +217,6 @@ namespace OpenUtau.Plugin.Builtin {
                 && presamp.PhonemeList.TryGetValue(currentAlias, out PresampPhoneme phoneme)
                 && phoneme.HasConsonant
                 && !presamp.Priorities.Contains(phoneme.Consonant)) {
-                var consonant = phoneme.Consonant;
                 if (checkOtoUntilHit(new List<string> { $"-{vcvpad}{phoneme.Consonant}" }, note, 2, out var cOto, out var color)
                     && checkOtoUntilHit(new List<string> { currentLyric }, note, out var oto)) {
 


### PR DESCRIPTION
This PR fixes 2 main things:
- Starting consonants will no longer be inserted before syllables that start with a priority consonant. This is because most priority consonants (usually stops and affricates) are not configured in a way to handle this in Japanese voicebanks (if the end user wishes to include stop consonants anyway, e.g. when they're configured similarly to in Arpasing banks, simply remove them from under the ``[PRIORITY]`` line in the presamp.ini);
- If a voice color does not contain a starting consonant in the oto, it will no longer be inserted (similar to how VC works). Now, it will insert a starting consonant from the main color if it exists, which may give undesired results.
- Adjust VC and starting C length based on tempo changes, similar to #1161. I'm gonna look into turning this into the default behavior (though I will keep the old method for legacy functionality).