### PR TITLE
Ignore slur lyrics when merging notes with Ctrl+U

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -774,8 +774,13 @@ namespace OpenUtau.App.ViewModels {
             }
             var notes = Selection.ToList();
             notes.Sort((a, b) => a.position.CompareTo(b.position));
+            //Ignore slur lyrics
+            var mergedLyrics = String.Join("", notes.Select(x => x.lyric).Where(l => !l.StartsWith("+")));
+            if(mergedLyrics == ""){ //If all notes are slur, the merged note is single slur note
+                mergedLyrics = notes[0].lyric;
+            }
             DocManager.Inst.StartUndoGroup();
-            DocManager.Inst.ExecuteCmd(new ChangeNoteLyricCommand(Part, notes[0], String.Join("", notes.Select(x => x.lyric))));
+            DocManager.Inst.ExecuteCmd(new ChangeNoteLyricCommand(Part, notes[0], mergedLyrics));
             DocManager.Inst.ExecuteCmd(new ResizeNoteCommand(Part, notes[0], notes.Last().End - notes[0].End));
             notes.RemoveAt(0);
             DocManager.Inst.ExecuteCmd(new RemoveNoteCommand(Part, notes));


### PR DESCRIPTION
Currently we can use `Ctrl+U` to merge notes, which will join the lyrics of all selected notes together as the lyric of the merged note. After this change, slur lyrics (lyric that starts with `+`) will be ignored. 
If all the notes are slur, it will use the lyric of the first note in selection.

For example:
Original notes: `{a} {+}`
Merged note (before this change): `{a+}`
Merged note (after this change): `{a}`