### PR TITLE
Changed font size to be calculated in order of height

### DIFF
--- a/OpenUtau/Controls/NotesCanvas.cs
+++ b/OpenUtau/Controls/NotesCanvas.cs
@@ -217,10 +217,18 @@ namespace OpenUtau.App.Controls {
                 return;
             }
             string displayLyric = note.lyric;
-            var textLayout = TextLayoutCache.Get(displayLyric, Brushes.White, 12);
+            int txtsize = 12;
+            var textLayout = TextLayoutCache.Get(displayLyric, Brushes.White, txtsize);
+            if (txtsize > size.Height) {
+                return;
+            }
+            if (textLayout.Height + 5 < size.Height) {
+                txtsize = (int)(12 * (size.Height / textLayout.Height));
+                textLayout = TextLayoutCache.Get(displayLyric, Brushes.White, txtsize);
+            }
             if (textLayout.Width + 5 > size.Width) {
                 displayLyric = displayLyric[0] + "..";
-                textLayout = TextLayoutCache.Get(displayLyric, Brushes.White, 12);
+                textLayout = TextLayoutCache.Get(displayLyric, Brushes.White, txtsize);
                 if (textLayout.Width + 5 > size.Width) {
                     return;
                 }


### PR DESCRIPTION
It is difficult to distinguish between hiragana muddled sounds (e.g., ba-go) and semi-muddled sounds (e.g., pa-go).
Enlarge the piano roll to change the font size.

ひらがなの濁音（ば行等）と半濁音（ぱ行等）の区別が難しいので
ピアノロールを拡大して文字サイズを変更する。

![image](https://github.com/stakira/OpenUtau/assets/93469977/34032552-1ddb-4920-9a0b-25a39423d987)
