### PR TITLE
Add support for straycat's cache files

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankFiles.cs
+++ b/OpenUtau.Core/Classic/VoicebankFiles.cs
@@ -57,6 +57,7 @@ namespace OpenUtau.Classic {
                 Tuple.Create(source + ".pmk", sourceTemp + ".pmk"),
                 Tuple.Create(source + ".vs4ufrq", sourceTemp + ".vs4ufrq"),
                 Tuple.Create(noExt + ".rudb", tempNoExt + ".rudb"),
+                Tuple.Create(noExt + ".sc.npz", tempNoExt + ".sc.npz"),
             };
         }
 

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -193,7 +193,7 @@ namespace OpenUtau.Core.Util {
             public bool LockUnselectedNotesExpressions = true;
 
             public bool VoicebankPublishUseIgnore = true;
-            public string VoicebankPublishIgnores = "#Adobe Audition\n*.pkf\n\n#UTAU Engines\n*.ctspec\n*.d4c\n*.dio\n*.frc\n*.frt\n*.frq\n*.harvest\n*.lessaudio\n*.llsm\n*.mrq\n*.pitchtier\n*.pkf\n*.platinum\n*.pmk\n*.star\n*.uspec\n*.vs4ufrq\n\n#UTAU related tools\n$read\n*.setParam-Scache\n*.lbp\n*.lbp.caches/*\n\n#OpenUtau\nerrors.txt";
+            public string VoicebankPublishIgnores = "#Adobe Audition\n*.pkf\n\n#UTAU Engines\n*.ctspec\n*.d4c\n*.dio\n*.frc\n*.frt\n*.frq\n*.harvest\n*.lessaudio\n*.llsm\n*.mrq\n*.pitchtier\n*.pkf\n*.platinum\n*.pmk\n*.star\n*.uspec\n*.vs4ufrq\n\n#UTAU related tools\n$read\n*.setParam-Scache\n*.lbp\n*.lbp.caches/*\n\n#OpenUtau\nerrors.txt\n*.sc.npz";
         }
     }
 }


### PR DESCRIPTION
Straycat uses .sc.npz to cache frq and WORLD features like MoreSampler's "llsm" file type. this commit simply adds support for it.