### PR TITLE
ZH CVVC: Fix note timing after tempo change

### DIFF
--- a/OpenUtau.Core/Util/TimeAxis.cs
+++ b/OpenUtau.Core/Util/TimeAxis.cs
@@ -147,6 +147,18 @@ namespace OpenUtau.Core {
             return TickPosToMsPos(tickEnd) - TickPosToMsPos(tickPos);
         }
 
+        /// <summary>
+        /// Convert ms duration to tick at a given reference tick position
+        /// </summary>
+        /// <param name="durationMs">Duration in ms, positive value means starting from refTickPos, negative value means ending at refTickPos</param>
+        /// <param name="refTickPos">Reference tick position</param>
+        /// <returns>Duration in ticks</returns>
+        public int MsToTickAt(double offsetMs, int refTickPos) {
+            return TicksBetweenMsPos(
+                TickPosToMsPos(refTickPos), 
+                TickPosToMsPos(refTickPos) + offsetMs);
+        }
+
         public void TickPosToBarBeat(int tick, out int bar, out int beat, out int remainingTicks) {
             var segment = timeSigSegments.First(seg => seg.tickPos == tick || seg.tickEnd > tick); // TODO: optimize
             bar = segment.barPos + (tick - segment.tickPos) / segment.ticksPerBar;

--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -56,12 +56,12 @@ namespace OpenUtau.Plugin.Builtin {
             int vcLen = 120;
             int endTick = notes[^1].position + notes[^1].duration;
             if (singer.TryGetMappedOto(lyric, notes[0].tone + attr1.toneShift, attr1.voiceColor, out var cvOto)) {
-                vcLen = -MsToTickAt(-cvOto.Preutter, endTick);
+                vcLen = -timeAxis.MsToTickAt(-cvOto.Preutter, endTick);
                 if (cvOto.Overlap == 0 && vcLen < 120) {
                     vcLen = Math.Min(120, vcLen * 2); // explosive consonant with short preutter.
                 }
                 if (cvOto.Overlap < 0) {
-                    vcLen = -MsToTickAt(-(cvOto.Preutter - cvOto.Overlap), endTick);
+                    vcLen = -timeAxis.MsToTickAt(-(cvOto.Preutter - cvOto.Overlap), endTick);
                 }
             }
 
@@ -176,19 +176,6 @@ namespace OpenUtau.Plugin.Builtin {
             }
             return MakeSimpleResult(cvOtoSimple?.Alias ?? lyric);
         }
-                
-        /// <summary>
-        /// Convert ms to tick at a given reference tick position
-        /// </summary>
-        /// <param name="durationMs">Duration in ms</param>
-        /// <param name="refTick">Reference tick position</param>
-        /// <returns>Duration in ticks</returns>
-        public int MsToTickAt(double offsetMs, int refTick) {
-            return timeAxis.TicksBetweenMsPos(
-                timeAxis.TickPosToMsPos(refTick), 
-                timeAxis.TickPosToMsPos(refTick)+ offsetMs);
-        }
-
 
         public override void SetSinger(USinger singer) {
             if (this.singer == singer) {

--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -54,13 +54,14 @@ namespace OpenUtau.Plugin.Builtin {
                 return MakeSimpleResult(oto.Alias);
             }
             int vcLen = 120;
+            int endTick = notes[^1].position + notes[^1].duration;
             if (singer.TryGetMappedOto(lyric, notes[0].tone + attr1.toneShift, attr1.voiceColor, out var cvOto)) {
-                vcLen = MsToTick(cvOto.Preutter);
+                vcLen = -MsToTickAt(-cvOto.Preutter, endTick);
                 if (cvOto.Overlap == 0 && vcLen < 120) {
                     vcLen = Math.Min(120, vcLen * 2); // explosive consonant with short preutter.
                 }
                 if (cvOto.Overlap < 0) {
-                    vcLen = MsToTick(cvOto.Preutter - cvOto.Overlap);
+                    vcLen = -MsToTickAt(-(cvOto.Preutter - cvOto.Overlap), endTick);
                 }
             }
 
@@ -175,6 +176,19 @@ namespace OpenUtau.Plugin.Builtin {
             }
             return MakeSimpleResult(cvOtoSimple?.Alias ?? lyric);
         }
+                
+        /// <summary>
+        /// Convert ms to tick at a given reference tick position
+        /// </summary>
+        /// <param name="durationMs">Duration in ms</param>
+        /// <param name="refTick">Reference tick position</param>
+        /// <returns>Duration in ticks</returns>
+        public int MsToTickAt(double durationMs, int refTick) {
+            return timeAxis.TicksBetweenMsPos(
+                timeAxis.TickPosToMsPos(refTick), 
+                timeAxis.TickPosToMsPos(refTick)+ durationMs);
+        }
+
 
         public override void SetSinger(USinger singer) {
             if (this.singer == singer) {

--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -183,10 +183,10 @@ namespace OpenUtau.Plugin.Builtin {
         /// <param name="durationMs">Duration in ms</param>
         /// <param name="refTick">Reference tick position</param>
         /// <returns>Duration in ticks</returns>
-        public int MsToTickAt(double durationMs, int refTick) {
+        public int MsToTickAt(double offsetMs, int refTick) {
             return timeAxis.TicksBetweenMsPos(
                 timeAxis.TickPosToMsPos(refTick), 
-                timeAxis.TickPosToMsPos(refTick)+ durationMs);
+                timeAxis.TickPosToMsPos(refTick)+ offsetMs);
         }
 
 


### PR DESCRIPTION
Before this fix, ZH CVVC phonemizer converts between tick and ms only based on the initial tempo instead of the changed tempo. Now it converts them based on the tempo at the position of the note 