### PR TITLE
Fix pitch misplaced when using overwrite pitch tool

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModelHitTest.cs
+++ b/OpenUtau/ViewModels/NotesViewModelHitTest.cs
@@ -223,7 +223,7 @@ namespace OpenUtau.App.ViewModels {
                 return null;
             }
             double tick = viewModel.PointToTick(point);
-            var phrase = viewModel.Part.renderPhrases.FirstOrDefault(p => p.position - p.leading >= tick);
+            var phrase = viewModel.Part.renderPhrases.FirstOrDefault(p => p.end >= tick);
             if (phrase == null) {
                 phrase = viewModel.Part.renderPhrases.Last();
             }


### PR DESCRIPTION
Before this fix, if the part contains at least 2 render phrases, the pitch drawn with overwrite pitch tool will be misplaced