### PR TITLE
Clear vibrato and MOD+ after pitch baking

### DIFF
--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -581,6 +581,18 @@ namespace OpenUtau.Core.Editing {
                         end, 0));
                 }
             }
+            //Clear vibratos for selected notes
+            foreach (var note in notes) {
+                if (note.vibrato.length > 0) {
+                    docManager.ExecuteCmd(new VibratoLengthCommand(part, note, 0));
+                }
+            }
+            //Clear MOD+ expressions for selected notes
+            foreach(var phoneme in part.phonemes) {
+                if (phoneme.Parent != null && notes.Contains(phoneme.Parent)) {
+                    docManager.ExecuteCmd(new SetPhonemeExpressionCommand(DocManager.Inst.Project, project.tracks[part.trackNo], part, phoneme, "mod+", null));
+                }
+            }
             docManager.EndUndoGroup();
         }
     }


### PR DESCRIPTION
because they are already baked into the pitch control points