### PR TITLE
[KoreanPhonemizerUtil] Fixed crashing when reading ini from non-utf-8 singers

### DIFF
--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Classic;
 using Serilog;
@@ -1171,7 +1172,7 @@ namespace OpenUtau.Core {
             iniSetting = defaultIniSetting;
             filePath = Path.Combine(singer.Location, iniFileName);
             try {
-                using (StreamReader reader = new StreamReader(filePath, singer.TextFileEncoding)){
+                using (StreamReader reader = new StreamReader(filePath, Encoding.UTF8)){
                     List<IniBlock> blocks = Ini.ReadBlocks(reader, filePath, @"\[\w+\]");
                     if (blocks.Count == 0) {
                         throw new IOException($"[{iniFileName}] is empty.");

--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -1183,7 +1183,7 @@ namespace OpenUtau.Core {
             } 
             catch (IOException e) {
                 Log.Error(e, $"failed to read {iniFileName}, Making new {iniFileName}...");
-                using (StreamWriter writer = new StreamWriter(filePath)){
+                using (StreamWriter writer = new StreamWriter(filePath, Encoding.UTF8)){
                     iniSetting = defaultIniSetting;
                     try{
                         writer.Write(ConvertSettingsToString());
@@ -1193,7 +1193,7 @@ namespace OpenUtau.Core {
                         Log.Error(e_, $"[{iniFileName}] Failed to Write new {iniFileName}.");
                     }
                 };
-                using (StreamReader reader = new StreamReader(filePath)){
+                using (StreamReader reader = new StreamReader(filePath, Encoding.UTF8)){
                     List<IniBlock> blocks = Ini.ReadBlocks(reader, filePath, @"\[\w+\]");
                     this.blocks = blocks;
                 };

--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -1183,7 +1183,7 @@ namespace OpenUtau.Core {
             } 
             catch (IOException e) {
                 Log.Error(e, $"failed to read {iniFileName}, Making new {iniFileName}...");
-                using (StreamWriter writer = new StreamWriter(filePath, Encoding.UTF8)){
+                using (StreamWriter writer = new StreamWriter(filePath, false, Encoding.UTF8)){
                     iniSetting = defaultIniSetting;
                     try{
                         writer.Write(ConvertSettingsToString());


### PR DESCRIPTION
- `KoreanPhonemizerUtil.cs`uses singer's encoding to read .ini file, but crashing occurs by inproper key reading  when singer's encoding does not support some characters in .ini file. (e.g. When singer's encoding is Shift-jis, but singer's `ko-CV.ini` contains Hangeul characters.)
- So Forced `BaseIniManager`'s read encoding to *utf-8* to handle that issue.
- This change has effects to **Korean CV**, **Korean ENUNU** Phonemizers.