### PR TITLE
GitHub actions test won't be canceled if it fails on one OS

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ${{ matrix.os.runs-on }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: 
           - runs-on: windows-latest


### PR DESCRIPTION
If github action test fails on one OS, it will continue to run on other OSs.