### PR TITLE
Add 'Install singer' to singer menu in track header

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -521,6 +521,7 @@ General
 
   <system:String x:Key="tracks.duplicate">Duplicate Track</system:String>
   <system:String x:Key="tracks.duplicatesettings">Duplicate Track Settings</system:String>
+  <system:String x:Key="tracks.installsinger">Install singer</system:String>
   <system:String x:Key="tracks.more">More</system:String>
   <system:String x:Key="tracks.movedown">Move Down</system:String>
   <system:String x:Key="tracks.moveup">Move Up</system:String>


### PR DESCRIPTION
Since "Open Singers location" is added into the singer menu, I think "Install Singer" should also be added into it, because it is the recommended way for importing singers into OpenUtau for most users
![image](https://github.com/stakira/OpenUtau/assets/54425948/ecd1efa3-a98f-4de0-838f-8b70f455679a)
