### PR TITLE
Fix pitch curve 'add point' misplaced

### DIFF
--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -11,6 +11,9 @@ namespace OpenUtau.Core.Ustx {
     public class UNote : IComparable {
         static readonly Regex phoneticHintPattern = new Regex(@"\[(.*)\]");
 
+        /// <summary>
+        /// Position of the note in ticks, relative to the beginning of the part.
+        /// </summary>
         public int position;
         public int duration;
         public int tone;
@@ -22,6 +25,10 @@ namespace OpenUtau.Core.Ustx {
         public List<UPhonemeOverride> phonemeOverrides = new List<UPhonemeOverride>();
 
         [YamlIgnore] public int End => position + duration;
+
+        /// <summary>
+        /// Position of the note in milliseconds, relative to the beginning of the project.
+        /// </summary>
         [YamlIgnore] public double PositionMs { get; set; }
         [YamlIgnore] public double DurationMs => EndMs - PositionMs;
         [YamlIgnore] public double EndMs { get; set; }
@@ -435,7 +442,14 @@ namespace OpenUtau.Core.Ustx {
     };
 
     public class PitchPoint : IComparable<PitchPoint> {
+        /// <summary>
+        /// Position relative to the beginning of the note in milliseconds.
+        /// </summary>
         public float X;
+
+        /// <summary>
+        /// Pitch relative to the tone of the note in 0.1 semi-tones.
+        /// </summary>
         public float Y;
         public PitchPointShape shape;
 

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -355,6 +355,11 @@ namespace OpenUtau.App.ViewModels {
             this.RaisePropertyChanged(nameof(ViewportTracks));
         }
 
+        /// <summary>
+        /// Convert mouse position in piano roll window to tick in part
+        /// </summary>
+        /// <param name="point">Mouse position</param>
+        /// <returns>Tick position related to the beginning of the part</returns>
         public int PointToTick(Point point) {
             return (int)(point.X / TickWidth + TickOffset);
         }

--- a/OpenUtau/ViewModels/NotesViewModelHitTest.cs
+++ b/OpenUtau/ViewModels/NotesViewModelHitTest.cs
@@ -176,7 +176,8 @@ namespace OpenUtau.App.ViewModels {
                         double castX = MusicMath.InterpolateShapeX(lastX, x, lastY, y, point.Y, lastShape) - point.X;
                         double dis = double.IsNaN(castX) ? Math.Abs(castY) : Math.Cos(Math.Atan2(Math.Abs(castY), Math.Abs(castX))) * Math.Abs(castY);
                         if (dis < 3) {
-                            double msX = viewModel.Project.timeAxis.TickPosToMsPos(viewModel.PointToTick(point)) - note.PositionMs;
+                            var timeAxis = viewModel.Project.timeAxis;
+                            double msX = timeAxis.TickPosToMsPos(viewModel.PointToTick(point) + viewModel.Part.position) - note.PositionMs;
                             double decCentY = (viewModel.PointToToneDouble(point) - note.tone) * 10;
                             return new PitchPointHitInfo() {
                                 Note = note,


### PR DESCRIPTION
Before this fix, if the part doesn't start at 0 and you right-click on the pitch curve and select "Add point", the added point will be misplaced