### PR TITLE
Fix issue when using exe wavtools on Linux

### DIFF
--- a/OpenUtau.Core/Classic/ExeWavtool.cs
+++ b/OpenUtau.Core/Classic/ExeWavtool.cs
@@ -197,13 +197,19 @@ namespace OpenUtau.Classic {
         } 
 
         string ConvertToWindowsPath (string linuxPath) {
-            char[] path = linuxPath.ToCharArray();
+            List<char> path = new List<char>(linuxPath.ToCharArray());
             bool absolutePath = false;
             if (path[0] == '/') absolutePath = true;
-            for (int i = 0; i < path.Length; i++) {
+            for (int i = path.Count - 1; i > 0; i--) {
+                if (path[i] == ' ' && path[i-1] == '\\') {
+                    path.RemoveAt(i-1);
+                    i--;
+                }
+            }
+            for (int i = 0; i < path.Count; i++) {
                 if (path[i] == '/') path[i] = '\\';
             }
-            string windowsPath = new string(path);
+            string windowsPath = new string(path.ToArray());
             if (absolutePath) windowsPath = "Z:" + windowsPath;
             return windowsPath;
         }

--- a/OpenUtau.Core/Classic/ExeWavtool.cs
+++ b/OpenUtau.Core/Classic/ExeWavtool.cs
@@ -9,9 +9,12 @@ using OpenUtau.Core.Render;
 using OpenUtau.Core.Util;
 using Serilog;
 
+using System;
+
 namespace OpenUtau.Classic {
     class ExeWavtool : IWavtool {
         static object tempBatLock = new object();
+        static object tempShLock = new object();
 
         readonly StringBuilder sb = new StringBuilder();
         readonly string filePath;
@@ -41,7 +44,8 @@ namespace OpenUtau.Classic {
             string batPath = Path.Combine(PathManager.Inst.CachePath, "temp.bat");
             lock (tempBatLock) {
                 using (var stream = File.Open(batPath, FileMode.Create)) {
-                    using (var writer = new StreamWriter(stream, osEncoding)) {
+                    UTF8Encoding noBomEncoding = new UTF8Encoding(false);
+                    using (var writer = new StreamWriter(stream, OS.IsLinux() ? noBomEncoding : osEncoding)) {
                         WriteSetUp(writer, resamplerItems, tempPath);
                         for (var i = 0; i < resamplerItems.Count; i++) {
                             WriteItem(writer, resamplerItems[i], i, resamplerItems.Count);
@@ -49,7 +53,15 @@ namespace OpenUtau.Classic {
                         WriteTearDown(writer);
                     }
                 }
-                ProcessRunner.Run(batPath, "", Log.Logger, workDir: PathManager.Inst.CachePath, timeoutMs: 5 * 60 * 1000);
+
+                if (OS.IsLinux()) {
+                    //Because you can't run .bat files directly on linux, we have to create a shell script wrapper
+                    string shPath = PrepareSh();
+                    ProcessRunner.Run(shPath, "", Log.Logger, workDir: PathManager.Inst.CachePath, timeoutMs: 5 * 60 * 1000);
+                }
+                else {
+                    ProcessRunner.Run(batPath, "", Log.Logger, workDir: PathManager.Inst.CachePath, timeoutMs: 5 * 60 * 1000);
+                }
             }
             if (string.IsNullOrEmpty(tempPath) || File.Exists(tempPath)) {
                 using (var wavStream = Core.Format.Wave.OpenFile(tempPath)) {
@@ -59,12 +71,39 @@ namespace OpenUtau.Classic {
             return new float[0];
         }
 
+        string PrepareSh () {
+            string shPath = Path.Join(PathManager.Inst.CachePath, "temp.sh");
+            lock(tempShLock) {
+                if (!File.Exists(shPath)) {
+                    using (FileStream stream = File.Open(shPath, FileMode.Create)) {
+                        //Making a new encoding here that does not have a byte order mark
+                        //The byte order mark at the front of an shell script causes an exec format error
+                        UTF8Encoding noBomEncoding = new UTF8Encoding(false);
+                        using (StreamWriter writer = new StreamWriter(stream, noBomEncoding)) {
+                            WriteSh(writer);
+                        }
+                    }
+                    int mode = (7 << 6) | (5 << 3) | 5;
+                    chmod(shPath, mode);
+                }
+            }
+            return shPath;
+        }
+
+        void WriteSh (StreamWriter writer) {
+            string batPath = Path.Combine(PathManager.Inst.CachePath, "temp.bat");
+            writer.WriteLine("#!/bin/bash");
+            writer.WriteLine("LANG=\"ja_JP.UTF8\" wine \"" + batPath + "\" \"${@,-1}\"");
+        }
+
         void PrepareHelper() {
             string tempHelper = Path.Join(PathManager.Inst.CachePath, "temp_helper.bat");
             lock (Renderers.GetCacheLock(tempHelper)) {
                 if (!File.Exists(tempHelper)) {
                     using (var stream = File.Open(tempHelper, FileMode.Create)) {
-                        using (var writer = new StreamWriter(stream, osEncoding)) {
+                        //BOM also causes problems when running .bat files through wine
+                        UTF8Encoding noBomEncoding = new UTF8Encoding(false);
+                        using (var writer = new StreamWriter(stream, OS.IsLinux() ? noBomEncoding : osEncoding)) {
                             WriteHelper(writer);
                         }
                     }
@@ -87,12 +126,13 @@ namespace OpenUtau.Classic {
             writer.WriteLine("@set loadmodule=");
             writer.WriteLine($"@set tempo={resamplerItems[0].tempo}");
             writer.WriteLine($"@set samples={44100}");
-            writer.WriteLine($"@set oto={PathManager.Inst.CachePath}");
-            writer.WriteLine($"@set tool={filePath}");
+            writer.WriteLine($"@set oto={ConvertIfNeeded(PathManager.Inst.CachePath)}");
+            string toolPath = OS.IsLinux() ? ResolveResamplerExePathLinux(filePath) : filePath;
+            writer.WriteLine($"@set tool={ConvertIfNeeded(toolPath)}");
             string tempFile = Path.GetRelativePath(PathManager.Inst.CachePath, tempPath);
-            writer.WriteLine($"@set output={tempFile}");
+            writer.WriteLine($"@set output={ConvertIfNeeded(tempFile)}");
             writer.WriteLine("@set helper=temp_helper.bat");
-            writer.WriteLine($"@set cachedir={PathManager.Inst.CachePath}");
+            writer.WriteLine($"@set cachedir={ConvertIfNeeded(PathManager.Inst.CachePath)}");
             writer.WriteLine($"@set flag=\"{globalFlags}\"");
             writer.WriteLine("@set env=0 5 35 0 100 100 0");
             writer.WriteLine("@set stp=0");
@@ -103,19 +143,20 @@ namespace OpenUtau.Classic {
         }
 
         void WriteItem(StreamWriter writer, ResamplerItem item, int index, int total) {
-            writer.WriteLine($"@set resamp={item.resampler.FilePath}");
+            string resampPath = OS.IsLinux() ? ResolveResamplerExePathLinux(item.resampler.FilePath) : item.resampler.FilePath;
+            writer.WriteLine($"@set resamp={ConvertIfNeeded(resampPath)}");
             writer.WriteLine($"@set params={item.volume} {item.modulation} !{item.tempo:G999} {Base64.Base64EncodeInt12(item.pitches)}");
             writer.WriteLine($"@set flag=\"{item.GetFlagsString()}\"");
             writer.WriteLine($"@set env={GetEnvelope(item)}");
             writer.WriteLine($"@set stp={item.skipOver}");
             writer.WriteLine($"@set vel={item.velocity}");
             string relOutputFile = Path.GetRelativePath(PathManager.Inst.CachePath, item.outputFile);
-            writer.WriteLine($"@set temp=\"%cachedir%\\{relOutputFile}\"");
+            writer.WriteLine($"@set temp=\"%cachedir%\\{ConvertIfNeeded(relOutputFile)}\"");
             string toneName = MusicMath.GetToneName(item.tone);
             string dur = $"{item.phone.duration:G999}@{item.phone.adjustedTempo:G999}{(item.durCorrection >= 0 ? "+" : "")}{item.durCorrection}";
             string relInputTemp = Path.GetRelativePath(PathManager.Inst.CachePath, item.inputTemp);
             writer.WriteLine($"@echo {MakeProgressBar(index + 1, total)}");
-            writer.WriteLine($"@call %helper% \"%oto%\\{relInputTemp}\" {toneName} {dur} {item.preutter} {item.offset} {item.durRequired} {item.consonant} {item.cutoff} {index}");
+            writer.WriteLine($"@call %helper% \"%oto%\\{ConvertIfNeeded(relInputTemp)}\" {toneName} {dur} {item.preutter} {item.offset} {item.durRequired} {item.consonant} {item.cutoff} {index}");
         }
 
         string MakeProgressBar(int index, int total) {
@@ -148,6 +189,66 @@ namespace OpenUtau.Classic {
             writer.WriteLine("del \"%output%.whd\"");
             writer.WriteLine("del \"%output%.dat\"");
             writer.WriteLine(":E");
+        }
+
+        string ConvertIfNeeded(string path) {
+            if (OS.IsLinux()) return ConvertToWindowsPath(path);
+            else return path;
+        } 
+
+        string ConvertToWindowsPath (string linuxPath) {
+            char[] path = linuxPath.ToCharArray();
+            bool absolutePath = false;
+            if (path[0] == '/') absolutePath = true;
+            for (int i = 0; i < path.Length; i++) {
+                if (path[i] == '/') path[i] = '\\';
+            }
+            string windowsPath = new string(path);
+            if (absolutePath) windowsPath = "Z:" + windowsPath;
+            return windowsPath;
+        }
+
+        //Parse the wrapper shell script created by the user during the resampler install process on linux for the path
+        //to the resampler's exe file. Should work for most paths and files that people would make, but there may be edge cases.
+        //Intended only for use on linux
+        string ResolveResamplerExePathLinux (string wrapperPath) {
+            using (FileStream stream = File.Open(wrapperPath, FileMode.Open)) {
+                using (StreamReader reader = new StreamReader(stream)) {
+                    string line;
+                    int start = -1;
+                    int end = -1;
+                    for (line = reader.ReadLine(); line != null; line = reader.ReadLine()) {
+                        if (line[0] == '#') continue; //ignore comments in the file
+                        start = line.IndexOf("wine ") + 5;
+                        if (start == -1) continue;
+
+                        end = -1;
+                        if (line[start] == '"') { //if path is enclosed by quotation marks
+                            start++;
+                            end = line.IndexOf('"', start + 1);
+                        }
+                        else { //if path is not enclosed by quotation marks (potential for "\ " in string)
+                            int lastChecked = start;
+                            do {
+                                end = line.IndexOf(' ', lastChecked);
+                                if (line[end - 1] != '\\') break;
+
+                                lastChecked = end + 1;
+                            } while (end != -1);
+                        }
+                        if (end != -1) break;
+                    }
+                    if (line == null) 
+                        throw new InvalidDataException("Shell script wrapper for exe resampler is empty");
+                    else if (start == -1 || end == -1) 
+                        throw new InvalidDataException("Could not find path to .exe resampler in shell script wrapper");
+                    else {
+                        string output = line.Substring(start, end - start);
+                        Console.WriteLine("Parsed shell wrapper for exe file, output is: " + output);
+                        return output;
+                    }
+                }
+            }
         }
 
         [DllImport("libc", SetLastError = true)]

--- a/OpenUtau.Core/Classic/ExeWavtool.cs
+++ b/OpenUtau.Core/Classic/ExeWavtool.cs
@@ -248,11 +248,8 @@ namespace OpenUtau.Classic {
                         throw new InvalidDataException("Shell script wrapper for exe resampler is empty");
                     else if (start == -1 || end == -1) 
                         throw new InvalidDataException("Could not find path to .exe resampler in shell script wrapper");
-                    else {
-                        string output = line.Substring(start, end - start);
-                        Console.WriteLine("Parsed shell wrapper for exe file, output is: " + output);
-                        return output;
-                    }
+                    else
+                        return line.Substring(start, end - start);
                 }
             }
         }


### PR DESCRIPTION
I encountered this error when trying to use an external .exe wavtool on Linux: (the first image shows the original error, and the second shows the error after I marked temp.bat and temp_helper.bat as executable)
![openutau error 1](https://github.com/stakira/OpenUtau/assets/117691913/91928b56-8d0d-45a7-833c-a5a94298f79e)
![openutau error 2](https://github.com/stakira/OpenUtau/assets/117691913/d906fb53-88fe-468b-aab0-c13bc3b6f650)

The cause was that OpenUtau creates a temporary batch file to run the wavtool and attempts to run it directly, which does not work on Linux because batch files can only run on Windows or through Wine.

This patch fixes it by creating a temporary shell wrapper to run the batch file, but there were a few other changes I had to make to accommodate this, which is described in more detail in the commit messages (there are 5 commits when really there are 2 because I changed one of the commit messages to be worded more clearly). All of the new code is behind checks for OS.IsLinux(), so none of the new code affects things on Windows, but to make sure, I tested it in a Windows VM and external wavtools and resamplers worked fine.

I don't know if macOS faces the same issue, nor do I know if the same fix would work on macOS (because I have never used a mac or developed anything for a mac), so for now this patch affects only Linux.