### PR TITLE
[KoreanPhonemizerUtil] Fix for batchim "T" phoneme with initial "ㅅ"/"ㅆ" + text encoding fix (from #1179)

### DIFF
--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -311,11 +311,15 @@ namespace OpenUtau.Core {
                 firstLastConsonant = " ";
                 nextFirstConsonant = (string)aspirateSounds[basicSounds[nextFirstConsonant]];
             } 
-            else if (firstLastConsonant.Equals("ㅎ") && (!nextFirstConsonant.Equals("ㅅ")) && nextFirstConsonant.Equals("ㅇ")) {
+            else if (firstLastConsonant.Equals("ㅎ") && (nextFirstConsonant.Equals("ㅁ") || nextFirstConsonant.Equals("ㅅ") || nextFirstConsonant.Equals("ㄹ")
+                || nextFirstConsonant.Equals("ㅊ") || nextFirstConsonant.Equals("ㅋ") || nextFirstConsonant.Equals("ㅌ") || nextFirstConsonant.Equals("ㅍ") || nextFirstConsonant.Equals("ㄲ") || nextFirstConsonant.Equals("ㄸ") || nextFirstConsonant.Equals("ㅃ") || nextFirstConsonant.Equals("ㅆ") || nextFirstConsonant.Equals("ㅉ"))
+                ) {
                 // ㅎ으로 끝나고 다음 소리가 없으면 / ex) 낳아 = 나아
                 firstLastConsonant = " ";
-            } 
-            else if (firstLastConsonant.Equals("ㄶ") && (! nextFirstConsonant.Equals("ㅅ")) && basicSounds.Contains(nextFirstConsonant)) {
+            } else if (firstLastConsonant.Equals("ㅎ") && nextFirstConsonant.Equals("ㄴ")) {
+                // Transform batchim ㅎ into ㄴ when next initial is ㄴ
+                firstLastConsonant = "ㄴ";
+            } else if (firstLastConsonant.Equals("ㄶ") && (! nextFirstConsonant.Equals("ㅅ")) && basicSounds.Contains(nextFirstConsonant)) {
                 // ㄶ으로 끝나고 다음 소리가 ㄱㄷㅂㅈ이면 / ex) 많다 = 만타
                 firstLastConsonant = "ㄴ";
                 nextFirstConsonant = (string)aspirateSounds[basicSounds[nextFirstConsonant]];
@@ -324,9 +328,10 @@ namespace OpenUtau.Core {
                 // ㅀ으로 끝나고 다음 소리가 ㄱㄷㅂㅈ이면 / ex) 끓다 = 끌타
                 firstLastConsonant = "ㄹ";
                 nextFirstConsonant = (string)aspirateSounds[basicSounds[nextFirstConsonant]];
+            } else if (firstLastConsonant.Equals("ㅎ") && (fortisSounds.Contains(nextFirstConsonant) || aspirateSounds.Contains(nextFirstConsonant))) {
+                // ㅎ으로 끝나고 다음 소리가 없으면 / ex) 낳아 = 나아
+                firstLastConsonant = " ";
             }
-
-
 
 
             // 2-1. 된소리되기 1
@@ -417,6 +422,11 @@ namespace OpenUtau.Core {
             if (firstLastConsonant.Equals("ㄴ") && nextFirstConsonant.Equals("ㄱ")) {
                 // ex) ~라는 감정 = ~라능 감정
                 firstLastConsonant = "ㅇ";
+            }
+
+            // If batchim isn't ㄹ, ㅎ or null, transform initial ㄹ into ㄴ
+            if ((basicSounds.Contains(firstLastConsonant) || nasalSounds.Contains(firstLastConsonant) || fortisSounds.Contains(firstLastConsonant) || aspirateSounds.Contains(firstLastConsonant)) && nextFirstConsonant.Equals("ㄹ")) {
+                nextFirstConsonant = "ㄴ";
             }
 
             // return results

--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Classic;
 using Serilog;
@@ -1176,7 +1177,7 @@ namespace OpenUtau.Core {
             iniSetting = defaultIniSetting;
             filePath = Path.Combine(singer.Location, iniFileName);
             try {
-                using (StreamReader reader = new StreamReader(filePath, singer.TextFileEncoding)){
+                using (StreamReader reader = new StreamReader(filePath, Encoding.UTF8)){
                     List<IniBlock> blocks = Ini.ReadBlocks(reader, filePath, @"\[\w+\]");
                     if (blocks.Count == 0) {
                         throw new IOException($"[{iniFileName}] is empty.");

--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -332,6 +332,11 @@ namespace OpenUtau.Core {
             if ((firstLastConsonant.Equals("ㄳ") || firstLastConsonant.Equals("ㄵ") || firstLastConsonant.Equals("ㄽ") || firstLastConsonant.Equals("ㄾ") || firstLastConsonant.Equals("ㅄ") || firstLastConsonant.Equals("ㄼ") || firstLastConsonant.Equals("ㄺ") || firstLastConsonant.Equals("ㄿ")) && basicSounds.Contains(nextFirstConsonant)) {
                 // [ㄻ, (ㄶ, ㅀ)<= 유기음화에 따라 예외] 제외한 겹받침으로 끝나고 다음 소리가 예사소리이면
                 nextFirstConsonant = (string)fortisSounds[basicSounds[nextFirstConsonant]];
+            // Merge current batchim ㄷ, ㅅ, ㅈ, ㅊ, ㅌ, ㅆ with next initial ㅅ or ㅆ
+            // Current batchim will be null, next initial will be ㅆ
+            } else if ((firstLastConsonant.Equals("ㄷ") || firstLastConsonant.Equals("ㅅ") || firstLastConsonant.Equals("ㅈ") || firstLastConsonant.Equals("ㅊ") || firstLastConsonant.Equals("ㅌ") || firstLastConsonant.Equals("ㅆ")) && (nextFirstConsonant.Equals("ㅅ") || nextFirstConsonant.Equals("ㅆ"))) {
+                firstLastConsonant = " ";
+                nextFirstConsonant = (string)fortisSounds[basicSounds[nextFirstConsonant]];
             }
 
             // 3. 첫 번째 글자의 자음군단순화 및 평파열음화(음절의 끝소리 규칙)


### PR DESCRIPTION
- I noticed that ``KoreanPhonemizerUtil`` does not parse the final ``T`` phoneme (batchim jamo ``ㄷ, ㅅ, ㅈ, ㅊ, ㅌ, ㅆ``) correctly when the next syllable starts with ``ㅅ/ㅆ``. In actuality, the batchim should become null in this case; currently, it remains there, which is incorrect.
- I also implemented the text encoding fix from #1179 already. @EX3exp Is that alright?