### PR TITLE
Update System.Text.Json to 8.0.4 because of vulnerability

### DIFF
--- a/OpenUtau/OpenUtau.csproj
+++ b/OpenUtau/OpenUtau.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenUtau.Core\OpenUtau.Core.csproj" />


### PR DESCRIPTION
See https://github.com/advisories/GHSA-hh2w-p6rv-4g7w for detail
Nuget is preventing any older version of this package from being downloaded, which blocks all our GitHub Actions (and any developer who compiles OpenUtau for the first time)