### PR TITLE
Fix several bugs on pressing Ctrl+Z in TextBoxes

### DIFF
--- a/OpenUtau.Core/Util/SplitLyrics.cs
+++ b/OpenUtau.Core/Util/SplitLyrics.cs
@@ -11,7 +11,10 @@ namespace OpenUtau.Core.Util {
             @"\p{IsCJKUnifiedIdeographs}|\p{IsHiragana}|\p{IsKatakana}|\p{IsHangulSyllables}");
         static Regex contracted = new Regex(@"[ゃゅょぁぃぅぇぉャュョァィゥェォ]");
 
-        public static List<string> Split(string text) {
+        public static List<string> Split(string? text) {
+            if(text == null){
+                return new List<string>();
+            }
             var lyrics = new List<string>();
             var builder = new StringBuilder();
             var etor = StringInfo.GetTextElementEnumerator(text);

--- a/OpenUtau/ViewModels/LyricsViewModel.cs
+++ b/OpenUtau/ViewModels/LyricsViewModel.cs
@@ -11,7 +11,7 @@ using ReactiveUI.Fody.Helpers;
 
 namespace OpenUtau.App.ViewModels {
     class LyricsViewModel : ViewModelBase {
-        [Reactive] public string Text { get; set; }
+        [Reactive] public string? Text { get; set; }
         [Reactive] public int CurrentCount { get; set; }
         [Reactive] public int TotalCount { get; set; }
         [Reactive] public int MaxCount { get; set; }

--- a/OpenUtau/ViewModels/NoteDefaultsViewModel.cs
+++ b/OpenUtau/ViewModels/NoteDefaultsViewModel.cs
@@ -9,7 +9,7 @@ using ReactiveUI.Fody.Helpers;
 namespace OpenUtau.App.ViewModels {
     class NoteDefaultsViewModel : ViewModelBase {
 
-        [Reactive] public string DefaultLyric { get; set; }
+        [Reactive] public string? DefaultLyric { get; set; }
         [Reactive] public int CurrentPortamentoLength { get; set; }
         [Reactive] public int CurrentPortamentoStart { get; set; }
         [Reactive] public float CurrentVibratoLength { get; set; }
@@ -57,6 +57,9 @@ namespace OpenUtau.App.ViewModels {
 
             this.WhenAnyValue(vm => vm.DefaultLyric)
                     .Subscribe(defaultLyric => {
+                        if(defaultLyric == null){
+                            return;
+                        }
                         NotePresets.Default.DefaultLyric = defaultLyric;
                         NotePresets.Save();
                     });

--- a/OpenUtau/ViewModels/PhoneticAssistantViewModel.cs
+++ b/OpenUtau/ViewModels/PhoneticAssistantViewModel.cs
@@ -21,7 +21,7 @@ namespace OpenUtau.App.ViewModels {
         public List<G2pOption> G2ps => g2ps;
 
         [Reactive] public G2pOption? G2p { get; set; }
-        [Reactive] public string Grapheme { get; set; }
+        [Reactive] public string? Grapheme { get; set; }
         [Reactive] public string Phonemes { get; set; }
 
         private readonly List<G2pOption> g2ps = new List<G2pOption>() {
@@ -57,7 +57,7 @@ namespace OpenUtau.App.ViewModels {
         }
 
         private void Refresh() {
-            if (g2p == null) {
+            if (Grapheme == null || g2p == null) {
                 Phonemes = string.Empty;
                 return;
             }


### PR DESCRIPTION
The following bugs are fixed:

- In "Edit Lyrics" dialog, pressing Ctrl+Z will result in error. If you click "apply", OpenUtau will crash.
![image](https://github.com/user-attachments/assets/9a36499a-e555-4bdb-b03d-3ee7badfbb86)

- In "Note Defaults" dialog, press Ctrl+Z in "Default Lyric" field, draw a new note, and OpenUtau will crash
- In "Phonetic assistant" dialog, input a letter, press Ctrl+Z for 3 times and it will show an error
![image](https://github.com/user-attachments/assets/48c9a730-56a8-43cb-808c-99ae58c1177f)
