### PR TITLE
ㅎ dropout reduction in KoreanPhonemizerUtil

### DIFF
--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -368,9 +368,6 @@ namespace OpenUtau.Core {
                 nextFirstConsonant = (string)aspirateSounds[basicSounds[firstLastConsonant]];
                 firstLastConsonant = " ";
             } 
-            else if (nextFirstConsonant.Equals("ㅎ")) {
-                nextFirstConsonant = "ㅇ";
-            }
 
             if ((!firstLastConsonant.Equals(" ")) && nextFirstConsonant.Equals("ㅇ") && (!firstLastConsonant.Equals("ㅇ"))) {
                 // 연음 2

--- a/OpenUtau.Core/KoreanPhonemizerUtil.cs
+++ b/OpenUtau.Core/KoreanPhonemizerUtil.cs
@@ -242,8 +242,10 @@ namespace OpenUtau.Core {
                     nextFirstConsonant = (string)aspirateSounds[basicSounds[firstLastConsonant]];
                     firstLastConsonant = " ";
                 } else {
-                    // 뻔한 = 뻔안 (아래에서 연음 적용되서 뻐난 됨)
-                    nextFirstConsonant = "ㅇ";
+                    if (!firstLastConsonant.Equals("ㅇ")) { // 사랑해 -> 사랑애 방지
+                        // 뻔한 = 뻔안 (아래에서 연음 적용되서 뻐난 됨)
+                        nextFirstConsonant = "ㅇ";
+                    }
                 }
             }
 


### PR DESCRIPTION
Reduced unnecessary ㅎ dropout in KoreanPhonemizerUtil, specifically:

```
Vowel + ㅎ + Vowel -> Vowel + Vowel
Vowel + ㅇ + ㅎ + Vowel -> Vowel + ㅇ + Vowel
```

Both case is removed for sake of naturality.