### PR TITLE
Add checks for phoneme definitions in dsdict.yaml

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -153,12 +153,19 @@ namespace OpenUtau.Core.DiffSinger
         /// distribute phonemes to each note inside the group
         /// </summary>
         List<phonemesPerNote> ProcessWord(Note[] notes, string[] symbols){
+            //Check if all phonemes are defined in dsdict.yaml (for their types)
+            foreach (var symbol in symbols) {
+                if (!g2p.IsValidSymbol(symbol)) {
+                    throw new InvalidDataException(
+                        $"Type definition of symbol \"{symbol}\" not found. Consider adding it to dsdict.yaml (or dsdict-<lang>.yaml) of the phonemizer.");
+                }
+            }
             var wordPhonemes = new List<phonemesPerNote>{
                 new phonemesPerNote(-1, notes[0].tone)
             };
             var dsPhonemes = symbols
                 .Select((symbol, index) => new dsPhoneme(symbol, GetSpeakerAtIndex(notes[0], index)))
-                .ToArray(); 
+                .ToArray();
             var isVowel = dsPhonemes.Select(s => g2p.IsVowel(s.Symbol)).ToArray();
             var isGlide = dsPhonemes.Select(s => g2p.IsGlide(s.Symbol)).ToArray();
             var nonExtensionNotes = notes.Where(n=>!IsSyllableVowelExtensionNote(n)).ToArray();

--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -93,6 +93,15 @@ namespace OpenUtau.Core.DiffSinger
             var endMs = phrase.notes[^1].endMs + tailMs;
             int headFrames = (int)Math.Round(headMs / frameMs);
             int tailFrames = (int)Math.Round(tailMs / frameMs);
+            if (dsConfig.predict_dur || dsConfig.use_note_rest) {
+                //Check if all phonemes are defined in dsdict.yaml (for their types)
+                foreach (var phone in phrase.phones) {
+                    if (!g2p.IsValidSymbol(phone.phoneme)) {
+                        throw new InvalidDataException(
+                            $"Type definition of symbol \"{phone.phoneme}\" not found. Consider adding it to dsdict.yaml of the pitch predictor.");
+                    }
+                }
+            }
             //Linguistic Encoder
             var linguisticInputs = new List<NamedOnnxValue>();
             var tokens = phrase.phones

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -87,6 +87,15 @@ namespace OpenUtau.Core.DiffSinger{
         public VarianceResult Process(RenderPhrase phrase){
             int headFrames = (int)Math.Round(headMs / frameMs);
             int tailFrames = (int)Math.Round(tailMs / frameMs);
+            if (dsConfig.predict_dur) {
+                //Check if all phonemes are defined in dsdict.yaml (for their types)
+                foreach (var phone in phrase.phones) {
+                    if (!g2p.IsValidSymbol(phone.phoneme)) {
+                        throw new InvalidDataException(
+                            $"Type definition of symbol \"{phone.phoneme}\" not found. Consider adding it to dsdict.yaml of the variance predictor.");
+                    }
+                }
+            }
             //Linguistic Encoder
             var linguisticInputs = new List<NamedOnnxValue>();
             var tokens = phrase.phones.Select(p => p.phoneme)


### PR DESCRIPTION
Some inputs of DiffSinger depend on whether the phones are vowels. However, `G2pDictionary.IsVowel()` returns `false` if the phoneme symbol is not found in the dictionary (mostly dsdict.yaml). The rendering continues because the phoneme exists in the phoneme list (mostly phonemes.txt), but produces wrong results because the types of the phonemes are misconfigured. Many people missed some phonemes in their dictionary and had trouble debugging.

This PR adds some checks so that all phonemes should be defined in dictionary if the inputs depend on the phoneme types. If not, OpenUTAU shows an explicit error message.