### PR TITLE
Improve error message when parameter is missing for DiffSinger acoustic models

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -324,6 +324,10 @@ namespace OpenUtau.Core.DiffSinger {
                     } else{
                         userEnergy = Enumerable.Repeat(0d, totalFrames);
                     }
+                    if (varianceResult.energy == null) {
+                        throw new KeyNotFoundException(
+                            "The parameter \"energy\" required by acoustic model is not found in variance predictions.");
+                    }
                     var predictedEnergy = DiffSingerUtils.ResampleCurve(varianceResult.energy, totalFrames);
                     var energy = predictedEnergy.Zip(userEnergy, (x,y)=>(float)Math.Min(x + y*12/100, 0)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("energy", 
@@ -334,6 +338,10 @@ namespace OpenUtau.Core.DiffSinger {
                     var userBreathiness = DiffSingerUtils.SampleCurve(phrase, phrase.breathiness,
                         0, frameMs, totalFrames, headFrames, tailFrames,
                         x => x);
+                    if (varianceResult.breathiness == null) {
+                        throw new KeyNotFoundException(
+                            "The parameter \"breathiness\" required by acoustic model is not found in variance predictions.");
+                    }
                     var predictedBreathiness = DiffSingerUtils.ResampleCurve(varianceResult.breathiness, totalFrames);
                     var breathiness = predictedBreathiness.Zip(userBreathiness, (x,y)=>(float)Math.Min(x + y*12/100, 0)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("breathiness", 
@@ -344,6 +352,10 @@ namespace OpenUtau.Core.DiffSinger {
                     var userVoicing = DiffSingerUtils.SampleCurve(phrase, phrase.voicing,
                         0, frameMs, totalFrames, headFrames, tailFrames,
                         x => x);
+                    if (varianceResult.voicing == null) {
+                        throw new KeyNotFoundException(
+                            "The parameter \"voicing\" required by acoustic model is not found in variance predictions.");
+                    }
                     var predictedVoicing = DiffSingerUtils.ResampleCurve(varianceResult.voicing, totalFrames);
                     var voicing = predictedVoicing.Zip(userVoicing, (x,y)=>(float)Math.Min(x + (y-100)*12/100, 0)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("voicing",
@@ -354,6 +366,10 @@ namespace OpenUtau.Core.DiffSinger {
                     var userTension = DiffSingerUtils.SampleCurve(phrase, phrase.tension,
                         0, frameMs, totalFrames, headFrames, tailFrames,
                         x => x);
+                    if (varianceResult.tension == null) {
+                        throw new KeyNotFoundException(
+                            "The parameter \"tension\" required by acoustic model is not found in variance predictions.");
+                    }
                     var predictedTension = DiffSingerUtils.ResampleCurve(varianceResult.tension, totalFrames);
                     var tension = predictedTension.Zip(userTension, (x,y)=>(float)(x + y * 5 / 100)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("tension",


### PR DESCRIPTION
This PR add checks to ensure all parameters required by the acoustic model are provided by the variance model. If some parameters are missing, OpenUTAU shows an explicit error message instead of throwing an `ArgumentNullException`.