### PR TITLE
Fix openutau crash when exporting midi file with a note above 127

### DIFF
--- a/OpenUtau.Core/Format/MidiWriter.cs
+++ b/OpenUtau.Core/Format/MidiWriter.cs
@@ -263,6 +263,10 @@ namespace OpenUtau.Core.Format {
                     using (var objectsManager = new TimedObjectsManager<TimedEvent>(trackChunk.Events)) {
                         var events = objectsManager.Objects;
                         foreach (UNote note in voicePart.notes) {
+                            //Ignore notes whose pitch is out of midi range
+                            if(note.tone < 0 || note.tone > 127){
+                                continue;
+                            }
                             string lyric = note.lyric;
                             if (lyric == "+") {
                                 lyric = "-";


### PR DESCRIPTION
The highest note possible on OpenUtau's piano roll is B9, or midi 131, while the highest note supported by midi standard is 127

Before this change, when exporting a project with such a high note to midi file, OpenUtau crashes. After this change, OpenUtau will ignore these notes.