### PR TITLE
[WIP] Create customizable english phonemizer

### DIFF
--- a/OpenUtau.Plugin.Builtin/Data/Resources.Designer.cs
+++ b/OpenUtau.Plugin.Builtin/Data/Resources.Designer.cs
@@ -83,6 +83,16 @@ namespace OpenUtau.Plugin.Builtin.Data {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
+        internal static byte[] en_custom_template {
+            get {
+                object obj = ResourceManager.GetObject("en_custom_template", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
         internal static byte[] en_xsampa_template {
             get {
                 object obj = ResourceManager.GetObject("en_xsampa_template", resourceCulture);

--- a/OpenUtau.Plugin.Builtin/Data/Resources.resx
+++ b/OpenUtau.Plugin.Builtin/Data/Resources.resx
@@ -127,6 +127,9 @@
   <data name="envccv_template" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>envccv.template.yaml;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="en_custom_template" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>en-custom.template.yaml;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="en_xsampa_template" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\en-xsampa.template.yaml;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>

--- a/OpenUtau.Plugin.Builtin/Data/en-custom.template.yaml
+++ b/OpenUtau.Plugin.Builtin/Data/en-custom.template.yaml
@@ -1,0 +1,126 @@
+%YAML 1.2
+---
+symbols:
+  - name: aa
+    type: vowel
+    rename: aa
+  - name: ae
+    type: vowel
+    rename: ae
+  - name: ah
+    type: vowel
+    rename: ah
+  - name: ao
+    type: vowel
+    rename: ao
+  - name: aw
+    type: vowel
+    rename: au
+  - name: ay
+    type: vowel
+    rename: ai
+  - name: b
+    type: consonant
+    rename: b
+  - name: ch
+    type: consonant
+    rename: ch
+  - name: d
+    type: consonant
+    rename: d
+  - name: dh
+    type: consonant
+    rename: dh
+  - name: eh
+    type: vowel
+    rename: eh
+  - name: er
+    type: vowel
+    rename: er
+  - name: ey
+    type: vowel
+    rename: ey
+  - name: f
+    type: consonant
+    rename: f
+  - name: g
+    type: consonant
+    rename: g
+  - name: hh
+    type: consonant
+    rename: hh
+  - name: ih
+    type: vowel
+    rename: ih
+  - name: iy
+    type: vowel
+    rename: iy
+  - name: jh
+    type: consonant
+    rename: jh
+  - name: k
+    type: consonant
+    rename: k
+  - name: l
+    type: consonant
+    rename: l
+  - name: m
+    type: consonant
+    rename: m
+  - name: n
+    type: consonant
+    rename: n
+  - name: ng
+    type: consonant
+    rename: ng
+  - name: ow
+    type: vowel
+    rename: ow
+  - name: oy
+    type: vowel
+    rename: oy
+  - name: p
+    type: consonant
+    rename: p
+  - name: r
+    type: consonant
+    rename: r
+  - name: s
+    type: consonant
+    rename: s
+  - name: sh
+    type: consonant
+    rename: sh
+  - name: t
+    type: consonant
+    rename: t
+  - name: th
+    type: consonant
+    rename: th
+  - name: uh
+    type: vowel
+    rename: uh
+  - name: uw
+    type: vowel
+    rename: uw
+  - name: v
+    type: consonant
+    rename: v
+  - name: w
+    type: consonant
+    rename: w
+  - name: y
+    type: consonant
+    rename: y
+  - name: z
+    type: consonant
+    rename: z
+  - name: zh
+    type: consonant
+    rename: zh
+  - name: dx
+    type: consonant
+    rename: dx
+  - name: ax
+    type: vowel
+    rename: ax

--- a/OpenUtau.Plugin.Builtin/Data/en-custom.template.yaml
+++ b/OpenUtau.Plugin.Builtin/Data/en-custom.template.yaml
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+tails:
+  - "-"
 symbols:
   - name: aa
     type: vowel
@@ -15,10 +17,10 @@ symbols:
     rename: ao
   - name: aw
     type: vowel
-    rename: au
+    rename: aw
   - name: ay
     type: vowel
-    rename: ai
+    rename: ay
   - name: b
     type: consonant
     rename: b

--- a/OpenUtau.Plugin.Builtin/Data/en-custom.template.yaml
+++ b/OpenUtau.Plugin.Builtin/Data/en-custom.template.yaml
@@ -16,10 +16,10 @@ symbols:
     type: vowel
     rename: ao
   - name: aw
-    type: vowel
+    type: diphthong
     rename: aw
   - name: ay
-    type: vowel
+    type: diphthong
     rename: ay
   - name: b
     type: consonant
@@ -40,7 +40,7 @@ symbols:
     type: vowel
     rename: er
   - name: ey
-    type: vowel
+    type: diphthong
     rename: ey
   - name: f
     type: consonant
@@ -76,10 +76,10 @@ symbols:
     type: consonant
     rename: ng
   - name: ow
-    type: vowel
+    type: diphthong
     rename: ow
   - name: oy
-    type: vowel
+    type: diphthong
     rename: oy
   - name: p
     type: consonant

--- a/OpenUtau.Plugin.Builtin/EnglishCustomizablePhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishCustomizablePhonemizer.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OpenUtau.Api;
+using OpenUtau.Core.G2p;
+using OpenUtau.Core.Ustx;
+
+namespace OpenUtau.Plugin.Builtin {
+    [Phonemizer("English Customizable Phonemizer", "EN CUSTOM", "TUBS", language: "EN")]
+    public class EnglishCustomizablePhonemizer : SyllableBasedPhonemizer {
+        public EnglishCustomizablePhonemizer () {
+            vowels = new string[] { "aa", "ae", "ah", "ao", "eh", "er", "ih", "iy", "uh", "uw", "ay", "ey", "oy", "ow", "aw", "ax" };
+            replacements = new Dictionary<string, string> { };
+        }
+        
+        protected override string GetDictionaryName() => "";
+        protected override IG2p LoadBaseDictionary() => new ArpabetG2p();
+        
+        private string[] vowels { get; set; }
+        protected override string[] GetVowels() => vowels;
+        protected override string[] GetConsonants() => new string[] { }; // All non-vowel symbols are consonants by default. No need to define
+        private Dictionary<string, string> replacements { get; set; }
+        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => replacements;
+
+        public override void SetSinger(USinger singer) {
+            if (this.singer != singer) {
+                string file = "";
+                if (singer.Location != null) {
+                    file = Path.Combine(singer.Location, "en-custom.yaml");
+                }
+
+                if (File.Exists(file)) {
+                    var data = Core.Yaml.DefaultDeserializer.Deserialize<EnglishCustomConfigData>(File.ReadAllText(file));
+                    var loadVowels = new List<string>();
+                    var loadReplacements = new Dictionary<string, string>();
+
+                    foreach (var symbol in data.symbols) { 
+                        var rename = symbol.rename ?? symbol.name;
+                        loadReplacements.Add(symbol.name, rename);
+                        if (symbol.type == "vowel") {
+                            loadVowels.Add(rename);
+                        }
+                    }
+                    vowels = loadVowels.ToArray();
+                    replacements = loadReplacements;
+                } else {
+                    File.WriteAllBytes(file, Data.Resources.en_custom_template);
+                }
+
+                ReadDictionaryAndInit();
+                this.singer = singer;
+            }
+        }
+
+        protected override List<string> ProcessSyllable(Syllable syllable) {
+            if (CanMakeAliasExtension(syllable)) {
+                return new List<string> { "null" };
+            }
+
+            var phonemes = new List<string>();
+            var symbols = new List<string>();
+            symbols.Add(syllable.prevV == "" ? "-" : syllable.prevV);
+            symbols.AddRange(syllable.cc);
+            if (syllable.cc.Length == 0) {
+                symbols.Add(syllable.v);
+            }
+
+            for (int i = 0; i < symbols.Count - 1; i++) {
+                phonemes.Add($"{symbols[i]} {symbols[i + 1]}");
+            }
+
+            if (syllable.cc.Length > 0) {
+                var cv = new[] { $"{syllable.cc.Last()}{syllable.v}",
+                $"{syllable.cc.Last()} {syllable.v}"};
+                if (!TryAddPhoneme(phonemes, syllable.vowelTone, cv)) {
+                    phonemes.Add(cv[1]);
+                }
+            }
+
+            return phonemes;
+        }
+
+        protected override List<string> ProcessEnding(Ending ending) {
+            var phonemes = new List<string>();
+            var symbols = new List<string>();
+            symbols.Add(ending.prevV);
+            symbols.AddRange(ending.cc);
+            symbols.Add("-");
+
+            for (int i = 0; i < symbols.Count - 1; i++) {
+                phonemes.Add($"{symbols[i]} {symbols[i + 1]}");
+            }
+            return phonemes;
+        }
+    }
+
+    public class EnglishCustomConfigData {
+        public struct SymbolData {
+            public string name;
+            public string type;
+            public string? rename;
+        }
+
+        public SymbolData[] symbols;
+    }
+}

--- a/OpenUtau.Plugin.Builtin/EnglishCustomizablePhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishCustomizablePhonemizer.cs
@@ -29,6 +29,7 @@ namespace OpenUtau.Plugin.Builtin {
 
         private string[] tails;
         private CombinedPhoneme[] combinations;
+        private Dictionary<string, string[]> splits;
 
         public override void SetSinger(USinger singer) {
             if (this.singer != singer) {
@@ -60,7 +61,6 @@ namespace OpenUtau.Plugin.Builtin {
                     replacements = loadReplacements;
 
                     if (data.combinations != null) {
-                        //combinations = new Dictionary<string, string>();
                         var loadCombinations = new List<CombinedPhoneme>();
                         foreach (var combo in data.combinations) {
                             loadCombinations.Add(new CombinedPhoneme {
@@ -71,7 +71,14 @@ namespace OpenUtau.Plugin.Builtin {
                         }
                         combinations = loadCombinations.ToArray();
                     }
-                } else {
+
+                    if (data.splits != null) {
+                        splits = new Dictionary<string, string[]>();
+                        foreach (var split in data.splits) {
+                            splits.Add(split.before, split.after);
+                        }
+                    }
+                } else if (singer.Location != null) {
                     File.WriteAllBytes(file, Data.Resources.en_custom_template);
                 }
 
@@ -93,6 +100,18 @@ namespace OpenUtau.Plugin.Builtin {
                     symbolString = symbolString.Replace(combo.before, combo.after);
                 }
                 symbols = symbolString.Split();
+            }
+
+            if (splits != null) {
+                var adjustedSymbols = new List<string>();
+                foreach(var symbol in symbols) {
+                    if (splits.ContainsKey(symbol)) {
+                        adjustedSymbols.AddRange(splits[symbol]);
+                    } else {
+                        adjustedSymbols.Add(symbol);
+                    }
+                }
+                symbols = adjustedSymbols.ToArray();
             }
 
             return symbols;
@@ -177,5 +196,12 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         public CombinePhonemeData[]? combinations;
+
+        public struct SplitPhonemeData {
+            public string before;
+            public string[] after;
+        }
+
+        public SplitPhonemeData[]? splits;
     }
 }

--- a/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
@@ -673,7 +673,7 @@ namespace OpenUtau.Plugin.Builtin {
             return MakeSimpleResult(note.lyric.Substring(1));
         }
 
-        private void ReadDictionaryAndInit() {
+        protected void ReadDictionaryAndInit() {
             var dictionaryName = GetDictionaryName();
             if (dictionaryName == null) {
                 return;

--- a/OpenUtau.Test/Files/en_custom_a/character.txt
+++ b/OpenUtau.Test/Files/en_custom_a/character.txt
@@ -1,0 +1,1 @@
+name=en_custom_a

--- a/OpenUtau.Test/Files/en_custom_a/en-custom.yaml
+++ b/OpenUtau.Test/Files/en_custom_a/en-custom.yaml
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+tails:
+  - "-"
 symbols:
   - name: aa
     type: vowel

--- a/OpenUtau.Test/Files/en_custom_a/en-custom.yaml
+++ b/OpenUtau.Test/Files/en_custom_a/en-custom.yaml
@@ -1,0 +1,112 @@
+%YAML 1.2
+---
+symbols:
+  - name: aa
+    type: vowel
+    rename: Q
+  - name: ae
+    type: vowel
+    rename: "{"
+  - name: ah
+    type: vowel
+    rename: V
+  - name: ao
+    type: vowel
+    rename: "O:"
+  - name: aw
+    type: vowel
+    rename: aU
+  - name: ay
+    type: vowel
+    rename: aI
+  - name: b
+    type: consonant
+  - name: ch
+    type: consonant
+    rename: tS
+  - name: d
+    type: consonant
+  - name: dh
+    type: consonant
+    rename: D
+  - name: eh
+    type: vowel
+    rename: e
+  - name: er
+    type: vowel
+    rename: "@r"
+  - name: ey
+    type: vowel
+    rename: eI
+  - name: f
+    type: consonant
+  - name: g
+    type: consonant
+  - name: hh
+    type: consonant
+    rename: h
+  - name: ih
+    type: vowel
+    rename: I
+  - name: iy
+    type: vowel
+    rename: "i:"
+  - name: jh
+    type: consonant
+    rename: dZ
+  - name: k
+    type: consonant
+  - name: l
+    type: consonant
+  - name: m
+    type: consonant
+  - name: n
+    type: consonant
+  - name: ng
+    type: consonant
+    rename: N
+  - name: ow
+    type: vowel
+    rename: "@U"
+  - name: oy
+    type: vowel
+    rename: OI
+  - name: p
+    type: consonant
+  - name: r
+    type: consonant
+    rename: r
+  - name: s
+    type: consonant
+  - name: sh
+    type: consonant
+    rename: S
+  - name: t
+    type: consonant
+  - name: th
+    type: consonant
+    rename: T
+  - name: uh
+    type: vowel
+    rename: U
+  - name: uw
+    type: vowel
+    rename: "u:"
+  - name: v
+    type: consonant
+  - name: w
+    type: consonant
+  - name: y
+    type: consonant
+    rename: j
+  - name: z
+    type: consonant
+  - name: zh
+    type: consonant
+    rename: Z
+  - name: dx
+    type: consonant
+    rename: "4"
+  - name: ax
+    type: vowel
+    rename: "@"

--- a/OpenUtau.Test/Files/en_custom_a/oto.ini
+++ b/OpenUtau.Test/Files/en_custom_a/oto.ini
@@ -1,0 +1,3 @@
+a.wav=hV,,,,,
+a.wav=l@U,,,,,
+a.wav=w@r,,,,,

--- a/OpenUtau.Test/Files/en_custom_b/character.txt
+++ b/OpenUtau.Test/Files/en_custom_b/character.txt
@@ -1,0 +1,1 @@
+name=en_custom_b

--- a/OpenUtau.Test/Files/en_custom_b/en-custom.yaml
+++ b/OpenUtau.Test/Files/en_custom_b/en-custom.yaml
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+tails:
+  - "-"
 symbols:
   - name: aa
     type: vowel
@@ -15,10 +17,10 @@ symbols:
     rename: AO
   - name: aw
     type: vowel
-    rename: AU
+    rename: AW
   - name: ay
     type: vowel
-    rename: AI
+    rename: AY
   - name: b
     type: consonant
     rename: B

--- a/OpenUtau.Test/Files/en_custom_b/en-custom.yaml
+++ b/OpenUtau.Test/Files/en_custom_b/en-custom.yaml
@@ -1,0 +1,126 @@
+%YAML 1.2
+---
+symbols:
+  - name: aa
+    type: vowel
+    rename: AA
+  - name: ae
+    type: vowel
+    rename: AE
+  - name: ah
+    type: vowel
+    rename: AH
+  - name: ao
+    type: vowel
+    rename: AO
+  - name: aw
+    type: vowel
+    rename: AU
+  - name: ay
+    type: vowel
+    rename: AI
+  - name: b
+    type: consonant
+    rename: B
+  - name: ch
+    type: consonant
+    rename: CH
+  - name: d
+    type: consonant
+    rename: D
+  - name: dh
+    type: consonant
+    rename: DH
+  - name: eh
+    type: vowel
+    rename: EH
+  - name: er
+    type: vowel
+    rename: ER
+  - name: ey
+    type: vowel
+    rename: EY
+  - name: f
+    type: consonant
+    rename: F
+  - name: g
+    type: consonant
+    rename: G
+  - name: hh
+    type: consonant
+    rename: HH
+  - name: ih
+    type: vowel
+    rename: IH
+  - name: iy
+    type: vowel
+    rename: IY
+  - name: jh
+    type: consonant
+    rename: JH
+  - name: k
+    type: consonant
+    rename: K
+  - name: l
+    type: consonant
+    rename: L
+  - name: m
+    type: consonant
+    rename: M
+  - name: n
+    type: consonant
+    rename: N
+  - name: ng
+    type: consonant
+    rename: NG
+  - name: ow
+    type: vowel
+    rename: OW
+  - name: oy
+    type: vowel
+    rename: OY
+  - name: p
+    type: consonant
+    rename: P
+  - name: r
+    type: consonant
+    rename: R
+  - name: s
+    type: consonant
+    rename: S
+  - name: sh
+    type: consonant
+    rename: SH
+  - name: t
+    type: consonant
+    rename: T
+  - name: th
+    type: consonant
+    rename: TH
+  - name: uh
+    type: vowel
+    rename: UH
+  - name: uw
+    type: vowel
+    rename: UW
+  - name: v
+    type: consonant
+    rename: V
+  - name: w
+    type: consonant
+    rename: W
+  - name: y
+    type: consonant
+    rename: Y
+  - name: z
+    type: consonant
+    rename: Z
+  - name: zh
+    type: consonant
+    rename: ZH
+  - name: dx
+    type: consonant
+    rename: DX
+  - name: ax
+    type: vowel
+    rename: AX

--- a/OpenUtau.Test/Files/en_custom_c/character.txt
+++ b/OpenUtau.Test/Files/en_custom_c/character.txt
@@ -1,0 +1,1 @@
+name=en_custom_c

--- a/OpenUtau.Test/Files/en_custom_c/en-custom.yaml
+++ b/OpenUtau.Test/Files/en_custom_c/en-custom.yaml
@@ -1,5 +1,9 @@
 %YAML 1.2
 ---
+tails:
+  - "-"
+  - "R"
+  - "br"
 symbols:
   - name: aa
     type: vowel

--- a/OpenUtau.Test/Files/en_custom_c/en-custom.yaml
+++ b/OpenUtau.Test/Files/en_custom_c/en-custom.yaml
@@ -14,9 +14,9 @@ symbols:
   - name: ao
     type: vowel
   - name: aw
-    type: vowel
+    type: diphthong
   - name: ay
-    type: vowel
+    type: diphthong
   - name: b
     type: consonant
   - name: ch
@@ -30,7 +30,7 @@ symbols:
   - name: er
     type: vowel
   - name: ey
-    type: vowel
+    type: diphthong
   - name: f
     type: consonant
   - name: g
@@ -56,9 +56,9 @@ symbols:
   - name: ng
     type: consonant
   - name: ow
-    type: vowel
+    type: diphthong
   - name: oy
-    type: vowel
+    type: diphthong
   - name: p
     type: consonant
   - name: r
@@ -93,10 +93,20 @@ symbols:
   - name: ax
     type: vowel
   - name: ing
-    type: vowel
+    type: diphthong
   - name: ul
-    type: vowel
+    type: diphthong
   - name: st
     type: consonant
   - name: ar
-    type: vowel
+    type: diphthong
+  - name: tr
+    type: consonant
+combinations:
+  - before: "T r"
+    after: "tr"  
+  - before: "ih ng"
+    after: "ing"
+  - before: "s T"
+    after: "st"
+    prefix: "s"

--- a/OpenUtau.Test/Files/en_custom_c/en-custom.yaml
+++ b/OpenUtau.Test/Files/en_custom_c/en-custom.yaml
@@ -1,0 +1,98 @@
+%YAML 1.2
+---
+symbols:
+  - name: aa
+    type: vowel
+  - name: ae
+    type: vowel
+  - name: ah
+    type: vowel
+  - name: ao
+    type: vowel
+  - name: aw
+    type: vowel
+  - name: ay
+    type: vowel
+  - name: b
+    type: consonant
+  - name: ch
+    type: consonant
+  - name: d
+    type: consonant
+  - name: dh
+    type: consonant
+  - name: eh
+    type: vowel
+  - name: er
+    type: vowel
+  - name: ey
+    type: vowel
+  - name: f
+    type: consonant
+  - name: g
+    type: consonant
+  - name: hh
+    type: consonant
+  - name: ih
+    type: vowel
+  - name: iy
+    type: vowel
+  - name: jh
+    type: consonant
+  - name: k
+    type: consonant
+    rename: K
+  - name: l
+    type: consonant
+    rename: L
+  - name: m
+    type: consonant
+  - name: n
+    type: consonant
+  - name: ng
+    type: consonant
+  - name: ow
+    type: vowel
+  - name: oy
+    type: vowel
+  - name: p
+    type: consonant
+  - name: r
+    type: consonant
+  - name: s
+    type: consonant
+  - name: sh
+    type: consonant
+  - name: t
+    type: consonant
+    rename: T
+  - name: th
+    type: consonant
+  - name: uh
+    type: vowel
+  - name: uw
+    type: vowel
+  - name: v
+    type: consonant
+  - name: w
+    type: consonant
+    rename: W
+  - name: y
+    type: consonant
+  - name: z
+    type: consonant
+  - name: zh
+    type: consonant
+  - name: dx
+    type: consonant
+    rename: DX
+  - name: ax
+    type: vowel
+  - name: ing
+    type: vowel
+  - name: ul
+    type: vowel
+  - name: st
+    type: consonant
+  - name: ar
+    type: vowel

--- a/OpenUtau.Test/Files/en_custom_d/character.txt
+++ b/OpenUtau.Test/Files/en_custom_d/character.txt
@@ -1,0 +1,1 @@
+name=en_custom_d

--- a/OpenUtau.Test/Files/en_custom_d/en-custom.yaml
+++ b/OpenUtau.Test/Files/en_custom_d/en-custom.yaml
@@ -1,0 +1,122 @@
+%YAML 1.2
+---
+tails:
+  - "-"
+symbols:
+  - name: aa
+    type: vowel
+    rename: A
+  - name: ae
+    type: vowel
+    rename: "{"
+  - name: ah
+    type: vowel
+    rename: V
+  - name: ao
+    type: vowel
+    rename: O
+  - name: aw
+    type: diphthong
+  - name: ay
+    type: diphthong
+  - name: b
+    type: consonant
+  - name: ch
+    type: consonant
+    rename: tS
+  - name: d
+    type: consonant
+  - name: dh
+    type: consonant
+    rename: D
+  - name: eh
+    type: vowel
+    rename: E
+  - name: er
+    type: vowel
+    rename: "3"
+  - name: ey
+    type: diphthong
+  - name: f
+    type: consonant
+  - name: g
+    type: consonant
+  - name: hh
+    type: consonant
+    rename: h
+  - name: ih
+    type: vowel
+    rename: I
+  - name: iy
+    type: vowel
+    rename: i
+  - name: jh
+    type: consonant
+    rename: dZ
+  - name: k
+    type: consonant
+  - name: l
+    type: consonant
+  - name: m
+    type: consonant
+  - name: n
+    type: consonant
+  - name: ng
+    type: consonant
+    rename: N
+  - name: ow
+    type: diphthong
+  - name: oy
+    type: diphthong
+  - name: p
+    type: consonant
+  - name: r
+    type: consonant
+  - name: s
+    type: consonant
+  - name: sh
+    type: consonant
+    rename: S
+  - name: t
+    type: consonant
+  - name: th
+    type: consonant
+    rename: T
+  - name: uh
+    type: vowel
+    rename: U
+  - name: uw
+    type: vowel
+    rename: u
+  - name: v
+    type: consonant
+  - name: w
+    type: consonant
+  - name: y
+    type: consonant
+    rename: j
+  - name: z
+    type: consonant
+  - name: zh
+    type: consonant
+    rename: Z
+  - name: ax
+    type: vowel
+    rename: "@"
+  - name: a
+    type: vowel
+  - name: e
+    type: vowel
+  - name: o
+    type: vowel
+splits:
+  - before: ay
+    after: [a, I]
+  - before: ey
+    after: [e, I]
+  - before: oy
+    after: [O, I]
+  - before: ow
+    after: [o, U]
+  - before: aw
+    after: [a, U]

--- a/OpenUtau.Test/Plugins/EnCustomTest.cs
+++ b/OpenUtau.Test/Plugins/EnCustomTest.cs
@@ -34,5 +34,19 @@ namespace OpenUtau.Test.Plugins {
                     "T W", "W ing", "ing K", "K ul", "ul L",
                     "L ih", "ih DX", "DX ul", "ul st", "st ar", "ar -"});
         }
+
+        [Theory]
+        [InlineData(
+            new string[] { "hey", "-"},
+            new string[] { "- hh", "hh ey", "ey -"})]
+        [InlineData(
+            new string[] { "hey", "R"},
+            new string[] { "- hh", "hh ey", "ey R" })]
+        [InlineData(
+            new string[] { "hey", "br", "yeah"},
+            new string[] { "- hh", "hh ey", "ey br", "- y", "y ae", "ae -" })]
+        public void CustomTailTest(string[] lyrics, string[] aliases) {
+            SameAltsTonesColorsTest("en_custom_c", lyrics, aliases, "", "C4", "");
+        }
     }
 }

--- a/OpenUtau.Test/Plugins/EnCustomTest.cs
+++ b/OpenUtau.Test/Plugins/EnCustomTest.cs
@@ -1,10 +1,9 @@
 ﻿using OpenUtau.Api;
 using OpenUtau.Plugin.Builtin;
-using OpenUtau.Plugins;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace OpenUtau.Test.Plugins {
+namespace OpenUtau.Plugins {
     public class EnCustomTest : PhonemizerTestBase {
         public EnCustomTest(ITestOutputHelper output) : base(output) { }
         protected override Phonemizer CreatePhonemizer() {
@@ -64,6 +63,18 @@ namespace OpenUtau.Test.Plugins {
             new string[] { "- L", "L ae", "ae s", "st -" })]
         public void CombinePhonemesTest(string[] lyrics, string[] aliases) {
             SameAltsTonesColorsTest("en_custom_c", lyrics, aliases, "", "C4", "");
+        }
+
+        [Fact]
+        public void SplitPhonemesTest() {
+            SameAltsTonesColorsTest("en_custom_d",
+                new string[] { "hi", "hey", "toy", "go", "down" },
+                new string[] { "- h", "h a", "a I", "I h", 
+                    "h e", "e I", "I t",
+                    "t O", "O I", "I g",
+                    "g o", "o U", "U d",
+                    "d a", "a U", "U n", "n -"},
+                "", "C4", "");
         }
     }
 }

--- a/OpenUtau.Test/Plugins/EnCustomTest.cs
+++ b/OpenUtau.Test/Plugins/EnCustomTest.cs
@@ -1,0 +1,38 @@
+﻿using OpenUtau.Api;
+using OpenUtau.Plugin.Builtin;
+using OpenUtau.Plugins;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenUtau.Test.Plugins {
+    public class EnCustomTest : PhonemizerTestBase {
+        public EnCustomTest(ITestOutputHelper output) : base(output) { }
+        protected override Phonemizer CreatePhonemizer() {
+            return new EnglishCustomizablePhonemizer();
+        }
+
+        [Theory]
+        [InlineData("en_custom_a",
+            new string[] { "- h", "hV", "V l", "l@U", "@U w", "w@r", "@r l", "l d", "d -" })]
+        [InlineData("en_custom_b",
+            new string[] { "- HH", "HH AH", "AH L", "L OW", "OW W", "W ER", "ER L", "L D", "D -" })]
+        public void BasicPhonemizingTest(string singerName, string[] aliases) {
+            SameAltsTonesColorsTest(singerName, new string[] {"hello", "world"}, aliases, "", "C4", "");
+        }
+
+        // validate in UI that extra vowels behave as vowels for phoneme timing
+        [Fact]
+        public void ExtraPhonemeTest() {
+            RunPhonemizeTest("en_custom_c", 
+                new NoteParams[] { 
+                    new NoteParams { lyric = "twinkle", hint = "", tone = "C4", phonemes = SamePhonemeParams(9, 0, 0, "") },
+                    new NoteParams { lyric = "twinkle", hint = "T W ing K ul", tone = "C4", phonemes = SamePhonemeParams(9, 0, 0, "") },
+                    new NoteParams { lyric = "little", hint = "L ih DX ul", tone = "C4", phonemes = SamePhonemeParams(9, 0, 0, "") },
+                    new NoteParams { lyric = "star", hint = "st ar", tone = "C4", phonemes = SamePhonemeParams(9, 0, 0, "") }
+                }, 
+                new string[] { "- T", "T W", "W ih","ih ng", "ng K", "K ah", "ah L", "L T",
+                    "T W", "W ing", "ing K", "K ul", "ul L",
+                    "L ih", "ih DX", "DX ul", "ul st", "st ar", "ar -"});
+        }
+    }
+}

--- a/OpenUtau.Test/Plugins/EnCustomTest.cs
+++ b/OpenUtau.Test/Plugins/EnCustomTest.cs
@@ -30,9 +30,9 @@ namespace OpenUtau.Test.Plugins {
                     new NoteParams { lyric = "little", hint = "L ih DX ul", tone = "C4", phonemes = SamePhonemeParams(9, 0, 0, "") },
                     new NoteParams { lyric = "star", hint = "st ar", tone = "C4", phonemes = SamePhonemeParams(9, 0, 0, "") }
                 }, 
-                new string[] { "- T", "T W", "W ih","ih ng", "ng K", "K ah", "ah L", "L T",
+                new string[] { "- T", "T W", "W ing", "ing K", "K ah", "ah L", "L T",
                     "T W", "W ing", "ing K", "K ul", "ul L",
-                    "L ih", "ih DX", "DX ul", "ul st", "st ar", "ar -"});
+                    "L ih", "ih DX", "DX ul", "ul s", "st ar", "ar -"});
         }
 
         [Theory]
@@ -46,6 +46,23 @@ namespace OpenUtau.Test.Plugins {
             new string[] { "hey", "br", "yeah"},
             new string[] { "- hh", "hh ey", "ey br", "- y", "y ae", "ae -" })]
         public void CustomTailTest(string[] lyrics, string[] aliases) {
+            SameAltsTonesColorsTest("en_custom_c", lyrics, aliases, "", "C4", "");
+        }
+
+        [Theory]
+        [InlineData(
+            new string[] { "true"},
+            new string[] { "- tr", "tr uw", "uw -"})]
+        [InlineData(
+            new string[] { "think" },
+            new string[] { "- th", "th ing", "ing K", "K -" })]
+        [InlineData(
+            new string[] { "singing" },
+            new string[] { "- s", "s ing", "ing ing", "ing -" })]
+        [InlineData(
+            new string[] { "last" },
+            new string[] { "- L", "L ae", "ae s", "st -" })]
+        public void CombinePhonemesTest(string[] lyrics, string[] aliases) {
             SameAltsTonesColorsTest("en_custom_c", lyrics, aliases, "", "C4", "");
         }
     }


### PR DESCRIPTION
All English phonemizers rely on the same underlying Arpabet G2P. Non-arpabet notation is achieved by renaming the phoneme symbols. This customizable phonemizer allows users to specify their own mapping from arpabet in a per-voicebank config file. The config file also allows adding custom phonemes, including extra vowels that will be correctly treated as vowels when timing the phonemes within a note.