### PR TITLE
Diffsinger phonemizers: G2p results add langcode by default; Check if phoneme is supported by duration model

### DIFF
--- a/OpenUtau.Core/Api/G2pDictionary.cs
+++ b/OpenUtau.Core/Api/G2pDictionary.cs
@@ -120,6 +120,15 @@ namespace OpenUtau.Api {
 
             public Builder Load(string input) {
                 var data = Core.Yaml.DefaultDeserializer.Deserialize<G2pDictionaryData>(input);
+                return Load(data);
+            }
+
+            public Builder Load(TextReader textReader) {
+                var data = Core.Yaml.DefaultDeserializer.Deserialize<G2pDictionaryData>(textReader);
+                return Load(data);
+            }
+
+            public Builder Load(G2pDictionaryData data){
                 if (data.symbols != null) {
                     foreach (var symbolData in data.symbols) {
                         AddSymbol(symbolData.symbol, symbolData.type);
@@ -129,17 +138,6 @@ namespace OpenUtau.Api {
                     foreach (var entry in data.entries) {
                         AddEntry(entry.grapheme, entry.phonemes);
                     }
-                }
-                return this;
-            }
-
-            public Builder Load(TextReader textReader) {
-                var data = Core.Yaml.DefaultDeserializer.Deserialize<G2pDictionaryData>(textReader);
-                foreach (var symbolData in data.symbols) {
-                    AddSymbol(symbolData.symbol, symbolData.type);
-                }
-                foreach (var entry in data.entries) {
-                    AddEntry(entry.grapheme, entry.phonemes);
                 }
                 return this;
             }

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -83,7 +83,7 @@ namespace OpenUtau.Core.DiffSinger
             }
             this.frameMs = dsConfig.frameMs();
             //Load g2p
-            g2p = LoadG2p(rootPath);
+            g2p = LoadG2p(rootPath, dsConfig.use_lang_id);
             //Load phonemes list
             string phonemesPath = Path.Combine(rootPath, dsConfig.phonemes);
             phonemeTokens = DiffSingerUtils.LoadPhonemes(phonemesPath);
@@ -109,7 +109,7 @@ namespace OpenUtau.Core.DiffSinger
             return true;
         }
 
-        protected virtual IG2p LoadG2p(string rootPath) {
+        protected virtual IG2p LoadG2p(string rootPath, bool useLangId = false) {
             //Each phonemizer has a delicated dictionary name, such as dsdict-en.yaml, dsdict-ru.yaml.
             //If this dictionary exists, load it.
             //If not, load dsdict.yaml.
@@ -138,13 +138,13 @@ namespace OpenUtau.Core.DiffSinger
         //Check if the phoneme is supported. If unsupported, return an empty string.
         //And apply language prefix to phoneme
         string ValidatePhoneme(string phoneme){
-            if(g2p.IsValidSymbol(phoneme)){
+            if(g2p.IsValidSymbol(phoneme) && phonemeTokens.ContainsKey(phoneme)){
                 return phoneme;
             }
             var langCode = GetLangCode();
             if(langCode != String.Empty){
                 var phonemeWithLanguage = langCode + "/" + phoneme;
-                if(g2p.IsValidSymbol(phonemeWithLanguage)){
+                if(g2p.IsValidSymbol(phonemeWithLanguage)  && phonemeTokens.ContainsKey(phonemeWithLanguage)){
                     return phonemeWithLanguage;
                 }
             }
@@ -306,7 +306,7 @@ namespace OpenUtau.Core.DiffSinger
             var wordFound = new bool[phrase.Length];
             foreach (int wordIndex in Enumerable.Range(0, phrase.Length)) {
                 Note[] word = phrase[wordIndex];
-                var symbols = GetSymbols(word[0]);
+                var symbols = GetSymbols(word[0]).Where(s => phonemeTokens.ContainsKey(s)).ToArray();
                 if (symbols == null || symbols.Length == 0) {
                     symbols = new string[] { defaultPause };
                     wordFound[wordIndex] = false;


### PR DESCRIPTION
This change is made to solve strange bugs caused by G2p, where the phonemizer thought the phoneme is supported but actually it isn't.
- For DiffSinger G2p phonemizers, if the duration uses multi-dict, replacements from bare g2p phoneme to `<langcode>/<phoneme>` will be added by default. No need to have `{from: b, to: en/b}` replacements. 
- When parsing phonetic hints, diffsinger phonemizer will check if the phoneme is supported by duration model before it desides whether to apply language prefix. (this bug made it unable to use DIFFS JA with phonetic hint without prefix such as `[h a]`)
- After running G2p, phonemes unsupported by duration model will be filtered out, which limits the error inside one note before it goes into duration model and affect the whole sentence.