### PR TITLE
Remove support for outdated DiffSinger script files

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -160,9 +160,8 @@
   <system:String x:Key="menu.file">File</system:String>
   <system:String x:Key="menu.file.exit">Exit</system:String>
   <system:String x:Key="menu.file.exportaudio">Export Audio</system:String>
-  <system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>
+  <system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>
   <system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>
   <system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>
   <system:String x:Key="menu.file.exportproject">Export Project</system:String>

--- a/OpenUtau/Strings/Strings.de-DE.axaml
+++ b/OpenUtau/Strings/Strings.de-DE.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">Datei</system:String>
   <system:String x:Key="menu.file.exit">Verlassen</system:String>
   <system:String x:Key="menu.file.exportaudio">Audio exportieren</system:String>
-  <system:String x:Key="menu.file.exportds">Exportiere DiffSinger Scripts To</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Exportiere DiffSinger Scripts To (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Exportiere DiffSinger Scripts To (v2, ohne pitch curve)</system:String>
+  <system:String x:Key="menu.file.exportds.v2">Exportiere DiffSinger Scripts To</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">Exportiere DiffSinger Scripts To (ohne pitch curve)</system:String>
   <system:String x:Key="menu.file.exportmidi">Midi Datei exportieren</system:String>
   <system:String x:Key="menu.file.exportmixdown">zu Wav Datei konvertieren</system:String>
   <system:String x:Key="menu.file.exportproject">Projekt exportieren</system:String>

--- a/OpenUtau/Strings/Strings.es-ES.axaml
+++ b/OpenUtau/Strings/Strings.es-ES.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">Archivo</system:String>
   <system:String x:Key="menu.file.exit">Salir</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>-->
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.es-MX.axaml
+++ b/OpenUtau/Strings/Strings.es-MX.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">_Archivo</system:String>
   <system:String x:Key="menu.file.exit">_Salir</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>-->
   <system:String x:Key="menu.file.exportmidi">Exportar como MIDI</system:String>
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.fi-FI.axaml
+++ b/OpenUtau/Strings/Strings.fi-FI.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">Tiedosto</system:String>
   <system:String x:Key="menu.file.exit">Lopeta OpenUtau</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>-->
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.fr-FR.axaml
+++ b/OpenUtau/Strings/Strings.fr-FR.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">Fichier</system:String>
   <system:String x:Key="menu.file.exit">Quitter</system:String>
   <system:String x:Key="menu.file.exportaudio">Exporter l'audio</system:String>
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>-->
   <system:String x:Key="menu.file.exportmidi">Exporter un MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Mixer en fichier Wav</system:String>
   <system:String x:Key="menu.file.exportproject">Exporter le projet</system:String>

--- a/OpenUtau/Strings/Strings.id-ID.axaml
+++ b/OpenUtau/Strings/Strings.id-ID.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">Berkas</system:String>
   <system:String x:Key="menu.file.exit">Keluar</system:String>
   <system:String x:Key="menu.file.exportaudio">Ekspor Audio</system:String>
-  <system:String x:Key="menu.file.exportds">Ekspor Skrip DiffSinger Ke</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Ekspor Skrip DiffSinger Ke (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Ekspor Skrip DiffSinger Ke (v2, tanpa kurva nada)</system:String>
+  <system:String x:Key="menu.file.exportds.v2">Ekspor Skrip DiffSinger Ke</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">Ekspor Skrip DiffSinger Ke (tanpa kurva nada)</system:String>
   <system:String x:Key="menu.file.exportmidi">Ekspor Berkas Midi</system:String>
   <system:String x:Key="menu.file.exportmixdown">Campur ke Berkas Wav</system:String>
   <system:String x:Key="menu.file.exportproject">Ekspor Proyek</system:String>

--- a/OpenUtau/Strings/Strings.it-IT.axaml
+++ b/OpenUtau/Strings/Strings.it-IT.axaml
@@ -153,9 +153,8 @@
   <!--<system:String x:Key="menu.file">File</system:String>-->
   <system:String x:Key="menu.file.exit">Esci</system:String>
   <system:String x:Key="menu.file.exportaudio">Esporta Audio</system:String>
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>-->
   <system:String x:Key="menu.file.exportmidi">Esporta File MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Mixdown su file WAV</system:String>
   <system:String x:Key="menu.file.exportproject">Esporta progetto</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -158,9 +158,8 @@
   <system:String x:Key="menu.file">ファイル</system:String>
   <system:String x:Key="menu.file.exit">OpenUTAUを終了</system:String>
   <system:String x:Key="menu.file.exportaudio">音声をエクスポート</system:String>
-  <system:String x:Key="menu.file.exportds">DiffSinger Scriptsをエクスポート...</system:String>
-  <system:String x:Key="menu.file.exportds.v2">DiffSinger Scriptsをエクスポート(v2)...</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">DiffSinger Scriptsをエクスポート(v2, ピッチカーブなし)...</system:String>
+  <system:String x:Key="menu.file.exportds.v2">DiffSinger Scriptsをエクスポート...</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">DiffSinger Scriptsをエクスポート(ピッチカーブなし)...</system:String>
   <system:String x:Key="menu.file.exportmidi">MIDIをエクスポート</system:String>
   <system:String x:Key="menu.file.exportmixdown">ミックスダウンしたWavファイルを出力</system:String>
   <system:String x:Key="menu.file.exportproject">プロジェクトファイルをエクスポート</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">파일</system:String>
   <system:String x:Key="menu.file.exit">나가기</system:String>
   <system:String x:Key="menu.file.exportaudio">[내보내기] 오디오</system:String>
-  <system:String x:Key="menu.file.exportds">[다른 이름으로 저장] DiffSinger 스크립트로...</system:String>
-  <system:String x:Key="menu.file.exportds.v2">[다른 이름으로 저장] DiffSinger 스크립트로 (v2)...</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">[다른 이름으로 저장] DiffSinger 스크립트로 (v2, 피치선 제외)...</system:String>
+  <system:String x:Key="menu.file.exportds.v2">[다른 이름으로 저장] DiffSinger 스크립트로...</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">[다른 이름으로 저장] DiffSinger 스크립트로 (피치선 제외)...</system:String>
   <system:String x:Key="menu.file.exportmidi">Midi로...</system:String>
   <system:String x:Key="menu.file.exportmixdown">Wav로 믹스다운</system:String>
   <system:String x:Key="menu.file.exportproject">[내보내기] 프로젝트</system:String>

--- a/OpenUtau/Strings/Strings.nl-NL.axaml
+++ b/OpenUtau/Strings/Strings.nl-NL.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">_Bestand</system:String>
   <system:String x:Key="menu.file.exit">_Afsluiten</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>-->
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.pl-PL.axaml
+++ b/OpenUtau/Strings/Strings.pl-PL.axaml
@@ -160,9 +160,8 @@
   <system:String x:Key="menu.file">Plik</system:String>
   <system:String x:Key="menu.file.exit">Zamknij</system:String>
   <system:String x:Key="menu.file.exportaudio">Eksportuj audio</system:String>
-  <system:String x:Key="menu.file.exportds">Eksportuj skrypt DiffSinger do...</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Eksportuj skrypt DiffSinger do... (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Eksportuj skrypt DiffSinger do... (v2, bez krzywej wysokości dźwięku)</system:String>
+  <system:String x:Key="menu.file.exportds.v2">Eksportuj skrypt DiffSinger do... </system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">Eksportuj skrypt DiffSinger do... (bez krzywej wysokości dźwięku)</system:String>
   <system:String x:Key="menu.file.exportmidi">Eksportuj plik MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Zmiksuj do pliku WAV</system:String>
   <system:String x:Key="menu.file.exportproject">Eksportuj projekt</system:String>

--- a/OpenUtau/Strings/Strings.pt-BR.axaml
+++ b/OpenUtau/Strings/Strings.pt-BR.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">Arquivo</system:String>
   <system:String x:Key="menu.file.exit">Fechar</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>-->
   <system:String x:Key="menu.file.exportmidi">Exportar Arquivo Midi</system:String>
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.ru-RU.axaml
+++ b/OpenUtau/Strings/Strings.ru-RU.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">Файл</system:String>
   <system:String x:Key="menu.file.exit">Выход</system:String>
   <system:String x:Key="menu.file.exportaudio">Экспортировать аудио</system:String>
-  <system:String x:Key="menu.file.exportds">Экспортировать скрипты DiffSinger</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Экспортировать скрипты DiffSinger (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Экспортировать скрипты DiffSinger (v2, без кривой питча)</system:String>
+  <system:String x:Key="menu.file.exportds.v2">Экспортировать скрипты DiffSinger</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">Экспортировать скрипты DiffSinger (без кривой питча)</system:String>
   <system:String x:Key="menu.file.exportmidi">Экспорт midi-файла</system:String>
   <system:String x:Key="menu.file.exportmixdown">Свести в wav файл</system:String>
   <system:String x:Key="menu.file.exportproject">Экспортировать проект</system:String>

--- a/OpenUtau/Strings/Strings.th-TH.axaml
+++ b/OpenUtau/Strings/Strings.th-TH.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">ไฟล์</system:String>
   <system:String x:Key="menu.file.exit">ออก</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To</system:String>-->
+  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (without pitch curve)</system:String>-->
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.vi-VN.axaml
+++ b/OpenUtau/Strings/Strings.vi-VN.axaml
@@ -160,9 +160,8 @@
   <system:String x:Key="menu.file">Tệp</system:String>
   <system:String x:Key="menu.file.exit">Thoát ra</system:String>
   <system:String x:Key="menu.file.exportaudio">Xuất ra tệp nhạc</system:String>
-  <system:String x:Key="menu.file.exportds">Xuất thành dự án DiffSinger</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Xuất thành dự án DiffSinger (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Xuất thành dự án DiffSinger (v2, không kèm luyến giọng)</system:String>
+  <system:String x:Key="menu.file.exportds.v2">Xuất thành dự án DiffSinger</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">Xuất thành dự án DiffSinger (không kèm luyến giọng)</system:String>
   <system:String x:Key="menu.file.exportmidi">Xuất thành MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Gộp thành một tệp nhạc</system:String>
   <system:String x:Key="menu.file.exportproject">Xuất thành dự án</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">文件</system:String>
   <system:String x:Key="menu.file.exit">退出</system:String>
   <system:String x:Key="menu.file.exportaudio">导出音频</system:String>
-  <system:String x:Key="menu.file.exportds">导出DiffSinger脚本至</system:String>
-  <system:String x:Key="menu.file.exportds.v2">导出DiffSinger脚本至（v2）</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">导出DiffSinger脚本至（v2，不包含音高曲线）</system:String>
+  <system:String x:Key="menu.file.exportds.v2">导出DiffSinger脚本至</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">导出DiffSinger脚本至（不包含音高曲线）</system:String>
   <system:String x:Key="menu.file.exportmidi">导出Midi文件</system:String>
   <system:String x:Key="menu.file.exportmixdown">混缩为Wav文件</system:String>
   <system:String x:Key="menu.file.exportproject">导出工程</system:String>

--- a/OpenUtau/Strings/Strings.zh-TW.axaml
+++ b/OpenUtau/Strings/Strings.zh-TW.axaml
@@ -153,9 +153,8 @@
   <system:String x:Key="menu.file">檔案</system:String>
   <system:String x:Key="menu.file.exit">結束</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
+  <system:String x:Key="menu.file.exportds.v2">匯出DiffSinger腳本至</system:String>
+  <system:String x:Key="menu.file.exportds.v2withoutpitch">匯出DiffSinger腳本至（不包含音高曲線）</system:String>
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -60,7 +60,6 @@
               <MenuItem Header="{DynamicResource menu.file.exportust}" Click="OnMenuExportUst"/>
               <MenuItem Header="{DynamicResource menu.file.exportustto}" Click="OnMenuExportUstTo"/>
               <MenuItem Header="{DynamicResource menu.file.exportmidi}" Click="OnMenuExportMidi"/>
-              <MenuItem Header="{DynamicResource menu.file.exportds}" Click="OnMenuExportDsTo"/>
               <MenuItem Header="{DynamicResource menu.file.exportds.v2}" Click="OnMenuExportDsV2To"/>
               <MenuItem Header="{DynamicResource menu.file.exportds.v2withoutpitch}" Click="OnMenuExportDsV2WithoutPitchTo"/>
             </MenuItem>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -413,22 +413,6 @@ namespace OpenUtau.App.Views {
             }
         }
 
-        async void OnMenuExportDsTo(object sender, RoutedEventArgs e) {
-            var project = DocManager.Inst.Project;
-            var file = await FilePicker.SaveFileAboutProject(
-                this, "menu.file.exportds", FilePicker.DS);
-            if (!string.IsNullOrEmpty(file)) {
-                for (var i = 0; i < project.parts.Count; i++) {
-                    var part = project.parts[i];
-                    if (part is UVoicePart voicePart) {
-                        var savePath =  PathManager.Inst.GetPartSavePath(file, voicePart.DisplayName, i)[..^4]+".ds";
-                        DiffSingerScript.SavePart(project, voicePart, savePath);
-                        DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"{savePath}."));
-                    }
-                }
-            }
-        }
-
         async void OnMenuExportDsV2To(object sender, RoutedEventArgs e) {
             var project = DocManager.Inst.Project;
             var file = await FilePicker.SaveFileAboutProject(


### PR DESCRIPTION
When stakira/OpenUtau first became compatible with DiffSinger, the early versions of DiffSinger, along with its corresponding datasets and project file specifications, had already been replaced by newer versions.
OpenVPI completely removed compatibility with the old version's dataset in their fork of DiffSinger v2.3.0, and now almost no one should be using this outdated specification.
In OpenUtau, exporting old version DiffSinger scripts is labeled as 'Export DiffSinger Scripts To,' which can easily create the illusion that both the old and new versions are compatible with each other. I think this should be removed, or at the very least, marked somewhere as 'outdated.'
![5951fb815c763b8acb8f7064f7a997df](https://github.com/user-attachments/assets/8c25bcf0-ecc7-41b3-ba3d-8f4606adc27e)
