### PR TITLE
Fix openutau failing to import midi if it contains two lyric events at the same time

### DIFF
--- a/OpenUtau.Core/Format/MidiWriter.cs
+++ b/OpenUtau.Core/Format/MidiWriter.cs
@@ -188,7 +188,8 @@ namespace OpenUtau.Core.Format {
                         var events = objectsManager.Objects;
                         //{position of lyric: lyric text}
                         Dictionary<long, string> lyrics = events.Where(e => e.Event is LyricEvent)
-                            .ToDictionary(e=> e.Time, e => ((LyricEvent)e.Event).Text);
+                            .GroupBy(e => e.Time)
+                            .ToDictionary(g=> g.Key, g => ((LyricEvent)g.First().Event).Text);
                         var trackName = events.Where(e => e.Event is SequenceTrackNameEvent)
                             .Select(e => ((SequenceTrackNameEvent)e.Event).Text).FirstOrDefault();
                         if (trackName != null) {


### PR DESCRIPTION
Reaper just created one midi file like this, so I fixed it