### PR TITLE
Support SimpleENUNUServer0.5.0

### DIFF
--- a/OpenUtau.Core/Enunu/EnunuClient.cs
+++ b/OpenUtau.Core/Enunu/EnunuClient.cs
@@ -7,13 +7,19 @@ using Serilog;
 namespace OpenUtau.Core.Enunu {
     class EnunuClient : Util.SingletonBase<EnunuClient> {
         internal T SendRequest<T>(string[] args) {
+            return SendRequest<T>(args, "15555");
+        }
+        internal T SendRequest<T>(string[] args, string port,int second = 300 ) {
             using (var client = new RequestSocket()) {
-                client.Connect("tcp://localhost:15555");
+                client.Connect($"tcp://localhost:{port}");
                 string request = JsonConvert.SerializeObject(args);
                 Log.Information($"EnunuProcess sending {request}");
                 client.SendFrame(request);
-                client.TryReceiveFrameString(TimeSpan.FromSeconds(300), out string? message);
+                client.TryReceiveFrameString(TimeSpan.FromSeconds(second), out string? message);
                 Log.Information($"EnunuProcess received {message}");
+                if (string.IsNullOrEmpty(message)) {
+                    return (T)Activator.CreateInstance(typeof(T))!;
+                }
                 return JsonConvert.DeserializeObject<T>(message ?? string.Empty)!;
             }
         }

--- a/OpenUtau.Core/Enunu/EnunuConfig.cs
+++ b/OpenUtau.Core/Enunu/EnunuConfig.cs
@@ -4,8 +4,11 @@ using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core.Enunu {
     class EnunuConfig {
-        public string tablePath;
-        public string questionPath;
+        public string enunu_type = string.Empty;
+
+        public string feature_type = string.Empty;
+        public string tablePath = string.Empty;
+        public string questionPath = string.Empty;
         public int sampleRate;
         public double framePeriod;
         public EnunuExtensions extensions;
@@ -16,8 +19,10 @@ namespace OpenUtau.Core.Enunu {
             if (File.Exists(configPath)) {
                 var configTxt = File.ReadAllText(configPath);
                 config = Yaml.DefaultDeserializer.Deserialize<RawEnunuConfig>(configTxt);
+                config.enunu_type = "ENUNU";
             } else {
                 config = SetSimpleENUNUConfig(singer.Location);
+                config.enunu_type = "SimpleENUNU";
             }
             return config.Convert();
         }
@@ -70,14 +75,19 @@ namespace OpenUtau.Core.Enunu {
     }
 
     class RawEnunuConfig {
-        public string tablePath;
-        public string questionPath;
+        public string enunu_type = string.Empty;
+        public string feature_type = string.Empty;
+        public string tablePath = string.Empty;
+        public string questionPath = string.Empty;
         public int sampleRate;
         public double framePeriod;
         public RawEnunuExtensions extensions;
 
         public EnunuConfig Convert() {
             EnunuConfig enunuConfig = new EnunuConfig();
+            enunuConfig.enunu_type = this.enunu_type;
+
+            enunuConfig.feature_type = this.feature_type;
             enunuConfig.tablePath = this.tablePath;
             enunuConfig.questionPath = this.questionPath;
             enunuConfig.sampleRate = this.sampleRate;

--- a/OpenUtau.Core/Enunu/EnunuEnglishPhonemizer.cs
+++ b/OpenUtau.Core/Enunu/EnunuEnglishPhonemizer.cs
@@ -60,6 +60,9 @@ namespace OpenUtau.Core.Enunu {
         public override void SetSinger(USinger singer) {
             this.singer = singer as EnunuSinger;
             g2p = LoadG2p();
+            if (port == null) {
+                port = EnunuUtils.SetPortNum();
+            }
         }
 
         string[] GetSymbols(Note note) {

--- a/OpenUtau.Core/Enunu/EnunuPhonemizer.cs
+++ b/OpenUtau.Core/Enunu/EnunuPhonemizer.cs
@@ -13,6 +13,7 @@ namespace OpenUtau.Core.Enunu {
         readonly string PhonemizerType = "ENUNU";
 
         protected EnunuSinger singer;
+        protected string port;
         Dictionary<Note[], Phoneme[]> partResult = new Dictionary<Note[], Phoneme[]>();
 
         struct TimingResult {
@@ -27,6 +28,9 @@ namespace OpenUtau.Core.Enunu {
 
         public override void SetSinger(USinger singer) {
             this.singer = singer as EnunuSinger;
+            if (port == null) {
+                port = EnunuUtils.SetPortNum();
+            }
         }
 
         public override void SetUp(Note[][] notes, UProject project, UTrack track) {
@@ -42,9 +46,10 @@ namespace OpenUtau.Core.Enunu {
             var scorePath = Path.Join(enutmpPath, $"score.lab");
             var timingPath = Path.Join(enutmpPath, $"timing.lab");
             var enunuNotes = NoteGroupsToEnunu(notes);
+            var voicebankNameHash = $"{this.singer.voicebankNameHash:x16}";
             if (!File.Exists(scorePath) || !File.Exists(timingPath)) {
                 EnunuUtils.WriteUst(enunuNotes, bpm, singer, ustPath);
-                var response = EnunuClient.Inst.SendRequest<TimingResponse>(new string[] { "timing", ustPath });
+                var response = EnunuClient.Inst.SendRequest<TimingResponse>(new string[] { "timing", ustPath,"", voicebankNameHash, "600" }, port);
                 if (response.error != null) {
                     throw new Exception(response.error);
                 }

--- a/OpenUtau.Core/Enunu/EnunuRenderer.cs
+++ b/OpenUtau.Core/Enunu/EnunuRenderer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using K4os.Hash.xxHash;
 using NAudio.Wave;
 using NumSharp;
 using OpenUtau.Core.Format;
@@ -16,6 +17,8 @@ namespace OpenUtau.Core.Enunu {
     public class EnunuRenderer : IRenderer {
         public const int headTicks = 240;
         public const int tailTicks = 240;
+        protected string port;
+        private EnunuConfig config;
 
         static readonly HashSet<string> supportedExp = new HashSet<string>(){
             Format.Ustx.DYN,
@@ -25,13 +28,16 @@ namespace OpenUtau.Core.Enunu {
             Format.Ustx.BREC,
             Format.Ustx.TENC,
             Format.Ustx.VOIC,
+            Format.Ustx.SHFT
+
         };
 
         struct AcousticResult {
-            public string path_acoustic;
             public string path_f0;
             public string path_spectrogram;
             public string path_aperiodicity;
+            public string path_mel;
+            public string path_vuv;
         }
 
         struct AcousticResponse {
@@ -76,75 +82,99 @@ namespace OpenUtau.Core.Enunu {
                     }
                     string progressInfo = $"Track {trackNo + 1}: {this} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
                     progress.Complete(0, progressInfo);
-                    var tmpPath = Path.Join(PathManager.Inst.CachePath, $"enu-{phrase.preEffectHash:x16}");
+                    ulong hash = HashPhraseGroups(phrase);
+                    var tmpPath = Path.Join(PathManager.Inst.CachePath, $"enu-{hash:x16}");
                     var ustPath = tmpPath + ".tmp";
                     var enutmpPath = tmpPath + "_enutemp";
                     var wavPath = Path.Join(PathManager.Inst.CachePath, $"enu-{phrase.hash:x16}.wav");
+                    var voicebankNameHash = $"{(phrase.singer as EnunuSinger).voicebankNameHash:x16}";
+                    config = EnunuConfig.Load(phrase.singer);
+                    if (port == null) {
+                        port = EnunuUtils.SetPortNum();
+                    }
                     var result = Layout(phrase);
                     if (!File.Exists(wavPath)) {
-                        var config = EnunuConfig.Load(phrase.singer);
-                        if (config.extensions.wav_synthesizer.Contains("synthe")) {
-                            Log.Information($"Starting enunu synthesis \"{ustPath}\"");
-                            var enunuNotes = PhraseToEnunuNotes(phrase);
-                            // TODO: using first note tempo as ust tempo.
-                            EnunuUtils.WriteUst(enunuNotes, phrase.phones.First().tempo, phrase.singer, ustPath);
-                            var response = EnunuClient.Inst.SendRequest<SyntheResponse>(new string[] { "synthe", ustPath, wavPath });
-                            if (response.error != null) {
-                                throw new Exception(response.error);
+                        if (config.extensions.wav_synthesizer.Contains("synthe") || config.feature_type.Equals("melf0")) {
+                            var f0Path = Path.Join(enutmpPath, "f0.npy");
+                            var editorf0Path = Path.Join(enutmpPath, "editorf0.npy");
+                            var melPath = Path.Join(enutmpPath, "mel.npy");
+                            var vuvPath = Path.Join(enutmpPath, "vuv.npy");
+                            if (!File.Exists(f0Path) || !File.Exists(melPath) || !File.Exists(vuvPath)) {
+                                Log.Information($"Starting enunu synthesis \"{ustPath}\"");
+                                var enunuNotes = PhraseToEnunuNotes(phrase);
+                                // TODO: using first note tempo as ust tempo.
+                                EnunuUtils.WriteUst(enunuNotes, phrase.phones.First().tempo, phrase.singer, ustPath);
+                                var ac_response = EnunuClient.Inst.SendRequest<AcousticResponse>(new string[] { "acoustic", ustPath, "", voicebankNameHash, "600", phrase.phones[0].toneShift.ToString() }, port);
+                                if (ac_response.error != null) {
+                                    Log.Error(ac_response.error);
+                                }
+                            }
+                            var f0 = np.Load<double[]>(f0Path);
+                            int totalFrames = f0.Length;
+                            var headMs = phrase.positionMs - phrase.timeAxis.TickPosToMsPos(phrase.position - headTicks);
+                            var tailMs = phrase.timeAxis.TickPosToMsPos(phrase.end + tailTicks) - phrase.endMs;
+                            int headFrames = (int)Math.Round(headMs / config.framePeriod);
+                            int tailFrames = (int)Math.Round(tailMs / config.framePeriod);
+                            var editorF0 = SampleCurve(phrase, phrase.pitches, 0, config.framePeriod, totalFrames, headFrames, tailFrames, x => MusicMath.ToneToFreq(x * 0.01));
+                            np.Save(editorF0, editorf0Path);
+                            SyntheResponse sy_response = new SyntheResponse();
+                            sy_response = EnunuClient.Inst.SendRequest<SyntheResponse>(new string[] { "synthe", ustPath, wavPath, voicebankNameHash, "600", phrase.phones[0].toneShift.ToString() }, port);
+                            if (sy_response.error != null) {
+                                throw new Exception(sy_response.error);
                             }
                         } else {
-                        var f0Path = Path.Join(enutmpPath, "f0.npy");
-                        var spPath = Path.Join(enutmpPath, "spectrogram.npy");
-                        var apPath = Path.Join(enutmpPath, "aperiodicity.npy");
-                        if (!File.Exists(f0Path) || !File.Exists(spPath) || !File.Exists(apPath)) {
-                            Log.Information($"Starting enunu acoustic \"{ustPath}\"");
-                            var enunuNotes = PhraseToEnunuNotes(phrase);
-                            // TODO: using first note tempo as ust tempo.
-                            EnunuUtils.WriteUst(enunuNotes, phrase.phones.First().tempo, phrase.singer, ustPath);
-                            var response = EnunuClient.Inst.SendRequest<AcousticResponse>(new string[] { "acoustic", ustPath });
-                            if (response.error != null) {
-                                throw new Exception(response.error);
+                            var f0Path = Path.Join(enutmpPath, "f0.npy");
+                            var spPath = Path.Join(enutmpPath, "spectrogram.npy");
+                            var apPath = Path.Join(enutmpPath, "aperiodicity.npy");
+                            if (!File.Exists(f0Path) || !File.Exists(spPath) || !File.Exists(apPath)) {
+                                Log.Information($"Starting enunu acoustic \"{ustPath}\"");
+                                var enunuNotes = PhraseToEnunuNotes(phrase);
+                                // TODO: using first note tempo as ust tempo.
+                                EnunuUtils.WriteUst(enunuNotes, phrase.phones.First().tempo, phrase.singer, ustPath);
+                                var ac_response = EnunuClient.Inst.SendRequest<AcousticResponse>(new string[] { "acoustic", ustPath, "", voicebankNameHash, "600",  phrase.phones[0].toneShift.ToString() }, port);
+                                if (ac_response.error != null) {
+                                    throw new Exception(ac_response.error);
+                                }
                             }
-                        }
-                        if (cancellation.IsCancellationRequested) {
-                            return new RenderResult();
-                        }
-                        var f0 = np.Load<double[]>(f0Path);
-                        var sp = np.Load<double[,]>(spPath);
-                        var ap = np.Load<double[,]>(apPath);
-                        int totalFrames = f0.Length;
-                        var headMs = phrase.positionMs - phrase.timeAxis.TickPosToMsPos(phrase.position - headTicks);
-                        var tailMs = phrase.timeAxis.TickPosToMsPos(phrase.end + tailTicks) - phrase.endMs;
-                        int headFrames = (int)Math.Round(headMs / config.framePeriod);
-                        int tailFrames = (int)Math.Round(tailMs / config.framePeriod);
-                        var editorF0 = SampleCurve(phrase, phrase.pitches, 0, config.framePeriod, totalFrames, headFrames, tailFrames, x => MusicMath.ToneToFreq(x * 0.01));
-                        var gender = SampleCurve(phrase, phrase.gender, 0.5, config.framePeriod, totalFrames, headFrames, tailFrames, x => 0.5 + 0.005 * x);
-                        var tension = SampleCurve(phrase, phrase.tension, 0.5, config.framePeriod, totalFrames, headFrames, tailFrames, x => 0.5 + 0.005 * x);
-                        var breathiness = SampleCurve(phrase, phrase.breathiness, 0.5, config.framePeriod, totalFrames, headFrames, tailFrames, x => 0.5 + 0.005 * x);
-                        var voicing = SampleCurve(phrase, phrase.voicing, 1.0, config.framePeriod, totalFrames, headFrames, tailFrames, x => 0.01 * x);
-                        int fftSize = (sp.GetLength(1) - 1) * 2;
-                        for (int i = 0; i < f0.Length; i++) {
-                            if (f0[i] < 50) {
-                                editorF0[i] = 0;
+                            if (cancellation.IsCancellationRequested) {
+                                return new RenderResult();
                             }
+                            var f0 = np.Load<double[]>(f0Path);
+                            var sp = np.Load<double[,]>(spPath);
+                            var ap = np.Load<double[,]>(apPath);
+                            int totalFrames = f0.Length;
+                            var headMs = phrase.positionMs - phrase.timeAxis.TickPosToMsPos(phrase.position - headTicks);
+                            var tailMs = phrase.timeAxis.TickPosToMsPos(phrase.end + tailTicks) - phrase.endMs;
+                            int headFrames = (int)Math.Round(headMs / config.framePeriod);
+                            int tailFrames = (int)Math.Round(tailMs / config.framePeriod);
+                            var editorF0 = SampleCurve(phrase, phrase.pitches, 0, config.framePeriod, totalFrames, headFrames, tailFrames, x => MusicMath.ToneToFreq(x * 0.01));
+                            var gender = SampleCurve(phrase, phrase.gender, 0.5, config.framePeriod, totalFrames, headFrames, tailFrames, x => 0.5 + 0.005 * x);
+                            var tension = SampleCurve(phrase, phrase.tension, 0.5, config.framePeriod, totalFrames, headFrames, tailFrames, x => 0.5 + 0.005 * x);
+                            var breathiness = SampleCurve(phrase, phrase.breathiness, 0.5, config.framePeriod, totalFrames, headFrames, tailFrames, x => 0.5 + 0.005 * x);
+                            var voicing = SampleCurve(phrase, phrase.voicing, 1.0, config.framePeriod, totalFrames, headFrames, tailFrames, x => 0.01 * x);
+                            int fftSize = (sp.GetLength(1) - 1) * 2;
+                            for (int i = 0; i < f0.Length; i++) {
+                                if (f0[i] < 50) {
+                                    editorF0[i] = 0;
+                                }
+                            }
+                            var samples = Worldline.WorldSynthesis(
+                                editorF0,
+                                sp, false, sp.GetLength(1),
+                                ap, false, fftSize,
+                                config.framePeriod, config.sampleRate,
+                                gender, tension, breathiness, voicing);
+                            result.samples = samples.Select(d => (float)d).ToArray();
+                            Wave.CorrectSampleScale(result.samples);
+                            if (config.sampleRate != 44100) {
+                                var signal = new NWaves.Signals.DiscreteSignal(config.sampleRate, result.samples);
+                                signal = NWaves.Operations.Operation.Resample(signal, 44100);
+                                result.samples = signal.Samples;
+                            }
+                            var source = new WaveSource(0, 0, 0, 1);
+                            source.SetSamples(result.samples);
+                            WaveFileWriter.CreateWaveFile16(wavPath, new ExportAdapter(source).ToMono(1, 0));
                         }
-                        var samples = Worldline.WorldSynthesis(
-                            editorF0,
-                            sp, false, sp.GetLength(1),
-                            ap, false, fftSize,
-                            config.framePeriod, config.sampleRate,
-                            gender, tension, breathiness, voicing);
-                        result.samples = samples.Select(d => (float)d).ToArray();
-                        Wave.CorrectSampleScale(result.samples);
-                        if (config.sampleRate != 44100) {
-                            var signal = new NWaves.Signals.DiscreteSignal(config.sampleRate, result.samples);
-                            signal = NWaves.Operations.Operation.Resample(signal, 44100);
-                            result.samples = signal.Samples;
-                        }
-                        var source = new WaveSource(0, 0, 0, 1);
-                        source.SetSamples(result.samples);
-                        WaveFileWriter.CreateWaveFile16(wavPath, new ExportAdapter(source).ToMono(1, 0));
-                    }
                     }
                     progress.Complete(phrase.phones.Length, progressInfo);
                     if (File.Exists(wavPath)) {
@@ -184,7 +214,8 @@ namespace OpenUtau.Core.Enunu {
         }
 
         public RenderPitchResult LoadRenderedPitch(RenderPhrase phrase) {
-            var tmpPath = Path.Join(PathManager.Inst.CachePath, $"enu-{phrase.preEffectHash:x16}");
+            ulong hash = HashPhraseGroups(phrase);
+            var tmpPath = Path.Join(PathManager.Inst.CachePath, $"enu-{hash:x16}");
             var enutmpPath = tmpPath + "_enutemp";
             var f0Path = Path.Join(enutmpPath, "f0.npy");
             if (!File.Exists(f0Path)) {
@@ -233,5 +264,16 @@ namespace OpenUtau.Core.Enunu {
         }
 
         public override string ToString() => Renderers.ENUNU;
+
+
+        ulong HashPhraseGroups(RenderPhrase phrase) {
+            using (var stream = new MemoryStream()) {
+                using (var writer = new BinaryWriter(stream)) {
+                    writer.Write(phrase.preEffectHash);
+                    writer.Write(phrase.phones[0].toneShift);
+                    return XXH64.DigestOf(stream.ToArray());
+                }
+            }
+        }
     }
 }

--- a/OpenUtau.Core/Enunu/EnunuSinger.cs
+++ b/OpenUtau.Core/Enunu/EnunuSinger.cs
@@ -4,10 +4,10 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using K4os.Hash.xxHash;
 using OpenUtau.Classic;
 using OpenUtau.Core.Ustx;
 using Serilog;
-using static OpenUtau.Api.Phonemizer;
 
 namespace OpenUtau.Core.Enunu {
     public class EnunuSinger : USinger {
@@ -46,6 +46,7 @@ namespace OpenUtau.Core.Enunu {
         Dictionary<string, string[]> table = new Dictionary<string, string[]>();
 
         public byte[] avatarData;
+        public ulong voicebankNameHash;
 
         public EnunuSinger(Voicebank voicebank) {
             this.voicebank = voicebank;
@@ -74,6 +75,7 @@ namespace OpenUtau.Core.Enunu {
 
         void Load() {
             enuconfig = EnunuConfig.Load(this);
+            voicebankNameHash = Hash();
             phonemes.Clear();
             timbres.Clear();
             table.Clear();
@@ -197,6 +199,16 @@ namespace OpenUtau.Core.Enunu {
             return string.IsNullOrEmpty(Sample)
                 ? null
                 : File.ReadAllBytes(Sample);
+        }
+
+        private ulong Hash() {
+            using (var stream = new MemoryStream()) {
+                using (var writer = new BinaryWriter(stream)) {
+                    writer.Write(Name);
+                    writer.Write(enuconfig.enunu_type);
+                    return XXH64.DigestOf(stream.ToArray());
+                }
+            }
         }
     }
 }

--- a/OpenUtau.Core/Enunu/EnunuUtils.cs
+++ b/OpenUtau.Core/Enunu/EnunuUtils.cs
@@ -1,10 +1,21 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using OpenUtau.Core.Ustx;
+using Serilog;
 
 namespace OpenUtau.Core.Enunu {
+    public struct VersionResult {
+        public string name;
+        public string version;
+        public string author;
+    }
+
+    public struct VersionResponse {
+        public string error;
+        public VersionResult result;
+    }
+
     public struct EnunuNote {
         public string lyric;
         public int length;
@@ -17,7 +28,11 @@ namespace OpenUtau.Core.Enunu {
         static readonly Encoding ShiftJIS = Encoding.GetEncoding("shift_jis");
 
         internal static void WriteUst(IList<EnunuNote> notes, double tempo, USinger singer, string ustPath) {
-            using (var writer = new StreamWriter(ustPath, false, ShiftJIS)) {
+            WriteUst(notes, tempo, singer, ustPath, ShiftJIS);
+        }
+
+        internal static void WriteUst(IList<EnunuNote> notes, double tempo, USinger singer, string ustPath, Encoding encoding) {
+            using (var writer = new StreamWriter(ustPath, false, encoding)) {
                 writer.WriteLine("[#SETTING]");
                 writer.WriteLine($"Tempo={tempo}");
                 writer.WriteLine("Tracks=1");
@@ -36,6 +51,16 @@ namespace OpenUtau.Core.Enunu {
                 }
                 writer.WriteLine("[#TRACKEND]");
             }
+        }
+
+        internal static string SetPortNum() {
+             var ver_response = EnunuClient.Inst.SendRequest<VersionResponse>(new string[] { "ver_check" }, "15556", 1);
+             if (ver_response.error != null) {
+                 Log.Error(ver_response.error);
+             } else if (ver_response.result.name != null) {
+                 return "15556";
+             }
+            return "15555";
         }
     }
 }

--- a/OpenUtau.Core/Enunu/EnunuUtils.cs
+++ b/OpenUtau.Core/Enunu/EnunuUtils.cs
@@ -21,7 +21,9 @@ namespace OpenUtau.Core.Enunu {
         public int length;
         public int noteNum;
         public int noteIndex;
+        public int style_shift;
         public string timbre;
+        public int velocity;
     }
 
     internal static class EnunuUtils {
@@ -45,8 +47,9 @@ namespace OpenUtau.Core.Enunu {
                     writer.WriteLine($"Lyric={notes[i].lyric}");
                     writer.WriteLine($"Length={notes[i].length}");
                     writer.WriteLine($"NoteNum={notes[i].noteNum}");
+                    writer.WriteLine($"Velocity={notes[i].velocity}");
                     if (!string.IsNullOrEmpty(notes[i].timbre)) {
-                        writer.WriteLine($"Flags={notes[i].timbre}");
+                        writer.WriteLine($"Flags={notes[i].timbre}S{notes[i].style_shift}");
                     }
                 }
                 writer.WriteLine("[#TRACKEND]");

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -68,7 +68,7 @@ namespace OpenUtau.Core.Render {
         public readonly bool direct;
         public readonly Vector2[] envelope;
 
-        // voicevox args
+        // voicevox & enunu args
         public readonly int toneShift;
 
         public readonly UOto oto;


### PR DESCRIPTION
[SimpleENUNUServer0.5.0](https://github.com/rokujyushi/SimpleEnunu/releases/tag/SimpleENUNUServer-0.5.0) is now supported.
Pitch adjustment of melf0 models is now supported.
Velocity and style shifting is now supported.
SimpleENUNUServer version check is now supported.
Client port change and connection expiration time change are now supported.

The following ENUNU and Singer were used to check operation and backward compatibility
ENUNUServer0.6.0
SimpleENUNUServer0.5.0

ENUNU_夏目悠李_ResSkipF0FFConvLSTM_v0.0.1
ENUNU_KanadeShia_NightScene_SiFiGAN_MEL

