### PR TITLE
Fix openutau crashing when trying to edit the preutterence of an invalid phoneme

### DIFF
--- a/OpenUtau/Views/NoteEditStates.cs
+++ b/OpenUtau/Views/NoteEditStates.cs
@@ -1012,7 +1012,7 @@ namespace OpenUtau.App.Views {
             var project = notesVm.Project;
             double preutter = project.timeAxis.MsBetweenTickPos(notesVm.PointToTick(point), phoneme.position);
             double preutterDelta = preutter - phoneme.autoPreutter;
-            preutterDelta = Math.Max(-phoneme.oto.Preutter, preutterDelta);
+            preutterDelta = Math.Max(-phoneme.oto?.Preutter ?? 0, preutterDelta);
             if (notesVm.Part == null) {
                 return;
             }


### PR DESCRIPTION
Steps to reproduce:
- Launch OpenUtau. Create a project. Create a track. Create a part. Open piano roll.
- Create 3 notes. The first and the last note are valid, while the second one is invalid
![image](https://github.com/user-attachments/assets/878626fe-d113-4845-b810-278152e26417)
- Drag the invalid phonemes's timing bar somewhere, move the preutter point of the next phoneme onto it
- Click here
![image](https://github.com/user-attachments/assets/86c2f1e0-bd94-40e9-ad47-f5a1db69926f)

Before this fix, OpenUtau will crash.