### PR TITLE
Update SyllableBasedPhonemizer.cs

### DIFF
--- a/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
@@ -305,7 +305,7 @@ namespace OpenUtau.Plugin.Builtin {
                     var subResult = dictionary.Query(subword);
                     if (subResult == null) {
                         Log.Warning($"Subword '{subword}' from word '{note.lyric}' can't be found in the dictionary");
-                        subResult = HandleWordNotFound(subword);
+                        subResult = HandleWordNotFound(note);
                         if (subResult == null) {
                             return null;
                         }
@@ -491,8 +491,17 @@ namespace OpenUtau.Plugin.Builtin {
         /// </summary>
         /// <param name="word"></param>
         /// <returns></returns>
-        protected virtual string[] HandleWordNotFound(string word) {
-            error = "word not found";
+        protected virtual string[] HandleWordNotFound(Note note) {
+            var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == 0) ?? default;
+            string alt = attr.alternate?.ToString() ?? string.Empty;
+            string color = attr.voiceColor;
+            int toneShift = attr.toneShift;
+            var mpdlyric = MapPhoneme(note.lyric, note.tone + toneShift, color, alt, singer);
+            if(HasOto(mpdlyric, note.tone)){
+                error = mpdlyric;
+            }else{
+                error = "word not found";
+            }
             return null;
         }
 


### PR DESCRIPTION
When using a Phonemizer that inherits from SyllableBasedPhonemizer, such as VCCVEnglishPhonemizer, When Japanese hiragana appears partially in the lyrics, the phoneme designation becomes ‘word not found’, This change allows the letters of the lyrics to be specified as phonemes as they are.

The argument passed to the function HandleWordNotFound is changed to note, In HandleWordNotFound,
For now, pass the lyrics of note as they are to MapPhoneme, If the return value is in oto, use it as the output of error, If not, the output of error is ‘word not found’, just as it was before the change.

Anything written before MapPhoneme() is written with reference to the contents of the AssignAllAffixes function. To be honest, I do not understand exactly what is being done here.

We propose to handle voicebanks that integrate English VCCV and Japanese VCV in a single track.

Translated with DeepL.com


original text↓

VCCVEnglishPhonemizerなど、SyllableBasedPhonemizerを継承元とするPhonemizerを使用しているとき、 歌詞に部分的に日本語ひらがなが出現する場合等に音素指定が「word not found」になるのを、 歌詞の文字をそのまま音素として指定するようにする変更です。

関数HandleWordNotFoundに渡す引数をnoteに変更し、
HandleWordNotFound内では
とりあえずnoteの歌詞そのままの文字列をMapPhonemeに渡してみて、
その戻り値がotoにあればそれをerrorの出力として、
なければ変更前と同じように"word not found"をerrorの出力とします。

MapPhoneme()以前に書かれているものはAssignAllAffixes関数の中身を参考にしています。正直、ここで何が行われているのかは正確には理解できていません。

英語VCCVと日本語VCVを統合したボイスバンクを1つのトラックで扱いたいという思いで提案します。