### PR TITLE
When loading rendered pitch, pitch curve of the next sentence will no longer affect the tail part of the previous sentence

### DIFF
--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -328,6 +328,8 @@ namespace OpenUtau.Core.Editing {
             int finished = 0;
             setProgressCallback(0, phrases.Length);
             var commands = new List<SetCurveCommand>();
+
+            int? prevEnd = null;//End x of previous render phrase
             foreach (var phrase in phrases) {
                 var result = renderer.LoadRenderedPitch(phrase);
                 if (result == null) {
@@ -342,6 +344,10 @@ namespace OpenUtau.Core.Editing {
                         continue;
                     }
                     int x = phrase.position - part.position + (int)result.ticks[i];
+                    // Skip points that are in the time range of the previous phrase
+                    if (prevEnd != null && x < prevEnd) {
+                        continue;
+                    }
                     int pitchIndex = Math.Clamp((x - (phrase.position - part.position - phrase.leading)) / 5, 0, phrase.pitches.Length - 1);
                     float basePitch = phrase.pitchesBeforeDeviation[pitchIndex];
                     int y = (int)(result.tones[i] * 100 - basePitch);
@@ -354,6 +360,7 @@ namespace OpenUtau.Core.Editing {
                     lastX = x;
                     lastY = y;
                 }
+                prevEnd = phrase.position - part.position + phrase.duration;
                 finished += 1;
                 setProgressCallback(finished, phrases.Length);
             }


### PR DESCRIPTION
Before this fix, if two sentences are too close, the PITD of the next sentence will affect the tail part of the previous sentence.
![image](https://github.com/user-attachments/assets/36f75d5b-10b5-4543-a27c-483381e38631)
