### PR TITLE
Multi-selection support for ExpressionsDialog.

### DIFF
--- a/OpenUtau/ViewModels/ExpressionsViewModel.cs
+++ b/OpenUtau/ViewModels/ExpressionsViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Linq;
@@ -117,8 +118,14 @@ namespace OpenUtau.App.ViewModels {
             set => this.RaiseAndSetIfChanged(ref expression, value);
         }
 
+        public List<ExpressionBuilder>? SelectExpressions {
+            get => selectexpressions;
+            set => this.RaiseAndSetIfChanged(ref selectexpressions, value);
+        }
+
         private ReadOnlyObservableCollection<ExpressionBuilder> expressions;
         private ExpressionBuilder? expression;
+        private List<ExpressionBuilder>? selectexpressions;
 
         private ObservableCollectionExtended<ExpressionBuilder> expressionsSource;
 
@@ -130,6 +137,7 @@ namespace OpenUtau.App.ViewModels {
             expressionsSource.AddRange(DocManager.Inst.Project.expressions.Select(pair => new ExpressionBuilder(pair.Value)));
             if (expressionsSource.Count > 0) {
                 expression = expressionsSource[0];
+                selectexpressions = expressionsSource.ToList();
             }
         }
 
@@ -160,7 +168,13 @@ namespace OpenUtau.App.ViewModels {
         }
 
         public void Remove() {
-            if (Expression != null) {
+            if (SelectExpressions != null) {
+                foreach (var expression in SelectExpressions) {
+                    if (expression.IsCustom) {
+                        expressionsSource.Remove(expression);
+                    }
+                }
+            } else if (Expression != null) {
                 expressionsSource.Remove(Expression);
             }
         }

--- a/OpenUtau/ViewModels/ExpressionsViewModel.cs
+++ b/OpenUtau/ViewModels/ExpressionsViewModel.cs
@@ -118,18 +118,16 @@ namespace OpenUtau.App.ViewModels {
             set => this.RaiseAndSetIfChanged(ref expression, value);
         }
 
-        public List<ExpressionBuilder>? SelectExpressions {
-            get => selectexpressions;
-            set => this.RaiseAndSetIfChanged(ref selectexpressions, value);
-        }
+        public ObservableCollection<ExpressionBuilder>? SelectExpressions => selectexpressions;
 
         private ReadOnlyObservableCollection<ExpressionBuilder> expressions;
         private ExpressionBuilder? expression;
-        private List<ExpressionBuilder>? selectexpressions;
+        private ObservableCollection<ExpressionBuilder>? selectexpressions;
 
         private ObservableCollectionExtended<ExpressionBuilder> expressionsSource;
 
         public ExpressionsViewModel() {
+            selectexpressions = new ObservableCollection<ExpressionBuilder>();
             expressionsSource = new ObservableCollectionExtended<ExpressionBuilder>();
             expressionsSource.ToObservableChangeSet()
                 .Bind(out expressions)
@@ -137,7 +135,6 @@ namespace OpenUtau.App.ViewModels {
             expressionsSource.AddRange(DocManager.Inst.Project.expressions.Select(pair => new ExpressionBuilder(pair.Value)));
             if (expressionsSource.Count > 0) {
                 expression = expressionsSource[0];
-                selectexpressions = expressionsSource.ToList();
             }
         }
 
@@ -169,7 +166,8 @@ namespace OpenUtau.App.ViewModels {
 
         public void Remove() {
             if (SelectExpressions != null) {
-                foreach (var expression in SelectExpressions) {
+                var selectedItems = SelectExpressions.ToList();
+                foreach (var expression in selectedItems) {
                     if (expression.IsCustom) {
                         expressionsSource.Remove(expression);
                     }

--- a/OpenUtau/Views/ExpressionsDialog.axaml
+++ b/OpenUtau/Views/ExpressionsDialog.axaml
@@ -19,7 +19,7 @@
 
   <Grid Margin="{Binding $parent.WindowDecorationMargin}">
     <Border Margin="10,10,10,40" Width="150" HorizontalAlignment="Left">
-      <ListBox ItemsSource="{Binding Expressions}" SelectedItem="{Binding Expression}">
+      <ListBox ItemsSource="{Binding Expressions}" SelectedItem="{Binding Expression}" SelectedItems="{Binding SelectExpressions}" SelectionMode="Multiple">
         <ListBox.ItemTemplate>
           <DataTemplate>
             <TextBlock Text="{Binding}"/>


### PR DESCRIPTION
Reason.
To batch delete unnecessary expressions after batch addition of expressions from the renderer.

Changes.
Multiple items can now be selected in the ListBox of the ExpressionsDialog.
Items can now be deleted in batches.