### PR TITLE
Refactor preferences page to using a navigation sidebar, rearrange preference items

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -387,6 +387,8 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>
   <system:String x:Key="prefs.caption">Preferences</system:String>
+  <system:String x:Key="prefs.diffsinger">DiffSinger</system:String>
+  <system:String x:Key="prefs.editing">Editing</system:String>
   <system:String x:Key="prefs.note.restart">Note: please restart OpenUtau after changing this item.</system:String>
   <system:String x:Key="prefs.off">Off</system:String>
   <system:String x:Key="prefs.on">On</system:String>
@@ -439,6 +441,7 @@ Warning: this option removes custom presets.</system:String>
   </system:String>
   <system:String x:Key="prefs.rendering.threads.numthreads">Maximum Render Threads</system:String>
   <system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>
+  <system:String x:Key="prefs.utau">UTAU</system:String>
 
   <system:String x:Key="progress.loadingsingers">Loading Singers...</system:String>
   <system:String x:Key="progress.saved">Project saved. {0}</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -360,6 +360,7 @@
   <system:String x:Key="prefs.cache.clearonquit">退出时清空缓存</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger 张量缓存</system:String>
   <system:String x:Key="prefs.caption">使用偏好</system:String>
+  <system:String x:Key="prefs.editing">编辑</system:String>
   <system:String x:Key="prefs.note.restart">注意: 修改本项后请重启OpenUtau</system:String>
   <system:String x:Key="prefs.off">关</system:String>
   <system:String x:Key="prefs.on">开</system:String>

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -170,7 +170,7 @@
 
         <!-- Appearance -->
         <StackPanel>
-          <TextBlock Text="{DynamicResource prefs.appearance.lang}" />
+          <TextBlock Text="{DynamicResource prefs.appearance.lang}" Margin="0,10,0,0"/>
           <ComboBox ItemsSource="{Binding Languages}" SelectedItem="{Binding Language}">
             <ComboBox.ItemTemplate>
               <DataTemplate>
@@ -209,7 +209,7 @@
             <TextBlock Text="{DynamicResource prefs.appearance.showicon}" HorizontalAlignment="Left"/>
             <ToggleSwitch IsChecked="{Binding ShowIcon}"/>
           </Grid>
-          <Grid>
+          <Grid Margin="0,5,0,0">
             <TextBlock Text="{DynamicResource prefs.appearance.showghostnotes}" HorizontalAlignment="Left"/>
             <ToggleSwitch IsChecked="{Binding ShowGhostNotes}"/>
           </Grid>
@@ -217,9 +217,9 @@
 
         <!-- UTAU -->
         <StackPanel>
-          <TextBlock Text="{DynamicResource prefs.rendering.defaultrenderer}"/>
+          <TextBlock Text="{DynamicResource prefs.rendering.defaultrenderer}" Margin="0,10,0,0"/>
           <ComboBox ItemsSource="{Binding DefaultRendererOptions}" SelectedItem="{Binding DefaultRenderer}"/>
-          <TextBlock Text="{DynamicResource prefs.otoeditor.select}" />
+          <TextBlock Text="{DynamicResource prefs.otoeditor.select}" Margin="0,10,0,0"/>
           <ComboBox SelectedIndex="{Binding OtoEditor}">
             <ComboBoxItem Content="OpenUtau"/>
             <ComboBoxItem Content="vLabeler"/>
@@ -261,7 +261,7 @@
               <Slider Grid.Column="4" Classes="fader" Value="{Binding DiffSingerDepth}" Minimum="0" Maximum="100"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
           </Grid>
-          <Grid>
+          <Grid Margin="0,5,0,0">
             <TextBlock Text="{DynamicResource prefs.cache.diffsingertensorcache}" HorizontalAlignment="Left" />
             <ToggleSwitch IsChecked="{Binding DiffSingerTensorCache}" />
           </Grid>
@@ -269,12 +269,12 @@
 
         <!-- Advanced -->
         <StackPanel>
-          <Grid>
+          <Grid Margin="0,5,0,0">
             <TextBlock Text="{DynamicResource prefs.advanced.beta}" HorizontalAlignment="Left"/>
             <ToggleSwitch IsChecked="{Binding Beta}"/>
           </Grid>
           <TextBlock Classes="restart"/>
-          <TextBlock Text="{DynamicResource prefs.advanced.rememberfiletypes}" Margin="0,5,0,0"/>
+          <TextBlock Text="{DynamicResource prefs.advanced.rememberfiletypes}" Margin="0,10,0,0"/>
           <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="25,25,25" VerticalAlignment="Center" Margin="4">
             <CheckBox IsChecked="{Binding RememberMid}" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"/>
             <TextBlock Text=" .mid" Grid.Column="1" Grid.Row="0" VerticalAlignment="Center"/>

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -3,12 +3,14 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:OpenUtau.App.ViewModels"
+        xmlns:controls="clr-namespace:Material.Styles.Controls;assembly=Material.Styles"
+        xmlns:styles="clr-namespace:Material.Styles;assembly=Material.Styles"
         mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="600"
         x:Class="OpenUtau.App.Views.PreferencesDialog"
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource prefs.caption}"
         WindowStartupLocation="CenterScreen"
-        MinWidth="500" MinHeight="600" Width="500" Height="600"
+        Width="800" Height="400"
         ExtendClientAreaToDecorationsHint="False">
   <Window.Resources>
     <vm:CultureNameConverter x:Key="cultureNameConverter"/>
@@ -34,239 +36,261 @@
   </Window.Styles>
   <Design.DataContext>
   </Design.DataContext>
-  <Grid Margin="{Binding $parent.WindowDecorationMargin}">
-    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
-      <StackPanel Margin="5">
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.playback}">
-          <StackPanel>
-            <TextBlock Text="{DynamicResource prefs.playback.device}"/>
-            <ComboBox ItemsSource="{Binding AudioOutputDevices}" SelectedItem="{Binding AudioOutputDevice}"/>
-            <Button Content="{DynamicResource prefs.playback.test}" HorizontalAlignment="Stretch" Command="{Binding TestAudioOutputDevice}"/>
-            <TextBlock Text="{DynamicResource prefs.playback.backend}" Margin="0,10,0,0"/>
-            <ComboBox SelectedIndex="{Binding PreferPortAudio}">
-              <ComboBoxItem Content="{DynamicResource prefs.playback.backend.auto}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.playback.backend.mini}"/>
-            </ComboBox>
-            <TextBlock Classes="restart"/>
-            <TextBlock Text="{DynamicResource prefs.playback.lockstarttime}" Margin="0,10,0,0"/>
-            <ComboBox SelectedIndex="{Binding LockStartTime}">
-              <ComboBoxItem Content="{DynamicResource prefs.playback.lockstarttime.off}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.playback.lockstarttime.on}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.playback.lockstarttime.onlycursor}"/>
-            </ComboBox>
-            <TextBlock Text="{DynamicResource prefs.playback.autoscroll}" Margin="0,10,0,0"/>
-            <ComboBox  SelectedIndex="{Binding PlaybackAutoScroll}">
-              <ComboBoxItem Content="{DynamicResource prefs.off}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.playback.autoscrollmode.stationarycursor}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.playback.autoscrollmode.pagescroll}"/>
-            </ComboBox>
-            <Grid ColumnDefinitions="Auto,8,20,8,*" Margin="0,10,0,0">
-              <TextBlock Grid.Column="0" Text="{DynamicResource prefs.playback.cursorposition}"/>
+  <Grid Margin="{Binding $parent.WindowDecorationMargin}" ColumnDefinitions="200,*">
+    <ListBox Classes="NoScroll" Name="DrawerList"
+              Focusable="{Binding ElementName=LeftDrawer, Path=LeftDrawerOpened}">
+      <ListBox.Styles>
+        <Style Selector="ListBoxItem">
+          <Setter Property="Height" Value="48" />
+          <Setter Property="Padding" Value="16,0" />
+          <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+      </ListBox.Styles>
+      <ListBoxItem Content="{DynamicResource prefs.playback}"/>
+      <ListBoxItem Content="{DynamicResource prefs.paths}"/>
+      <ListBoxItem Content="{DynamicResource prefs.editing}"/>
+      <ListBoxItem Content="{DynamicResource prefs.rendering}"/>
+      <ListBoxItem Content="{DynamicResource prefs.appearance}"/>
+      <ListBoxItem Content="{DynamicResource prefs.utau}"/>
+      <ListBoxItem Content="{DynamicResource prefs.diffsinger}"/>
+      <ListBoxItem Content="{DynamicResource prefs.advanced}"/>
+    </ListBox>
+    <ScrollViewer Grid.Column="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">
+      <Carousel Name="PageCarousel" Margin="10" HorizontalAlignment="Stretch" 
+          SelectedIndex="{Binding ElementName=DrawerList, Path=SelectedIndex}">
+        <!-- Playback -->
+        <StackPanel>
+          <TextBlock Text="{DynamicResource prefs.playback.device}"/>
+          <ComboBox ItemsSource="{Binding AudioOutputDevices}" SelectedItem="{Binding AudioOutputDevice}"/>
+          <Button Content="{DynamicResource prefs.playback.test}" HorizontalAlignment="Stretch" Command="{Binding TestAudioOutputDevice}"/>
+          <TextBlock Text="{DynamicResource prefs.playback.backend}" Margin="0,10,0,0"/>
+          <ComboBox SelectedIndex="{Binding PreferPortAudio}">
+            <ComboBoxItem Content="{DynamicResource prefs.playback.backend.auto}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.playback.backend.mini}"/>
+          </ComboBox>
+          <TextBlock Classes="restart"/>
+          <TextBlock Text="{DynamicResource prefs.playback.lockstarttime}" Margin="0,10,0,0"/>
+          <ComboBox SelectedIndex="{Binding LockStartTime}">
+            <ComboBoxItem Content="{DynamicResource prefs.playback.lockstarttime.off}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.playback.lockstarttime.on}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.playback.lockstarttime.onlycursor}"/>
+          </ComboBox>
+          <TextBlock Text="{DynamicResource prefs.playback.autoscroll}" Margin="0,10,0,0"/>
+          <ComboBox  SelectedIndex="{Binding PlaybackAutoScroll}">
+            <ComboBoxItem Content="{DynamicResource prefs.off}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.playback.autoscrollmode.stationarycursor}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.playback.autoscrollmode.pagescroll}"/>
+          </ComboBox>
+          <Grid ColumnDefinitions="Auto,8,20,8,*" Margin="0,10,0,0">
+            <TextBlock Grid.Column="0" Text="{DynamicResource prefs.playback.cursorposition}"/>
+            <TextBlock Grid.Column="2">
+              <TextBlock.Text>
+                <MultiBinding StringFormat="{}{0:#0.0}">
+                  <Binding Path="PlayPosMarkerMargin"/>
+                </MultiBinding>
+              </TextBlock.Text>
+            </TextBlock>
+            <Slider Grid.Column="4" Classes="fader" Value="{Binding PlayPosMarkerMargin}" Minimum="0" Maximum="1"
+                    TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"/>
+          </Grid>
+        </StackPanel>
+
+        <!-- Paths -->
+        <StackPanel>
+          <TextBlock Text="{DynamicResource prefs.paths.addlsinger}"/>
+          <TextBlock HorizontalAlignment="Stretch" Margin="4"
+                      TextWrapping="Wrap" FontSize="11" Text="{Binding AdditionalSingersPath}"/>
+          <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*,10,*">
+            <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
+                    HorizontalAlignment="Stretch" Click="ResetAddlSingersPath"/>
+            <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
+                    HorizontalAlignment="Stretch" Click="SelectAddlSingersPath"/>
+            <Button Grid.Column="4" Content="{DynamicResource singers.refresh}"
+                    HorizontalAlignment="Stretch" Click="ReloadSingers"/>
+          </Grid>
+          <Grid Margin="0,5,0,0">
+            <TextBlock Text="{DynamicResource prefs.paths.addlsinger.install}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding InstallToAdditionalSingersPath}"/>
+          </Grid>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.paths.loaddeepfolders}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding LoadDeepFolders}"/>
+          </Grid>
+        </StackPanel>
+
+        <!-- Editing -->
+        <StackPanel>
+          <TextBlock Text="{DynamicResource prefs.advanced.lyricshelper}" Margin="0,10,0,0"/>
+          <ComboBox ItemsSource="{Binding LyricsHelpers}" SelectedItem="{Binding LyricsHelper}"/>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.advanced.lyricshelper.brackets}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding LyricsHelperBrackets}"/>
+          </Grid>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.penplus}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding PenPlusDefault}"/>
+          </Grid>
+        </StackPanel>
+
+        <!-- Rendering -->
+        <StackPanel>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.rendering.prerender}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding PreRender}"/>
+          </Grid>
+          <Grid ColumnDefinitions="Auto,8,16,8,*">
+            <TextBlock Grid.Column="0" Text="{DynamicResource prefs.rendering.threads.numthreads}"/>
+            <TextBlock Grid.Column="2">
+              <TextBlock.Text>
+                <MultiBinding StringFormat="{}{0:#0}">
+                  <Binding Path="NumRenderThreads"/>
+                </MultiBinding>
+              </TextBlock.Text>
+            </TextBlock>
+            <Slider Grid.Column="4" Classes="fader" Value="{Binding NumRenderThreads}" Minimum="1" Maximum="{Binding LogicalCoreCount, Mode=OneTime}"
+                    TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
+          </Grid>
+          <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.rendering.threads.cpuwarn}" FontWeight="Bold"
+                      Foreground="Red" Margin="0,0,0,4" IsVisible="{Binding HighThreads}" FontSize="11"/>
+          <TextBlock Classes="restart"/>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.rendering.skipmuted}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding SkipRenderingMutedTracks}"/>
+          </Grid>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.cache.clearonquit}" HorizontalAlignment="Left" />
+            <ToggleSwitch IsChecked="{Binding ClearCacheOnQuit}" />
+          </Grid>
+          <TextBlock Text="{DynamicResource prefs.rendering.onnxrunner}" Margin="0,10,0,0"/>
+          <ComboBox ItemsSource="{Binding OnnxRunnerOptions}" SelectedItem="{Binding OnnxRunner}"/>
+          <TextBlock Text="{DynamicResource prefs.rendering.onnxgpu}" Margin="0,10,0,0"/>
+          <ComboBox ItemsSource="{Binding OnnxGpuOptions}" SelectedItem="{Binding OnnxGpu}"/>
+          <TextBlock Classes="restart"/>
+        </StackPanel>
+
+        <!-- Appearance -->
+        <StackPanel>
+          <TextBlock Text="{DynamicResource prefs.appearance.lang}" />
+          <ComboBox ItemsSource="{Binding Languages}" SelectedItem="{Binding Language}">
+            <ComboBox.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding Converter={StaticResource cultureNameConverter}}"/>
+              </DataTemplate>
+            </ComboBox.ItemTemplate>
+          </ComboBox>
+          <TextBlock Text="{DynamicResource prefs.appearance.sortorder}" Margin="0,10,0,0"/>
+          <ComboBox ItemsSource="{Binding SortingOrders}" SelectedItem="{Binding SortingOrder}">
+            <ComboBox.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding Converter={StaticResource cultureNameConverter}}"/>
+              </DataTemplate>
+            </ComboBox.ItemTemplate>
+          </ComboBox>
+          <TextBlock Text="{DynamicResource prefs.appearance.theme}" Margin="0,10,0,0"/>
+          <ComboBox SelectedIndex="{Binding Theme}">
+            <ComboBoxItem Content="{DynamicResource prefs.appearance.theme.light}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.appearance.theme.dark}"/>
+          </ComboBox>
+          <TextBlock Text="{DynamicResource prefs.appearance.degree}" Margin="0,10,0,0"/>
+          <ComboBox SelectedIndex="{Binding DegreeStyle}">
+            <ComboBoxItem Content="{DynamicResource prefs.appearance.degree.off}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.appearance.degree.solfege}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.appearance.degree.numbered}"/>
+          </ComboBox>
+          <Grid Margin="0,5,0,0">
+            <TextBlock Text="{DynamicResource prefs.appearance.trackcolor}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding UseTrackColor}"/>
+          </Grid>
+          <Grid Margin="0,5,0,0">
+            <TextBlock Text="{DynamicResource prefs.appearance.showportrait}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding ShowPortrait}"/>
+          </Grid>
+          <Grid Margin="0,5,0,0">
+            <TextBlock Text="{DynamicResource prefs.appearance.showicon}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding ShowIcon}"/>
+          </Grid>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.appearance.showghostnotes}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding ShowGhostNotes}"/>
+          </Grid>
+        </StackPanel>
+
+        <!-- UTAU -->
+        <StackPanel>
+          <TextBlock Text="{DynamicResource prefs.rendering.defaultrenderer}"/>
+          <ComboBox ItemsSource="{Binding DefaultRendererOptions}" SelectedItem="{Binding DefaultRenderer}"/>
+          <TextBlock Text="{DynamicResource prefs.otoeditor.select}" />
+          <ComboBox SelectedIndex="{Binding OtoEditor}">
+            <ComboBoxItem Content="OpenUtau"/>
+            <ComboBoxItem Content="vLabeler"/>
+            <ComboBoxItem Content="setParam"/>
+          </ComboBox>
+          <TextBlock Text="{DynamicResource prefs.advanced.vlabelerpath}" Margin="0,10,0,0"/>
+          <TextBlock HorizontalAlignment="Stretch" Margin="4"
+                      TextWrapping="Wrap" FontSize="11" Text="{Binding VLabelerPath}"/>
+          <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
+            <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
+                    HorizontalAlignment="Stretch" Click="ResetVLabelerPath"/>
+            <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
+                    HorizontalAlignment="Stretch" Click="SelectVLabelerPath"/>
+          </Grid>
+          <TextBlock Text="{DynamicResource prefs.otoeditor.setparampath}" Margin="0,10,0,0"/>
+          <TextBlock HorizontalAlignment="Stretch" Margin="4"
+                      TextWrapping="Wrap" FontSize="11" Text="{Binding SetParamPath}"/>
+          <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
+            <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
+                    HorizontalAlignment="Stretch" Click="ResetSetParamPath"/>
+            <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
+                    HorizontalAlignment="Stretch" Click="SelectSetParamPath"/>
+          </Grid>
+        </StackPanel>
+
+        <!-- DiffSinger -->
+        <StackPanel>
+          <TextBlock Text="{DynamicResource prefs.rendering.diffsingersteps}" Margin="0,10,0,0"/>
+          <ComboBox HorizontalAlignment="Stretch"  ItemsSource="{Binding DiffSingerStepsOptions}" SelectedItem="{Binding DiffSingerSteps}"/>
+          <Grid ColumnDefinitions="Auto,8,40,8,*" Margin="0,10,0,0">
+              <TextBlock Grid.Column="0" Text="{DynamicResource prefs.rendering.diffsingerdepth}"/>
               <TextBlock Grid.Column="2">
-                <TextBlock.Text>
-                  <MultiBinding StringFormat="{}{0:#0.0}">
-                    <Binding Path="PlayPosMarkerMargin"/>
-                  </MultiBinding>
-                </TextBlock.Text>
+                  <TextBlock.Text>
+                      <MultiBinding StringFormat="{}{0:#0}%">
+                          <Binding Path="DiffSingerDepth"/>
+                      </MultiBinding>
+                  </TextBlock.Text>
               </TextBlock>
-              <Slider Grid.Column="4" Classes="fader" Value="{Binding PlayPosMarkerMargin}" Minimum="0" Maximum="1"
-                      TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true"/>
-            </Grid>
-          </StackPanel>
-        </HeaderedContentControl>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.paths}">
-          <StackPanel>
-            <TextBlock Text="{DynamicResource prefs.paths.addlsinger}"/>
-            <TextBlock HorizontalAlignment="Stretch" Margin="4"
-                       TextWrapping="Wrap" FontSize="11" Text="{Binding AdditionalSingersPath}"/>
-            <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*,10,*">
-              <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
-                      HorizontalAlignment="Stretch" Click="ResetAddlSingersPath"/>
-              <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
-                      HorizontalAlignment="Stretch" Click="SelectAddlSingersPath"/>
-              <Button Grid.Column="4" Content="{DynamicResource singers.refresh}"
-                      HorizontalAlignment="Stretch" Click="ReloadSingers"/>
-            </Grid>
-            <Grid Margin="0,5,0,0">
-              <TextBlock Text="{DynamicResource prefs.paths.addlsinger.install}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding InstallToAdditionalSingersPath}"/>
-            </Grid>
-            <Grid>
-              <TextBlock Text="{DynamicResource prefs.paths.loaddeepfolders}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding LoadDeepFolders}"/>
-            </Grid>
-          </StackPanel>
-        </HeaderedContentControl>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.cache}">
-            <StackPanel>
-                <Grid>
-                    <TextBlock Text="{DynamicResource prefs.cache.clearonquit}" HorizontalAlignment="Left" />
-                    <ToggleSwitch IsChecked="{Binding ClearCacheOnQuit}" />
-                </Grid>
-                <Grid>
-                    <TextBlock Text="{DynamicResource prefs.cache.diffsingertensorcache}" HorizontalAlignment="Left" />
-                    <ToggleSwitch IsChecked="{Binding DiffSingerTensorCache}" />
-                </Grid>
-            </StackPanel>
-        </HeaderedContentControl>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.rendering}">
-          <StackPanel>
-            <TextBlock Text="{DynamicResource prefs.rendering.defaultrenderer}"/>
-            <ComboBox ItemsSource="{Binding DefaultRendererOptions}" SelectedItem="{Binding DefaultRenderer}"/>
-            <Grid>
-              <TextBlock Text="{DynamicResource prefs.rendering.prerender}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding PreRender}"/>
-            </Grid>
-            <Grid ColumnDefinitions="Auto,8,16,8,*">
-              <TextBlock Grid.Column="0" Text="{DynamicResource prefs.rendering.threads.numthreads}"/>
-              <TextBlock Grid.Column="2">
-                <TextBlock.Text>
-                  <MultiBinding StringFormat="{}{0:#0}">
-                    <Binding Path="NumRenderThreads"/>
-                  </MultiBinding>
-                </TextBlock.Text>
-              </TextBlock>
-              <Slider Grid.Column="4" Classes="fader" Value="{Binding NumRenderThreads}" Minimum="1" Maximum="{Binding LogicalCoreCount, Mode=OneTime}"
+              <Slider Grid.Column="4" Classes="fader" Value="{Binding DiffSingerDepth}" Minimum="0" Maximum="100"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
-            </Grid>
-            <TextBlock TextWrapping="Wrap" Text="{DynamicResource prefs.rendering.threads.cpuwarn}" FontWeight="Bold"
-                       Foreground="Red" Margin="0,0,0,4" IsVisible="{Binding HighThreads}" FontSize="11"/>
-            <TextBlock Text="{DynamicResource prefs.rendering.onnxrunner}" Margin="0,10,0,0"/>
-            <ComboBox ItemsSource="{Binding OnnxRunnerOptions}" SelectedItem="{Binding OnnxRunner}"/>
-            <TextBlock Classes="restart"/>
-            <TextBlock Text="{DynamicResource prefs.rendering.onnxgpu}" Margin="0,10,0,0"/>
-            <ComboBox ItemsSource="{Binding OnnxGpuOptions}" SelectedItem="{Binding OnnxGpu}"/>
-            <TextBlock Classes="restart"/>
-            <TextBlock Text="{DynamicResource prefs.rendering.diffsingersteps}" Margin="0,10,0,0"/>
-            <ComboBox HorizontalAlignment="Stretch"  ItemsSource="{Binding DiffSingerStepsOptions}" SelectedItem="{Binding DiffSingerSteps}"/>
-            <Grid ColumnDefinitions="Auto,8,40,8,*" Margin="0,10,0,0">
-                <TextBlock Grid.Column="0" Text="{DynamicResource prefs.rendering.diffsingerdepth}"/>
-                <TextBlock Grid.Column="2">
-                    <TextBlock.Text>
-                        <MultiBinding StringFormat="{}{0:#0}%">
-                            <Binding Path="DiffSingerDepth"/>
-                        </MultiBinding>
-                    </TextBlock.Text>
-                </TextBlock>
-                <Slider Grid.Column="4" Classes="fader" Value="{Binding DiffSingerDepth}" Minimum="0" Maximum="100"
-                        TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"/>
-            </Grid>
-            <Grid>
-              <TextBlock Text="{DynamicResource prefs.rendering.skipmuted}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding SkipRenderingMutedTracks}"/>
-            </Grid>
-          </StackPanel>
-        </HeaderedContentControl>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.appearance}">
-          <StackPanel>
-            <TextBlock Text="{DynamicResource prefs.appearance.lang}" />
-            <ComboBox ItemsSource="{Binding Languages}" SelectedItem="{Binding Language}">
-              <ComboBox.ItemTemplate>
-                <DataTemplate>
-                  <TextBlock Text="{Binding Converter={StaticResource cultureNameConverter}}"/>
-                </DataTemplate>
-              </ComboBox.ItemTemplate>
-            </ComboBox>
-            <TextBlock Text="{DynamicResource prefs.appearance.sortorder}" Margin="0,10,0,0"/>
-            <ComboBox ItemsSource="{Binding SortingOrders}" SelectedItem="{Binding SortingOrder}">
-              <ComboBox.ItemTemplate>
-                <DataTemplate>
-                  <TextBlock Text="{Binding Converter={StaticResource cultureNameConverter}}"/>
-                </DataTemplate>
-              </ComboBox.ItemTemplate>
-            </ComboBox>
-            <TextBlock Text="{DynamicResource prefs.appearance.theme}" Margin="0,10,0,0"/>
-            <ComboBox SelectedIndex="{Binding Theme}">
-              <ComboBoxItem Content="{DynamicResource prefs.appearance.theme.light}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.appearance.theme.dark}"/>
-            </ComboBox>
-            <TextBlock Text="{DynamicResource prefs.appearance.degree}" Margin="0,10,0,0"/>
-            <ComboBox SelectedIndex="{Binding DegreeStyle}">
-              <ComboBoxItem Content="{DynamicResource prefs.appearance.degree.off}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.appearance.degree.solfege}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.appearance.degree.numbered}"/>
-            </ComboBox>
-            <Grid Margin="0,5,0,0">
-              <TextBlock Text="{DynamicResource prefs.appearance.trackcolor}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding UseTrackColor}"/>
-            </Grid>
-            <Grid Margin="0,5,0,0">
-              <TextBlock Text="{DynamicResource prefs.appearance.showportrait}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding ShowPortrait}"/>
-            </Grid>
-            <Grid Margin="0,5,0,0">
-              <TextBlock Text="{DynamicResource prefs.appearance.showicon}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding ShowIcon}"/>
-            </Grid>
-            <Grid>
-              <TextBlock Text="{DynamicResource prefs.appearance.showghostnotes}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding ShowGhostNotes}"/>
-            </Grid>
-          </StackPanel>
-        </HeaderedContentControl>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.otoeditor}">
-          <StackPanel>
-            <TextBlock Text="{DynamicResource prefs.otoeditor.select}" />
-            <ComboBox SelectedIndex="{Binding OtoEditor}">
-              <ComboBoxItem Content="OpenUtau"/>
-              <ComboBoxItem Content="vLabeler"/>
-              <ComboBoxItem Content="setParam"/>
-            </ComboBox>
-            <TextBlock Text="{DynamicResource prefs.advanced.vlabelerpath}" Margin="0,10,0,0"/>
-            <TextBlock HorizontalAlignment="Stretch" Margin="4"
-                       TextWrapping="Wrap" FontSize="11" Text="{Binding VLabelerPath}"/>
-            <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
-              <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
-                      HorizontalAlignment="Stretch" Click="ResetVLabelerPath"/>
-              <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
-                      HorizontalAlignment="Stretch" Click="SelectVLabelerPath"/>
-            </Grid>
-            <TextBlock Text="{DynamicResource prefs.otoeditor.setparampath}" Margin="0,10,0,0"/>
-            <TextBlock HorizontalAlignment="Stretch" Margin="4"
-                       TextWrapping="Wrap" FontSize="11" Text="{Binding SetParamPath}"/>
-            <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
-              <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
-                      HorizontalAlignment="Stretch" Click="ResetSetParamPath"/>
-              <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
-                      HorizontalAlignment="Stretch" Click="SelectSetParamPath"/>
-            </Grid>
-          </StackPanel>
-        </HeaderedContentControl>
-        <HeaderedContentControl Classes="groupbox" Header="{DynamicResource prefs.advanced}">
-          <StackPanel>
-            <Grid>
-              <TextBlock Text="{DynamicResource prefs.advanced.beta}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding Beta}"/>
-            </Grid>
-            <TextBlock Classes="restart"/>
-            <TextBlock Text="{DynamicResource prefs.advanced.lyricshelper}" Margin="0,10,0,0"/>
-            <ComboBox ItemsSource="{Binding LyricsHelpers}" SelectedItem="{Binding LyricsHelper}"/>
-            <Grid>
-              <TextBlock Text="{DynamicResource prefs.advanced.lyricshelper.brackets}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding LyricsHelperBrackets}"/>
-            </Grid>
-            <Grid>
-              <TextBlock Text="{DynamicResource prefs.penplus}" HorizontalAlignment="Left"/>
-              <ToggleSwitch IsChecked="{Binding PenPlusDefault}"/>
-            </Grid>
-            <TextBlock Text="{DynamicResource prefs.advanced.rememberfiletypes}" Margin="0,5,0,0"/>
-            <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="25,25,25" VerticalAlignment="Center" Margin="4">
-              <CheckBox IsChecked="{Binding RememberMid}" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"/>
-              <TextBlock Text=" .mid" Grid.Column="1" Grid.Row="0" VerticalAlignment="Center"/>
-              <CheckBox IsChecked="{Binding RememberUst}" Grid.Column="0" Grid.Row="1" VerticalAlignment="Center"/>
-              <TextBlock Text=" .ust" Grid.Column="1" Grid.Row="1" VerticalAlignment="Center"/>
-              <CheckBox IsChecked="{Binding RememberVsqx}" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center"/>
-              <TextBlock Text=" .vsqx" Grid.Column="1" Grid.Row="2" VerticalAlignment="Center"/>
-            </Grid>
-            <TextBlock Text="{DynamicResource prefs.advanced.importtempo}" Margin="0,10,0,0"/>
-            <ComboBox SelectedIndex="{Binding ImportTempo}">
-              <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.always}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.never}"/>
-              <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.ask}"/>
-            </ComboBox>
-          </StackPanel>
-        </HeaderedContentControl>
-      </StackPanel>
+          </Grid>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.cache.diffsingertensorcache}" HorizontalAlignment="Left" />
+            <ToggleSwitch IsChecked="{Binding DiffSingerTensorCache}" />
+          </Grid>
+        </StackPanel>
+
+        <!-- Advanced -->
+        <StackPanel>
+          <Grid>
+            <TextBlock Text="{DynamicResource prefs.advanced.beta}" HorizontalAlignment="Left"/>
+            <ToggleSwitch IsChecked="{Binding Beta}"/>
+          </Grid>
+          <TextBlock Classes="restart"/>
+          <TextBlock Text="{DynamicResource prefs.advanced.rememberfiletypes}" Margin="0,5,0,0"/>
+          <Grid ColumnDefinitions="Auto,Auto" RowDefinitions="25,25,25" VerticalAlignment="Center" Margin="4">
+            <CheckBox IsChecked="{Binding RememberMid}" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"/>
+            <TextBlock Text=" .mid" Grid.Column="1" Grid.Row="0" VerticalAlignment="Center"/>
+            <CheckBox IsChecked="{Binding RememberUst}" Grid.Column="0" Grid.Row="1" VerticalAlignment="Center"/>
+            <TextBlock Text=" .ust" Grid.Column="1" Grid.Row="1" VerticalAlignment="Center"/>
+            <CheckBox IsChecked="{Binding RememberVsqx}" Grid.Column="0" Grid.Row="2" VerticalAlignment="Center"/>
+            <TextBlock Text=" .vsqx" Grid.Column="1" Grid.Row="2" VerticalAlignment="Center"/>
+          </Grid>
+          <TextBlock Text="{DynamicResource prefs.advanced.importtempo}" Margin="0,10,0,0"/>
+          <ComboBox SelectedIndex="{Binding ImportTempo}">
+            <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.always}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.never}"/>
+            <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.ask}"/>
+          </ComboBox>
+        </StackPanel>
+      </Carousel>
     </ScrollViewer>
   </Grid>
 </Window>


### PR DESCRIPTION
There are more and more preference items. Before this change, we have to scroll down to find the preference item we want. After this changes, the preferences page uses a sidebar for navigation, like how windows settings app does.

Preferences items are also rearranged. The main change is that two new categories, "UTAU" and "DiffSinger" are created for renderer-specified preference items, because some users only use UTAU voicebank or only use DiffSinger voicebanks. Having "UTAU" and "DiffSinger" will make these preference items easier to find.
![image](https://github.com/user-attachments/assets/c6ef467a-6c82-42d7-902b-bc7a13df3829)
