### PR TITLE
When inputting invalid number, textbox won't show yellow error message

### DIFF
--- a/OpenUtau/Controls/PropertyEditors/FloatEditor.cs
+++ b/OpenUtau/Controls/PropertyEditors/FloatEditor.cs
@@ -6,7 +6,7 @@ using Avalonia.Data;
 using Avalonia.Interactivity;
 using ReactiveUI;
 
-namespace OpenUtau.Controls.PropertyEditors{
+namespace OpenUtau.Controls{
     public class FloatEditor : TextBox
     {
         protected override Type StyleKeyOverride => typeof(TextBox);

--- a/OpenUtau/Controls/PropertyEditors/FloatEditor.cs
+++ b/OpenUtau/Controls/PropertyEditors/FloatEditor.cs
@@ -1,0 +1,62 @@
+﻿using System;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Interactivity;
+using ReactiveUI;
+
+namespace OpenUtau.Controls.PropertyEditors{
+    public class FloatEditor : TextBox
+    {
+        protected override Type StyleKeyOverride => typeof(TextBox);
+        public static readonly DirectProperty<FloatEditor, float> ValueProperty =
+            AvaloniaProperty.RegisterDirect<FloatEditor, float>(
+                nameof(Value),
+                o => o.Value,
+                (o, v) => o.Value = v,
+                defaultBindingMode: BindingMode.TwoWay);
+        private float _value = 0;
+
+        public FloatEditor()
+        {
+            Text = "0";
+            this.WhenAnyValue(x => x.Text)
+                .Subscribe((text => { 
+                    OnTextChanged(text);
+                }));
+        }
+
+        public float Value
+        {
+            get => _value;
+            set
+            {
+                if (SetAndRaise(ValueProperty, ref _value, value))
+                {
+                    Text = value.ToString();
+                }
+            }
+        }
+
+        protected void OnTextChanged(string? newText)
+        {
+            if (!IsKeyboardFocusWithin){
+                return;
+            }
+
+            if( newText != null && float.TryParse(newText, out float newValue))
+            {
+                Value = newValue;  
+            }
+        }
+
+        protected override void OnLostFocus(RoutedEventArgs e) {
+            base.OnLostFocus(e);
+            if (!float.TryParse(Text, out float newValue))
+            {
+                Text = Value.ToString();
+            }
+        }
+    }
+}

--- a/OpenUtau/Controls/PropertyEditors/IntEditor.cs
+++ b/OpenUtau/Controls/PropertyEditors/IntEditor.cs
@@ -6,7 +6,7 @@ using Avalonia.Data;
 using Avalonia.Interactivity;
 using ReactiveUI;
 
-namespace OpenUtau.Controls.PropertyEditors{
+namespace OpenUtau.Controls{
     public class IntEditor : TextBox
     {
         protected override Type StyleKeyOverride => typeof(TextBox);
@@ -53,7 +53,7 @@ namespace OpenUtau.Controls.PropertyEditors{
 
         protected override void OnLostFocus(RoutedEventArgs e) {
             base.OnLostFocus(e);
-            if (!float.TryParse(Text, out float newValue))
+            if (!int.TryParse(Text, out int newValue))
             {
                 Text = Value.ToString();
             }

--- a/OpenUtau/Controls/PropertyEditors/IntEditor.cs
+++ b/OpenUtau/Controls/PropertyEditors/IntEditor.cs
@@ -1,0 +1,62 @@
+using System;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Interactivity;
+using ReactiveUI;
+
+namespace OpenUtau.Controls.PropertyEditors{
+    public class IntEditor : TextBox
+    {
+        protected override Type StyleKeyOverride => typeof(TextBox);
+        public static readonly DirectProperty<IntEditor, int> ValueProperty =
+            AvaloniaProperty.RegisterDirect<IntEditor, int>(
+                nameof(Value),
+                o => o.Value,
+                (o, v) => o.Value = v,
+                defaultBindingMode: BindingMode.TwoWay);
+        private int _value = 0;
+
+        public IntEditor()
+        {
+            Text = "0";
+            this.WhenAnyValue(x => x.Text)
+                .Subscribe((text => { 
+                    OnTextChanged(text);
+                }));
+        }
+
+        public int Value
+        {
+            get => _value;
+            set
+            {
+                if (SetAndRaise(ValueProperty, ref _value, value))
+                {
+                    Text = value.ToString() ?? "";
+                }
+            }
+        }
+
+        protected void OnTextChanged(string? newText)
+        {
+            if (!IsKeyboardFocusWithin){
+                return;
+            }
+
+            if( newText != null && int.TryParse(newText, out int newValue))
+            {
+                Value = newValue;  
+            }
+        }
+
+        protected override void OnLostFocus(RoutedEventArgs e) {
+            base.OnLostFocus(e);
+            if (!float.TryParse(Text, out float newValue))
+            {
+                Text = Value.ToString();
+            }
+        }
+    }
+}

--- a/OpenUtau/Views/ExpressionsDialog.axaml
+++ b/OpenUtau/Views/ExpressionsDialog.axaml
@@ -3,7 +3,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:OpenUtau.App.ViewModels"
-        xmlns:pe="using:OpenUtau.Controls.PropertyEditors"
+        xmlns:c="using:OpenUtau.Controls"
         mc:Ignorable="d"
         x:Class="OpenUtau.App.Views.ExpressionsDialog"
         Icon="/Assets/open-utau.ico"
@@ -67,15 +67,15 @@
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.minvalue}" Width="130" HorizontalAlignment="Left"/>
-        <pe:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Min}"/>
+        <c:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Min}"/>
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.maxvalue}" Width="130" HorizontalAlignment="Left"/>
-        <pe:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Max}"/>
+        <c:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Max}"/>
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.defaultvalue}" Width="130" HorizontalAlignment="Left"/>
-        <pe:FloatEditor Margin="140,0,0,4" Value="{Binding Expression.DefaultValue}"/>
+        <c:FloatEditor Margin="140,0,0,4" Value="{Binding Expression.DefaultValue}"/>
       </Grid>
       <Grid IsVisible="{Binding Expression.IsOptions}">
         <Label Content="{DynamicResource exps.optionvalues}" Width="130" HorizontalAlignment="Left"/>

--- a/OpenUtau/Views/ExpressionsDialog.axaml
+++ b/OpenUtau/Views/ExpressionsDialog.axaml
@@ -67,11 +67,11 @@
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.minvalue}" Width="130" HorizontalAlignment="Left"/>
-        <c:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Min}"/>
+        <c:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Value="{Binding Expression.Min}"/>
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.maxvalue}" Width="130" HorizontalAlignment="Left"/>
-        <c:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Max}"/>
+        <c:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Value="{Binding Expression.Max}"/>
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.defaultvalue}" Width="130" HorizontalAlignment="Left"/>

--- a/OpenUtau/Views/ExpressionsDialog.axaml
+++ b/OpenUtau/Views/ExpressionsDialog.axaml
@@ -3,6 +3,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:OpenUtau.App.ViewModels"
+        xmlns:pe="using:OpenUtau.Controls.PropertyEditors"
         mc:Ignorable="d"
         x:Class="OpenUtau.App.Views.ExpressionsDialog"
         Icon="/Assets/open-utau.ico"
@@ -66,15 +67,15 @@
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.minvalue}" Width="130" HorizontalAlignment="Left"/>
-        <TextBox Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Min}"/>
+        <pe:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Min}"/>
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.maxvalue}" Width="130" HorizontalAlignment="Left"/>
-        <TextBox Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Max}"/>
+        <pe:FloatEditor Margin="140,0,0,4" IsEnabled="{Binding Expression.IsCustom}" Text="{Binding Expression.Max}"/>
       </Grid>
       <Grid IsVisible="{Binding Expression.ShowNumbers}">
         <Label Content="{DynamicResource exps.defaultvalue}" Width="130" HorizontalAlignment="Left"/>
-        <TextBox Margin="140,0,0,4" Text="{Binding Expression.DefaultValue}"/>
+        <pe:FloatEditor Margin="140,0,0,4" Value="{Binding Expression.DefaultValue}"/>
       </Grid>
       <Grid IsVisible="{Binding Expression.IsOptions}">
         <Label Content="{DynamicResource exps.optionvalues}" Width="130" HorizontalAlignment="Left"/>

--- a/OpenUtau/Views/NoteDefaultsDialog.axaml
+++ b/OpenUtau/Views/NoteDefaultsDialog.axaml
@@ -3,7 +3,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:OpenUtau.App.ViewModels"
-        xmlns:pe="using:OpenUtau.Controls.PropertyEditors"
+        xmlns:c="using:OpenUtau.Controls"
         mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="500"
         x:Class="OpenUtau.App.Views.NoteDefaultsDialog"
         Icon="/Assets/open-utau.ico"
@@ -42,13 +42,13 @@
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.portamento.length}"/>
-                      <pe:IntEditor Grid.Column="2" Value="{Binding CurrentPortamentoLength}" />
+                      <c:IntEditor Grid.Column="2" Value="{Binding CurrentPortamentoLength}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentPortamentoLength}" Minimum="2" Maximum="320"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.portamento.start}"/>
-                      <pe:IntEditor Grid.Column="2" Value="{Binding CurrentPortamentoStart}" />
+                      <c:IntEditor Grid.Column="2" Value="{Binding CurrentPortamentoStart}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentPortamentoStart}" Minimum="-200" Maximum="200"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
                   </Grid>
@@ -69,51 +69,51 @@
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.length}"/>
-                      <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoLength}" />
+                      <c:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoLength}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoLength}" Minimum="0" Maximum="100"
                       TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.period}"/>
-                      <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoPeriod}" />
+                      <c:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoPeriod}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoPeriod}" Minimum="5" Maximum="500"
                       TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.depth}"/>
-                      <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoDepth}" />
+                      <c:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoDepth}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoDepth}" Minimum="5" Maximum="200"
                       TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="*,20,*">
                       <Grid Grid.Column="0" ColumnDefinitions="70,10,40,20,*">
                           <Label Content="{DynamicResource notedefaults.vibrato.in}"/>
-                          <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoIn}" />
+                          <c:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoIn}" />
                           <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoIn}" Minimum="0" Maximum="100"
                           TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                       </Grid>
                       <Grid Grid.Column="2" ColumnDefinitions="70,10,40,20,*">
                           <Label Content="{DynamicResource notedefaults.vibrato.out}"/>
-                          <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoOut}" />
+                          <c:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoOut}" />
                           <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoOut}" Minimum="0" Maximum="100"
                           TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                       </Grid>
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                     <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
-                    <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoShift}" />
+                    <c:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoShift}" />
                     <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoShift}" Minimum="0" Maximum="100"
                     TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                     <Label Content="{DynamicResource notedefaults.vibrato.drift}"/>
-                    <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoDrift}" />
+                    <c:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoDrift}" />
                     <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoDrift}" Minimum="-100" Maximum="100"
                     TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                     <Label Content="{DynamicResource notedefaults.vibrato.vollink}"/>
-                    <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoVolLink}" />
+                    <c:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoVolLink}" />
                     <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoVolLink}" Minimum="-100" Maximum="100"
                     TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
@@ -123,7 +123,7 @@
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.autominlength}"/>
-                      <pe:FloatEditor Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" />
+                      <c:FloatEditor Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" />
                       <Slider Grid.Column="4" Classes="fader" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" Minimum="10" Maximum="1920"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
                   </Grid>

--- a/OpenUtau/Views/NoteDefaultsDialog.axaml
+++ b/OpenUtau/Views/NoteDefaultsDialog.axaml
@@ -3,6 +3,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:OpenUtau.App.ViewModels"
+        xmlns:pe="using:OpenUtau.Controls.PropertyEditors"
         mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="500"
         x:Class="OpenUtau.App.Views.NoteDefaultsDialog"
         Icon="/Assets/open-utau.ico"
@@ -41,13 +42,13 @@
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.portamento.length}"/>
-                      <TextBox Grid.Column="2" Text="{Binding CurrentPortamentoLength}" />
+                      <pe:IntEditor Grid.Column="2" Value="{Binding CurrentPortamentoLength}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentPortamentoLength}" Minimum="2" Maximum="320"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.portamento.start}"/>
-                      <TextBox Grid.Column="2" Text="{Binding CurrentPortamentoStart}" />
+                      <pe:IntEditor Grid.Column="2" Value="{Binding CurrentPortamentoStart}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentPortamentoStart}" Minimum="-200" Maximum="200"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
                   </Grid>
@@ -68,51 +69,51 @@
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.length}"/>
-                      <TextBox Grid.Column="2" Text="{Binding CurrentVibratoLength}" />
+                      <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoLength}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoLength}" Minimum="0" Maximum="100"
                       TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.period}"/>
-                      <TextBox Grid.Column="2" Text="{Binding CurrentVibratoPeriod}" />
+                      <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoPeriod}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoPeriod}" Minimum="5" Maximum="500"
                       TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.depth}"/>
-                      <TextBox Grid.Column="2" Text="{Binding CurrentVibratoDepth}" />
+                      <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoDepth}" />
                       <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoDepth}" Minimum="5" Maximum="200"
                       TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="*,20,*">
                       <Grid Grid.Column="0" ColumnDefinitions="70,10,40,20,*">
                           <Label Content="{DynamicResource notedefaults.vibrato.in}"/>
-                          <TextBox Grid.Column="2" Text="{Binding CurrentVibratoIn}" />
+                          <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoIn}" />
                           <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoIn}" Minimum="0" Maximum="100"
                           TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                       </Grid>
                       <Grid Grid.Column="2" ColumnDefinitions="70,10,40,20,*">
                           <Label Content="{DynamicResource notedefaults.vibrato.out}"/>
-                          <TextBox Grid.Column="2" Text="{Binding CurrentVibratoOut}" />
+                          <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoOut}" />
                           <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoOut}" Minimum="0" Maximum="100"
                           TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                       </Grid>
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                     <Label Content="{DynamicResource notedefaults.vibrato.shift}"/>
-                    <TextBox Grid.Column="2" Text="{Binding CurrentVibratoShift}" />
+                    <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoShift}" />
                     <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoShift}" Minimum="0" Maximum="100"
                     TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                     <Label Content="{DynamicResource notedefaults.vibrato.drift}"/>
-                    <TextBox Grid.Column="2" Text="{Binding CurrentVibratoDrift}" />
+                    <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoDrift}" />
                     <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoDrift}" Minimum="-100" Maximum="100"
                     TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                     <Label Content="{DynamicResource notedefaults.vibrato.vollink}"/>
-                    <TextBox Grid.Column="2" Text="{Binding CurrentVibratoVolLink}" />
+                    <pe:FloatEditor Grid.Column="2" Value="{Binding CurrentVibratoVolLink}" />
                     <Slider Grid.Column="4" Classes="fader" Value="{Binding CurrentVibratoVolLink}" Minimum="-100" Maximum="100"
                     TickPlacement="BottomRight" TickFrequency="0.1" IsSnapToTickEnabled="true" />
                   </Grid>
@@ -122,7 +123,7 @@
                   </Grid>
                   <Grid ColumnDefinitions="180,20,50,20,*">
                       <Label Content="{DynamicResource notedefaults.vibrato.autominlength}"/>
-                      <TextBox Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Text="{Binding AutoVibratoNoteLength}" />
+                      <pe:FloatEditor Grid.Column="2" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" />
                       <Slider Grid.Column="4" Classes="fader" IsEnabled="{Binding AutoVibratoToggle}" Value="{Binding AutoVibratoNoteLength}" Minimum="10" Maximum="1920"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true" />
                   </Grid>


### PR DESCRIPTION
Before this fix, when inputting invalid number, textbox shows a yellow error message and doesn't respond to further editing. This makes it very hard to input negative value because once you enter the `-`, it errors out
![image](https://github.com/user-attachments/assets/f52b8f4d-20ef-4486-85a6-b8a843c4059e)

After this fix, it won't show error message and it will allow you to temporarily input invalid numbers. The input will be applied once the text in the textbox becomes a valid number