### PR TITLE
Capitalize machine learning runner names in UI

### DIFF
--- a/OpenUtau.Core/Util/Onnx.cs
+++ b/OpenUtau.Core/Util/Onnx.cs
@@ -19,17 +19,17 @@ namespace OpenUtau.Core {
         public static List<string> getRunnerOptions() {
             if (OS.IsWindows()) {
                 return new List<string> {
-                "cpu",
-                "directml"
+                "CPU",
+                "DirectML"
                 };
             } else if (OS.IsMacOS()) {
                 return new List<string> {
-                "cpu",
-                "coreml"
+                "CPU",
+                "CoreML"
                 };
             }
             return new List<string> {
-                "cpu"
+                "CPU"
             };
         }
 
@@ -64,13 +64,13 @@ namespace OpenUtau.Core {
                 runner = runnerOptions[0];
             }
             if (!runnerOptions.Contains(runner)) {
-                runner = "cpu";
+                runner = "CPU";
             }
             switch(runner){
-                case "directml":
+                case "DirectML":
                     options.AppendExecutionProvider_DML(Preferences.Default.OnnxGpu);
                     break;
-                case "coreml":
+                case "CoreML":
                     options.AppendExecutionProvider_CoreML(CoreMLFlags.COREML_FLAG_ENABLE_ON_SUBGRAPH);
                     break;
             }


### PR DESCRIPTION
Capitalizes CPU, DirectML and CoreML in UI. This was something that was bugging me.