### PR TITLE
Add links to FAQ, and instructions for solving 'This app is damaged' on macOS into release page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,4 +156,11 @@ jobs:
           files: |
             appcast.${{ matrix.arch.name }}*.xml
             OpenUtau-${{ matrix.arch.name }}.*
+          body: |
+            See [Getting Started](https://github.com/stakira/OpenUtau/wiki/Getting-Started) for how to use.
+
+            If you encountered issues, see [FAQ](https://github.com/stakira/OpenUtau/wiki/FAQ)
+
+            ## macOS says "App damaged"
+            Open a terminal and run `xattr -rc /Applications/OpenUtau.app`. Try opening OpenUtau again.
         if: ${{ inputs.release }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,6 @@ jobs:
 
             If you encountered issues, see [FAQ](https://github.com/stakira/OpenUtau/wiki/FAQ)
 
-            ## macOS says "App damaged"
+            ## macOS says "This app is damaged"
             Open a terminal and run `xattr -rc /Applications/OpenUtau.app`. Try opening OpenUtau again.
         if: ${{ inputs.release }}


### PR DESCRIPTION
Many mac users are still blocked by 'This app is damaged', so I added instructions into our release page which is more noticeable than FAQ.