### PR TITLE
Musicxml: fix crash after importing a musicxml without tempo

### DIFF
--- a/OpenUtau.Core/Format/MusicXML.cs
+++ b/OpenUtau.Core/Format/MusicXML.cs
@@ -83,6 +83,12 @@ namespace OpenUtau.Core.Format
                 }
                 upart.Duration = upart.GetMinDurTick(uproject);
             }
+            if(uproject.tempos.Count == 0){
+                uproject.tempos.Add(new UTempo(0, 120));
+            }
+            if(uproject.tempos[0].position > 0){
+                uproject.tempos[0].position = 0;
+            }
             uproject.AfterLoad();
             uproject.ValidateFull();
             return uproject;

--- a/OpenUtau.Test/Core/Format/MusicXMLTest.cs
+++ b/OpenUtau.Test/Core/Format/MusicXMLTest.cs
@@ -110,5 +110,27 @@ namespace OpenUtau.Core.Format {
                 Assert.Equal(l, n.duration);
             }
         }
+
+        [Fact]
+        public void LyricsTest(){
+            var project = MusicXML.LoadProject(Path.Join(basePath, "61a-Lyrics.musicxml"));
+            var part = project.parts.First() as UVoicePart;
+            Assert.Equal(0, part.notes.First().position);
+            AssertLegato(part);
+            var notesList = part.notes.ToList();
+            foreach(var n in notesList[..^1]){
+                Assert.Equal(69, n.tone);
+                Assert.Equal(480, n.duration);
+            }
+            Assert.Equal(69, notesList[^1].tone);
+            Assert.Equal(960, notesList[^1].duration);
+            Assert.Equal("Tra", notesList[0].lyric);
+            Assert.Equal("la", notesList[1].lyric);
+            Assert.Equal("li", notesList[2].lyric);
+            Assert.Equal("Ja!", notesList[3].lyric);
+            Assert.Equal("Tra", notesList[5].lyric);
+            Assert.Equal("ra!", notesList[7].lyric);
+            Assert.Equal("Bah!", notesList[9].lyric);
+        }
     }
 }

--- a/OpenUtau.Test/Files/MusicXML/61a-Lyrics.musicxml
+++ b/OpenUtau.Test/Files/MusicXML/61a-Lyrics.musicxml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 1.0 Partwise//EN"
+                                "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+  <identification>
+    <miscellaneous>
+      <miscellaneous-field name="description">Some notes with simple lyrics: 
+            Syllables, notes without a syllable, syllable 
+            spanners.</miscellaneous-field>
+    </miscellaneous>
+  </identification>
+  <part-list>
+    <score-part id="P1">
+      <part-name>MusicXML Part</part-name>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>begin</syllabic>
+          <text>Tra</text>
+        </lyric>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>middle</syllabic>
+          <text>la</text>
+        </lyric>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>end</syllabic>
+          <text>li</text>
+        </lyric>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Ja!</text>
+        </lyric>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="2">
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>begin</syllabic>
+          <text>Tra</text>
+        </lyric>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>end</syllabic>
+          <text>ra!</text>
+        </lyric>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3">
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <lyric number="1">
+          <syllabic>single</syllabic>
+          <text>Bah!</text>
+        </lyric>
+      </note>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>


### PR DESCRIPTION
Before this fix, after importing a musicxml file without tempo, opening the pianoroll will make openutau crash. 