### PR TITLE
Add "legacy" to the names of JA VCV and JA CVVC phonemizers

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseCVVCPhonemizer.cs
@@ -6,7 +6,7 @@ using OpenUtau.Core.Ustx;
 using Serilog;
 
 namespace OpenUtau.Plugin.Builtin {
-    [Phonemizer("Japanese CVVC Phonemizer", "JA CVVC", "TUBS",language:"JA")]
+    [Phonemizer("Japanese CVVC Phonemizer (legacy)", "JA CVVC", "TUBS",language:"JA")]
     public class JapaneseCVVCPhonemizer : Phonemizer {
         static readonly string[] plainVowels = new string[] {"あ","い","う","え","お","を","ん","ン"};
         static readonly string[] nonVowels = new string[]{"息","吸","R","-","k","ky","g","gy",

--- a/OpenUtau.Plugin.Builtin/JapaneseVCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapaneseVCVPhonemizer.cs
@@ -4,7 +4,7 @@ using OpenUtau.Api;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Plugin.Builtin {
-    [Phonemizer("Japanese VCV Phonemizer", "JA VCV", language: "JA")]
+    [Phonemizer("Japanese VCV Phonemizer (legacy)", "JA VCV", language: "JA")]
     public class JapaneseVCVPhonemizer : Phonemizer {
         /// <summary>
         /// The lookup table to convert a hiragana to its tail vowel.


### PR DESCRIPTION
The current-recommended one is Japanese presamp Phonemizer (JA VCV & CVVC)