### PR TITLE
Simplify title on titlebar and in Apps and Features

### DIFF
--- a/OpenUtau.nsi
+++ b/OpenUtau.nsi
@@ -44,7 +44,7 @@
 
 ; MUI end ------
 
-Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
+Name "${PRODUCT_NAME}"
 OutFile "OpenUtau-win-${ARCH}.exe"
 InstallDir "$PROGRAMFILES64\OpenUtau"
 ShowInstDetails show

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -40,7 +40,7 @@ namespace OpenUtau.App.ViewModels {
 
         [Reactive] public string ClearCacheHeader { get; set; }
         public bool ProjectSaved => !string.IsNullOrEmpty(DocManager.Inst.Project.FilePath) && DocManager.Inst.Project.Saved;
-        public string AppVersion => $"OpenUtau v{System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version}";
+        public string AppVersion => $"OpenUtau v";
         [Reactive] public double Progress { get; set; }
         [Reactive] public string ProgressText { get; set; }
         public ReactiveCommand<UPart, Unit> PartDeleteCommand { get; set; }

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -40,7 +40,7 @@ namespace OpenUtau.App.ViewModels {
 
         [Reactive] public string ClearCacheHeader { get; set; }
         public bool ProjectSaved => !string.IsNullOrEmpty(DocManager.Inst.Project.FilePath) && DocManager.Inst.Project.Saved;
-        public string AppVersion => $"OpenUtau v";
+        public string AppVersion => $"OpenUtau";
         [Reactive] public double Progress { get; set; }
         [Reactive] public string ProgressText { get; set; }
         public ReactiveCommand<UPart, Unit> PartDeleteCommand { get; set; }


### PR DESCRIPTION
Simplify title on the titlebar on the main window and in Apps and Features for the installer, because version is not necessary to be shown there and it cleans up the presentation.