### PR TITLE
fix slice tool extending the part too much

### DIFF
--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -424,7 +424,7 @@ namespace OpenUtau.App.ViewModels {
             int tick = PointToTick(point);
             int snappedTick = (int)Math.Floor((double)tick / snapUnit) * snapUnit;
             UNote note = project.CreateNote(tone, snappedTick,
-                useLastLength ? _lastNoteLength : IsSnapOn ? snappedTick : 15);
+                useLastLength ? _lastNoteLength : IsSnapOn ? snapUnit : 15);
             DocManager.Inst.ExecuteCmd(new AddNoteCommand(Part, note));
             return note;
         }


### PR DESCRIPTION
Before this change, when using slice tool, the duration of the part will be extended to 2 * the position where you slice relative to the starting of the part

https://github.com/stakira/OpenUtau/issues/1387 will be fixed by this PR