### PR TITLE
Fix Note Properties Panel not working after auto reloading oto

### DIFF
--- a/OpenUtau.Core/Commands/Notifications.cs
+++ b/OpenUtau.Core/Commands/Notifications.cs
@@ -174,7 +174,11 @@ namespace OpenUtau.Core {
     }
 
     public class SingersRefreshedNotification : UNotification {
+        public readonly USinger? singer;
         public SingersRefreshedNotification() { }
+        public SingersRefreshedNotification(USinger singer) {
+            this.singer = singer;
+        }
         public override string ToString() => "Singers refreshed.";
     }
 

--- a/OpenUtau/Controls/NotePropertiesControl.axaml.cs
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml.cs
@@ -158,8 +158,11 @@ namespace OpenUtau.App.Controls {
                     LoadPart(notif.part);
                 } else if (cmd is LoadProjectNotification) {
                     LoadPart(null);
-                } else if (cmd is SingersRefreshedNotification) {
-                    LoadPart(notif.part);
+                } else if (cmd is SingersRefreshedNotification srn && srn.singer != null && ViewModel.Part != null) {
+                    var singer = DocManager.Inst.Project.tracks[ViewModel.Part.trackNo].Singer;
+                    if (singer != null && singer == srn.singer) {
+                        LoadPart(ViewModel.Part);
+                    }
                 }
             } else if (cmd is TrackCommand) {
                 if (cmd is RemoveTrackCommand removeTrack) {

--- a/OpenUtau/Controls/NotePropertiesControl.axaml.cs
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml.cs
@@ -170,8 +170,8 @@ namespace OpenUtau.App.Controls {
                         LoadPart(null);
                     }
                 }
-            } else if (cmd is ConfigureExpressionsCommand) {
-                LoadPart(null);
+            } else if (cmd is ConfigureExpressionsCommand && ViewModel.Part != null) {
+                LoadPart(ViewModel.Part);
             }
         }
     }

--- a/OpenUtau/ViewModels/SingersViewModel.cs
+++ b/OpenUtau/ViewModels/SingersViewModel.cs
@@ -356,7 +356,7 @@ namespace OpenUtau.App.ViewModels {
             Otos.AddRange(Singer.Otos);
             LoadSubbanks();
 
-            DocManager.Inst.ExecuteCmd(new SingersRefreshedNotification());
+            DocManager.Inst.ExecuteCmd(new SingersRefreshedNotification(Singer));
             DocManager.Inst.ExecuteCmd(new OtoChangedNotification());
             if (Otos.Count > 0) {
                 index = Math.Clamp(index, 0, Otos.Count - 1);


### PR DESCRIPTION
After making changes to a singer, the Note Properties Panel was not correctly determining if/which part should be reloaded.