### PR TITLE
Move to the next track part with PageUp/PageDown keys

### DIFF
--- a/OpenUtau.Core/Ustx/UProject.cs
+++ b/OpenUtau.Core/Ustx/UProject.cs
@@ -59,11 +59,11 @@ namespace OpenUtau.Core.Ustx {
         /// <summary>
         /// Transient field used for serialization.
         /// </summary>
-        public List<UVoicePart> voiceParts;
+        public List<UVoicePart>? voiceParts;
         /// <summary>
         /// Transient field used for serialization.
         /// </summary>
-        public List<UWavePart> waveParts;
+        public List<UWavePart>? waveParts;
 
         [YamlIgnore] public string FilePath { get; set; } = string.Empty;
         [YamlIgnore] public bool Saved { get; set; } = false;
@@ -141,13 +141,13 @@ namespace OpenUtau.Core.Ustx {
             }
             voiceParts = parts
                 .Where(part => part is UVoicePart)
-                .Select(part => part as UVoicePart)
+                .OfType<UVoicePart>()
                 .OrderBy(part => part.trackNo)
                 .ThenBy(part => part.position)
                 .ToList();
             waveParts = parts
                 .Where(part => part is UWavePart)
-                .Select(part => part as UWavePart)
+                .OfType<UWavePart>()
                 .OrderBy(part => part.trackNo)
                 .ThenBy(part => part.position)
                 .ToList();

--- a/OpenUtau/ViewModels/TracksViewModel.cs
+++ b/OpenUtau/ViewModels/TracksViewModel.cs
@@ -431,6 +431,11 @@ namespace OpenUtau.App.ViewModels {
                     if (!setPlayPosTick.pause || Preferences.Default.LockStartTime == 1) {
                         MaybeAutoScroll();
                     }
+                } else if (cmd is LoadPartNotification loadPartNotif) {
+                    if (SelectedParts.Count != 1 || SelectedParts.First() != loadPartNotif.part) {
+                        DeselectParts();
+                        SelectPart(loadPartNotif.part);
+                    }
                 }
                 Notify();
             }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1452,7 +1452,6 @@ namespace OpenUtau.App.Views {
                 // PLAY POSITION + SELECTION
                 case Key.Home:
                     if (isNone) {
-                        playVm.MovePlayPos(notesVm.Part.position);
                         HScrollBar.Value = HScrollBar.Minimum;
                         return true;
                     }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1453,7 +1453,6 @@ namespace OpenUtau.App.Views {
                 case Key.Home:
                     if (isNone) {
                         playVm.MovePlayPos(notesVm.Part.position);
-                        HScrollBar.Value = HScrollBar.Minimum;
                         return true;
                     }
                     if (isShift) {

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1452,6 +1452,7 @@ namespace OpenUtau.App.Views {
                 // PLAY POSITION + SELECTION
                 case Key.Home:
                     if (isNone) {
+                        playVm.MovePlayPos(notesVm.Part.position);
                         HScrollBar.Value = HScrollBar.Minimum;
                         return true;
                     }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1632,7 +1632,7 @@ namespace OpenUtau.App.Views {
                     }
                     break;
                 #endregion
-                #region scroll and select keys
+                #region move to the next track part
                 case Key.PageUp: {
                         if (isNone) {
                             return MoveToNextPart(false);


### PR DESCRIPTION
## New Feature
Use shortcut keys in the pianoroll window to move to the part of the track above or below in the same position.

https://github.com/user-attachments/assets/d9c39628-ada3-40e7-b7d1-cc0115a8c361

This feature does not change the horizontal scroll position of the pianoroll window, and the criterion for whether the part is in the same position is the center of the notes canvas.

## Bug Fixes
- Since voiceParts and waveParts in UProject are explicitly assigned null, I changed them to nullable types to avoid confusion.
- Fixed no scrolling when using End key to move play position.