### PR TITLE
zhcvvc: length of VC should be based on the whole length of the syllable, including slur notes

### DIFF
--- a/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVCPhonemizer.cs
@@ -75,7 +75,7 @@ namespace OpenUtau.Plugin.Builtin {
                     vcPhoneme = oto.Alias;
                 }
                 // prevDuration calculated on basis of previous note length
-                int prevDuration = prevNeighbour.Value.duration;
+                int prevDuration = notes[0].position - prevNeighbour.Value.position;
                 // vcLength depends on the Vel of the current base note
                 vcLen = Convert.ToInt32(Math.Min(prevDuration / 1.5, Math.Max(30, vcLen * (attr1.consonantStretchRatio ?? 1))));
             } else {


### PR DESCRIPTION
Before this PR, if a syllable contains a short syllabic note and a long slur note, the length of VC part will be very short.

#1391 will be fixed by this PR.