### PR TITLE
Classic renderer: support direct

### DIFF
--- a/OpenUtau.Core/Classic/ClassicRenderer.cs
+++ b/OpenUtau.Core/Classic/ClassicRenderer.cs
@@ -68,12 +68,14 @@ namespace OpenUtau.Classic {
                         if (!(item.resampler is WorldlineResampler)) {
                             VoicebankFiles.Inst.CopySourceTemp(item.inputFile, item.inputTemp);
                         }
-                        lock (Renderers.GetCacheLock(item.outputFile)) {
-                            item.resampler.DoResamplerReturnsFile(item, Log.Logger);
-                        }
-                        if (!File.Exists(item.outputFile)) {
-                            DocManager.Inst.Project.timeAxis.TickPosToBarBeat(item.phrase.position + item.phone.position, out int bar, out int beat, out int tick);
-                            throw new InvalidDataException($"{item.resampler} failed to resample \"{item.phone.phoneme}\" at {bar}:{beat}.{string.Format("{0:000}", tick)}");
+                        if(!item.phone.direct){
+                            lock (Renderers.GetCacheLock(item.outputFile)) {
+                                item.resampler.DoResamplerReturnsFile(item, Log.Logger);
+                            }
+                            if (!File.Exists(item.outputFile)) {
+                                DocManager.Inst.Project.timeAxis.TickPosToBarBeat(item.phrase.position + item.phone.position, out int bar, out int beat, out int tick);
+                                throw new InvalidDataException($"{item.resampler} failed to resample \"{item.phone.phoneme}\" at {bar}:{beat}.{string.Format("{0:000}", tick)}");
+                            }
                         }
                         if (!(item.resampler is WorldlineResampler)) {
                             VoicebankFiles.Inst.CopyBackMetaFiles(item.inputFile, item.inputTemp);

--- a/OpenUtau.Core/Classic/ExeWavtool.cs
+++ b/OpenUtau.Core/Classic/ExeWavtool.cs
@@ -156,7 +156,11 @@ namespace OpenUtau.Classic {
             string dur = $"{item.phone.duration:G999}@{item.phone.adjustedTempo:G999}{(item.durCorrection >= 0 ? "+" : "")}{item.durCorrection}";
             string relInputTemp = Path.GetRelativePath(PathManager.Inst.CachePath, item.inputTemp);
             writer.WriteLine($"@echo {MakeProgressBar(index + 1, total)}");
-            writer.WriteLine($"@call %helper% \"%oto%\\{ConvertIfNeeded(relInputTemp)}\" {toneName} {dur} {item.preutter} {item.offset} {item.durRequired} {item.consonant} {item.cutoff} {index}");
+            if(item.phone.direct){
+                writer.WriteLine($"@\"%tool%\" \"%output%\" \"%oto%\\{ConvertIfNeeded(relInputTemp)}\" {item.offset} {item.phone.durationMs:F1} %env%");
+            } else {
+                writer.WriteLine($"@call %helper% \"%oto%\\{ConvertIfNeeded(relInputTemp)}\" {toneName} {dur} {item.preutter} {item.offset} {item.durRequired} {item.consonant} {item.cutoff} {index}");
+            }
         }
 
         string MakeProgressBar(int index, int total) {


### PR DESCRIPTION
After this PR, Classic renderer will support DIR (direct) expression like how worldline-r does. It bypasses the resampler and put the original audio into output as-is.
Both builtin wavtools and external exe wavtools (including moresampler) are supported.