### PR TITLE
[Waiting for test] Show window title in macOS

### DIFF
--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -25,7 +25,6 @@ namespace OpenUtau.App.ViewModels {
     }
 
     public class MainWindowViewModel : ViewModelBase, ICmdSubscriber {
-        public bool ExtendToFrame => OS.IsMacOS();
         public string Title => !ProjectSaved
             ? $"{AppVersion}"
             : $"{(DocManager.Inst.ChangesSaved ? "" : "*")}{AppVersion} [{DocManager.Inst.Project.FilePath}]";

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -43,7 +43,6 @@ namespace OpenUtau.App.ViewModels {
 
     public class PianoRollViewModel : ViewModelBase, ICmdSubscriber {
 
-        public bool ExtendToFrame => OS.IsMacOS();
         [Reactive] public NotesViewModel NotesViewModel { get; set; }
         [Reactive] public PlaybackViewModel? PlaybackViewModel { get; set; }
 

--- a/OpenUtau/Views/EditSubbanksDialog.axaml
+++ b/OpenUtau/Views/EditSubbanksDialog.axaml
@@ -8,8 +8,7 @@
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource singers.subbanks.edit}"
         WindowStartupLocation="CenterScreen"
-        MinWidth="500" MinHeight="600" Width="500" Height="600"
-        ExtendClientAreaToDecorationsHint="False">
+        MinWidth="500" MinHeight="600" Width="500" Height="600">
   <Grid ColumnDefinitions="*,10,160" Margin="10">
     <DataGrid Name="SuffixGrid" Grid.Column="0" SelectionMode="Extended" IsReadOnly="True"
               CanUserReorderColumns="False" CanUserSortColumns="False" AutoGenerateColumns="False"

--- a/OpenUtau/Views/ExpressionsDialog.axaml
+++ b/OpenUtau/Views/ExpressionsDialog.axaml
@@ -9,8 +9,7 @@
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource exps.caption}"
         WindowStartupLocation="CenterScreen"
-        MinWidth="600" MinHeight="400" Width="600" Height="400"
-        ExtendClientAreaToDecorationsHint="False">
+        MinWidth="600" MinHeight="400" Width="600" Height="400">
   <Design.DataContext>
     <vm:ExpressionsViewModel/>
   </Design.DataContext>

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -10,8 +10,7 @@
         Title="{Binding Title}" MinWidth="300" MinHeight="200"
         KeyDown="OnKeyDown" PointerPressed="OnPointerPressed" Closing="WindowClosing"
         Focusable="True"
-        TransparencyLevelHint="None"
-        ExtendClientAreaToDecorationsHint="{Binding ExtendToFrame}">
+        TransparencyLevelHint="None">
   <Window.Styles>
     <Style Selector="Button,ToggleButton">
       <Setter Property="Focusable" Value="False"/>

--- a/OpenUtau/Views/MessageBox.axaml
+++ b/OpenUtau/Views/MessageBox.axaml
@@ -6,8 +6,7 @@
         x:Class="OpenUtau.App.Views.MessageBox" SizeToContent="WidthAndHeight" CanResize="False"
         Icon="/Assets/open-utau.ico"
         Title="MessageBox" MinWidth="300" MinHeight="150"
-        WindowStartupLocation="CenterScreen"
-        ExtendClientAreaToDecorationsHint="False">
+        WindowStartupLocation="CenterScreen">
   <ScrollViewer MaxHeight="700" VerticalScrollBarVisibility="Auto">
     <Grid Margin="{Binding $parent.WindowDecorationMargin}">
       <Grid.RowDefinitions>

--- a/OpenUtau/Views/NoteDefaultsDialog.axaml
+++ b/OpenUtau/Views/NoteDefaultsDialog.axaml
@@ -9,8 +9,7 @@
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource notedefaults.caption}"
         WindowStartupLocation="CenterScreen"
-        MinWidth="600" MinHeight="500" Width="600" Height="500"
-        ExtendClientAreaToDecorationsHint="False">
+        MinWidth="600" MinHeight="500" Width="600" Height="500">
   <Window.Resources>
     <vm:CultureNameConverter x:Key="cultureNameConverter"/>
   </Window.Resources>

--- a/OpenUtau/Views/PasteParamDialog.axaml
+++ b/OpenUtau/Views/PasteParamDialog.axaml
@@ -6,8 +6,7 @@
         x:Class="OpenUtau.App.Views.PasteParamDialog"
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource context.note.pasteparameters}"
-        WindowStartupLocation="CenterOwner"
-        ExtendClientAreaToDecorationsHint="False">
+        WindowStartupLocation="CenterOwner">
   <Grid RowDefinitions="*, 40" >
     <ListBox SelectionMode="Multiple,Toggle" ItemsSource="{Binding Params}"
              Grid.Row="0" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Auto" Background="Transparent" >

--- a/OpenUtau/Views/PhoneticAssistant.axaml
+++ b/OpenUtau/Views/PhoneticAssistant.axaml
@@ -7,8 +7,7 @@
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource phoneticassistant.caption}"
         WindowStartupLocation="CenterScreen"
-        Width="400" Height="136" CanResize="False"
-        ExtendClientAreaToDecorationsHint="False">
+        Width="400" Height="136" CanResize="False">
   <Grid Margin="{Binding $parent.WindowDecorationMargin}">
     <StackPanel Margin="10">
       <ComboBox HorizontalAlignment="Stretch" Margin="0,0,0,4" ItemsSource="{Binding G2ps}" SelectedItem="{Binding G2p}"/>

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -11,7 +11,7 @@
         Title="{Binding NotesViewModel.WindowTitle}" MinWidth="300" MinHeight="200" KeyDown="OnKeyDown" Closing="WindowClosing"
         Focusable="True"
         TransparencyLevelHint="None"
-        ExtendClientAreaToDecorationsHint="{Binding ExtendToFrame}" Deactivated="WindowDeactivated">
+        Deactivated="WindowDeactivated">
   <Window.Styles>
     <StyleInclude Source="/Styles/PianoRollStyles.axaml"/>
   </Window.Styles>

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -10,8 +10,7 @@
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource prefs.caption}"
         WindowStartupLocation="CenterScreen"
-        Width="800" Height="400"
-        ExtendClientAreaToDecorationsHint="False">
+        Width="800" Height="400">
   <Window.Resources>
     <vm:CultureNameConverter x:Key="cultureNameConverter"/>
   </Window.Resources>

--- a/OpenUtau/Views/SingerPublishDialog.axaml
+++ b/OpenUtau/Views/SingerPublishDialog.axaml
@@ -8,7 +8,6 @@
         Icon="/Assets/open-utau.ico"
         WindowStartupLocation="CenterScreen"
         MinWidth="500" MinHeight="500" Width="500" Height="500"
-        ExtendClientAreaToDecorationsHint="False"
         Title="{DynamicResource singers.publish}">
   <Grid Margin="{Binding $parent.WindowDecorationMargin}">
     <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Visible">

--- a/OpenUtau/Views/SingerSetupDialog.axaml
+++ b/OpenUtau/Views/SingerSetupDialog.axaml
@@ -7,8 +7,7 @@
         x:Class="OpenUtau.App.Views.SingerSetupDialog"
         Icon="/Assets/open-utau.ico"
         Title="Singer Setup"
-        WindowStartupLocation="CenterScreen"
-        ExtendClientAreaToDecorationsHint="False">
+        WindowStartupLocation="CenterScreen">
   <Window.Resources>
     <vm:EncodingNameConverter x:Key="encodingNameConverter"/>
   </Window.Resources>

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -9,8 +9,7 @@
         x:Class="OpenUtau.App.Views.SingersDialog"
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource singers.caption}" Width="1050" MinWidth="1050" MinHeight="640"
-        WindowStartupLocation="CenterScreen"
-        ExtendClientAreaToDecorationsHint="False" KeyDown="OnKeyDown">
+        WindowStartupLocation="CenterScreen" KeyDown="OnKeyDown">
   <Design.DataContext>
     <vm:SingersViewModel/>
   </Design.DataContext>

--- a/OpenUtau/Views/SliderDialog.axaml
+++ b/OpenUtau/Views/SliderDialog.axaml
@@ -5,8 +5,7 @@
         mc:Ignorable="d"
         x:Class="OpenUtau.App.Views.SliderDialog"
         Icon="/Assets/open-utau.ico"
-        Title="SliderDialog" Height="120" Width="300" WindowStartupLocation="CenterOwner"
-        ExtendClientAreaToDecorationsHint="False">
+        Title="SliderDialog" Height="120" Width="300" WindowStartupLocation="CenterOwner">
   <StackPanel VerticalAlignment="Center" Margin="{Binding $parent.WindowDecorationMargin}">
     <StackPanel Orientation="Horizontal" Spacing="10" Margin="10" HorizontalAlignment="Center">
       <Slider Name="Slider" Width="150"

--- a/OpenUtau/Views/TimeSignatureDialog.axaml
+++ b/OpenUtau/Views/TimeSignatureDialog.axaml
@@ -6,8 +6,7 @@
         x:Class="OpenUtau.App.Views.TimeSignatureDialog"
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource dialogs.timesig.caption}"
-        Height="100" Width="320" WindowStartupLocation="CenterOwner"
-        ExtendClientAreaToDecorationsHint="False">
+        Height="100" Width="320" WindowStartupLocation="CenterOwner">
   <StackPanel VerticalAlignment="Center" Margin="{Binding $parent.WindowDecorationMargin}">
     <Grid ColumnDefinitions="1*,1*" Margin="4,0">
       <ComboBox Grid.Column="0" Margin="4" HorizontalAlignment="Stretch"

--- a/OpenUtau/Views/TrackSettingsDialog.axaml
+++ b/OpenUtau/Views/TrackSettingsDialog.axaml
@@ -6,8 +6,7 @@
         x:Class="OpenUtau.App.Views.TrackSettingsDialog"
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource dialogs.tracksettings.caption}"
-        Height="184" Width="320" WindowStartupLocation="CenterOwner"
-        ExtendClientAreaToDecorationsHint="False" CanResize="False">
+        Height="184" Width="320" WindowStartupLocation="CenterOwner" CanResize="False">
   <Border Margin="{Binding $parent.WindowDecorationMargin}">
     <StackPanel Margin="8">
       <TextBlock Text="{DynamicResource warning.renderer}" IsVisible="{Binding IsNotClassic}"/>

--- a/OpenUtau/Views/TypeInDialog.axaml
+++ b/OpenUtau/Views/TypeInDialog.axaml
@@ -5,8 +5,7 @@
         mc:Ignorable="d"
         x:Class="OpenUtau.App.Views.TypeInDialog"
         Icon="/Assets/open-utau.ico"
-        Title="TypeInDialog" Height="120" Width="320" WindowStartupLocation="CenterOwner"
-        ExtendClientAreaToDecorationsHint="False">
+        Title="TypeInDialog" Height="120" Width="320" WindowStartupLocation="CenterOwner">
   <StackPanel VerticalAlignment="Center" Margin="{Binding $parent.WindowDecorationMargin}">
     <TextBlock Margin="20" Name="Prompt" IsVisible="False" TextWrapping="Wrap" MaxWidth="560"/>
     <TextBox Name="TextBox" Margin="4"/>

--- a/OpenUtau/Views/VoiceColorMappingDialog.axaml
+++ b/OpenUtau/Views/VoiceColorMappingDialog.axaml
@@ -6,8 +6,7 @@
         x:Class="OpenUtau.App.Views.VoiceColorMappingDialog"
         Icon="/Assets/open-utau.ico"
         Title="{DynamicResource dialogs.voicecolorremapping}"
-        WindowStartupLocation="CenterOwner"
-        ExtendClientAreaToDecorationsHint="False">
+        WindowStartupLocation="CenterOwner">
   <Grid RowDefinitions="40,1*,30" Margin="10">
     <StackPanel Grid.Row="0" >
       <TextBlock Text="{DynamicResource dialogs.voicecolorremapping.caption}" />


### PR DESCRIPTION
Changes: ExtendClientAreaToDecorationsHint  is now always false except for splash screen.

Fixed that version, file paths, etc. are not displayed on macOS.
However, I have not been able to test it on an actual device.
Can anyone give me feedback? Or if there is a reason why it shouldn't be modified, please let me know.