### PR TITLE
Fix OpenUtau's data folders appearing in the wrong place on macOS

### DIFF
--- a/OpenUtau.Core/Util/PathManager.cs
+++ b/OpenUtau.Core/Util/PathManager.cs
@@ -16,7 +16,7 @@ namespace OpenUtau.Core {
         public PathManager() {
             RootPath = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
             if (OS.IsMacOS()) {
-                string userHome = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+                string userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                 DataPath = Path.Combine(userHome, "Library", "OpenUtau");
                 CachePath = Path.Combine(userHome, "Library", "Caches", "OpenUtau");
                 HomePathIsAscii = true;


### PR DESCRIPTION
Ref: https://github.com/stakira/OpenUtau/issues/1459

By using `Environment.SpecialFolder.UserProfile` instead of `Environment.SpecialFolder.Personal` to get user's home directory, this will fix the issue that OpenUtau's folder appearing in `/Users/<username>/Documents/Library` but not `/Users/<username>/Library`.

Since I don't have a matrix to fully test this on a variety of macOS devices, you might want to test it more comprehensively before merging or pushing it to release.