### PR TITLE
Fixed many expression issues and improved the properties panel

### DIFF
--- a/OpenUtau.Core/Commands/ExpCommands.cs
+++ b/OpenUtau.Core/Commands/ExpCommands.cs
@@ -21,10 +21,20 @@ namespace OpenUtau.Core {
     }
 
     public class SetNoteExpressionCommand : ExpCommand {
+        static readonly HashSet<string> needsPhonemizer = new HashSet<string> {
+            Format.Ustx.ALT, Format.Ustx.CLR, Format.Ustx.SHFT, Format.Ustx.VEL
+        };
+
         public readonly UProject project;
         public readonly UTrack track;
         public readonly float?[] newValue;
         public readonly float?[] oldValue;
+        public override ValidateOptions ValidateOptions
+            => new ValidateOptions {
+                SkipTiming = true,
+                Part = Part,
+                SkipPhonemizer = !needsPhonemizer.Contains(Key),
+            };
         public SetNoteExpressionCommand(UProject project, UTrack track, UVoicePart part, UNote note, string abbr, float?[] values) : base(part) {
             this.project = project;
             this.track = track;
@@ -39,11 +49,21 @@ namespace OpenUtau.Core {
     }
 
     public class SetNotesSameExpressionCommand : ExpCommand {
+        static readonly HashSet<string> needsPhonemizer = new HashSet<string> {
+            Format.Ustx.ALT, Format.Ustx.CLR, Format.Ustx.SHFT, Format.Ustx.VEL
+        };
+
         public readonly UProject project;
         public readonly UTrack track;
         public readonly UNote[] notes;
         public readonly float? newValue;
         public readonly float?[][] oldValue;
+        public override ValidateOptions ValidateOptions
+            => new ValidateOptions {
+                SkipTiming = true,
+                Part = Part,
+                SkipPhonemizer = !needsPhonemizer.Contains(Key),
+            };
         public SetNotesSameExpressionCommand(UProject project, UTrack track, UVoicePart part, IEnumerable<UNote> notes, string abbr, float? value) : base(part) {
             this.project = project;
             this.track = track;

--- a/OpenUtau.Core/Ustx/UNote.cs
+++ b/OpenUtau.Core/Ustx/UNote.cs
@@ -220,6 +220,8 @@ namespace OpenUtau.Core.Ustx {
                 return;
             }
 
+            phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr);
+
             int indexes = phonemeIndexes.LastOrDefault() + 1;
             for (int i = 0; i < indexes; i++) {
                 if (i == 0 || phonemeIndexes.Contains(i)) {
@@ -229,21 +231,14 @@ namespace OpenUtau.Core.Ustx {
                     } else {
                         value = values.Last();
                     }
-
                     if (value == null) {
-                        phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == i);
                         continue;
                     }
-                    var phonemeExp = phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == i);
-                    if (phonemeExp != null) {
-                        phonemeExp.descriptor = trackExp.descriptor;
-                        phonemeExp.value = (float)value;
-                    } else {
-                        phonemeExpressions.Add(new UExpression(trackExp.descriptor) {
-                            index = i,
-                            value = (float)value,
-                        });
-                    }
+
+                    phonemeExpressions.Add(new UExpression(trackExp.descriptor) {
+                        index = i,
+                        value = (float)value,
+                    });
                 }
             }
         }

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -190,7 +190,7 @@ namespace OpenUtau.Core.Ustx {
             }
             var note = Parent.Extends ?? Parent;
             if (value == null) {
-                note.phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == index);
+                note.phonemeExpressions.RemoveAll(exp => exp.descriptor?.abbr == abbr && exp.index == index || (exp.index != null && !note.phonemeIndexes.Contains((int)exp.index)));
             } else {
                 var phonemeExp = note.phonemeExpressions.FirstOrDefault(exp => exp.descriptor?.abbr == abbr && exp.index == index);
                 if (phonemeExp != null) {

--- a/OpenUtau/Controls/NotePropertyExpression.axaml
+++ b/OpenUtau/Controls/NotePropertyExpression.axaml
@@ -13,6 +13,7 @@
             Name="slider"/>
     <ComboBox Grid.Column="1" Grid.ColumnSpan="4" ItemsSource="{Binding Options}"
               SelectedIndex="{Binding SelectedOption}" MinWidth="120" IsVisible="{Binding IsOptions}" VerticalAlignment="Center" IsEnabled="{Binding IsNoteSelected}"
-              IsDropDownOpen="{Binding DropDownOpen, Mode=OneWayToSource}"/>
+              IsDropDownOpen="{Binding DropDownOpen, Mode=OneWayToSource}"
+              Name="comboBox"/>
   </Grid>
 </UserControl>

--- a/OpenUtau/Controls/NotePropertyExpression.axaml.cs
+++ b/OpenUtau/Controls/NotePropertyExpression.axaml.cs
@@ -14,48 +14,39 @@ namespace OpenUtau.App.Controls {
             slider.AddHandler(PointerPressedEvent, SliderPointerPressed, RoutingStrategies.Tunnel);
             slider.AddHandler(PointerReleasedEvent, SliderPointerReleased, RoutingStrategies.Tunnel);
             slider.AddHandler(PointerMovedEvent, SliderPointerMoved, RoutingStrategies.Tunnel);
+            comboBox.AddHandler(PointerPressedEvent, OnComboBoxPointerPressed, RoutingStrategies.Tunnel);
         }
 
+        // textbox
         private string textBoxValue = string.Empty;
         void OnTextBoxGotFocus(object? sender, GotFocusEventArgs args) {
             Log.Debug("Note property textbox got focus");
-            if (sender is TextBox text) {
-                textBoxValue = text.Text ?? string.Empty;
+            if (sender is TextBox textBox) {
+                textBoxValue = textBox.Text ?? string.Empty;
             }
         }
         void OnTextBoxLostFocus(object? sender, RoutedEventArgs args) {
             Log.Debug("Note property textbox lost focus");
             if (sender is TextBox textBox && textBoxValue != textBox.Text) {
-                if (DataContext is NotePropertyExpViewModel ViewModel) {
-                    DocManager.Inst.StartUndoGroup();
-                    NotePropertiesViewModel.PanelControlPressed = true;
-                    ViewModel.SetNumericalExpressions(textBox.Text);
-                    NotePropertiesViewModel.PanelControlPressed = false;
-                    DocManager.Inst.EndUndoGroup();
-                }
+                SetNumericalExpressions(textBox.Text);
             }
         }
 
+        // slider
         void SliderPointerPressed(object? sender, PointerPressedEventArgs args) {
-            Log.Debug("Slider pressed");
+            Log.Debug("Note property slider pressed");
             if (sender is Control control) {
                 var point = args.GetCurrentPoint(control);
                 if (point.Properties.IsLeftButtonPressed) {
                     DocManager.Inst.StartUndoGroup();
                     NotePropertiesViewModel.PanelControlPressed = true;
                 } else if (point.Properties.IsRightButtonPressed) {
-                    if (DataContext is NotePropertyExpViewModel ViewModel) {
-                        DocManager.Inst.StartUndoGroup();
-                        NotePropertiesViewModel.PanelControlPressed = true;
-                        ViewModel.SetNumericalExpressions(null);
-                        NotePropertiesViewModel.PanelControlPressed = false;
-                        DocManager.Inst.EndUndoGroup();
-                    }
+                    SetNumericalExpressions(null);
                 }
             }
         }
         void SliderPointerReleased(object? sender, PointerReleasedEventArgs args) {
-            Log.Debug("Slider released");
+            Log.Debug("Note property slider released");
             if (NotePropertiesViewModel.PanelControlPressed) {
                 if (sender is Slider slider && DataContext is NotePropertyExpViewModel ViewModel) {
                     ViewModel.SetNumericalExpressions((float)slider.Value);
@@ -67,6 +58,27 @@ namespace OpenUtau.App.Controls {
         void SliderPointerMoved(object? sender, PointerEventArgs args) {
             if (sender is Slider slider && DataContext is NotePropertyExpViewModel ViewModel) {
                 ViewModel.SetNumericalExpressions((float)slider.Value);
+            }
+        }
+
+        void OnComboBoxPointerPressed(object? sender, PointerPressedEventArgs args) {
+            Log.Debug("Note property textbox pressed");
+            if (sender is ComboBox comboBox) {
+                var point = args.GetCurrentPoint(comboBox);
+                if (point.Properties.IsRightButtonPressed) {
+                    SetNumericalExpressions(null);
+                    args.Handled = true;
+                }
+            }
+        }
+
+        private void SetNumericalExpressions(string? expression) {
+            if (DataContext is NotePropertyExpViewModel viewModel) {
+                DocManager.Inst.StartUndoGroup();
+                NotePropertiesViewModel.PanelControlPressed = true;
+                viewModel.SetNumericalExpressions(expression);
+                NotePropertiesViewModel.PanelControlPressed = false;
+                DocManager.Inst.EndUndoGroup();
             }
         }
     }

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -189,7 +189,7 @@ namespace OpenUtau.App.ViewModels {
 
                     foreach (NotePropertyExpViewModel exp in Expressions) {
                         exp.IsNoteSelected = true;
-                        var phonemeExpression = note.phonemeExpressions.FirstOrDefault(e => e.abbr == exp.abbr);
+                        var phonemeExpression = note.phonemeExpressions.FirstOrDefault(e => e.abbr == exp.abbr && e.index == 0);
                         if (phonemeExpression != null) {
                             if (exp.IsNumerical) {
                                 exp.Value = phonemeExpression.value;
@@ -470,12 +470,18 @@ namespace OpenUtau.App.ViewModels {
         public void SetNumericalExpressionsChanges(string abbr, float? value) {
             if (AllowNoteEdit && Part != null && selectedNotes.Count > 0) {
                 var track = DocManager.Inst.Project.tracks[Part.trackNo];
+                if (track.TryGetExpression(DocManager.Inst.Project, abbr, out UExpression expression) && expression.value == value) {
+                    value = null;
+                }
                 DocManager.Inst.ExecuteCmd(new SetNotesSameExpressionCommand(DocManager.Inst.Project, track, Part, selectedNotes, abbr, value));
             }
         }
         public void SetOptionalExpressionsChanges(string abbr, int? value) {
             if (!NoteLoading && Part != null && selectedNotes.Count > 0) {
                 var track = DocManager.Inst.Project.tracks[Part.trackNo];
+                if (track.TryGetExpression(DocManager.Inst.Project, abbr, out UExpression expression) && expression.value == value) {
+                    value = null;
+                }
                 DocManager.Inst.StartUndoGroup();
                 DocManager.Inst.ExecuteCmd(new SetNotesSameExpressionCommand(DocManager.Inst.Project, track, Part, selectedNotes, abbr, value));
                 DocManager.Inst.EndUndoGroup();


### PR DESCRIPTION
## Development Background:
When lyrics or color changes reduced the number of phonemes in a note, old expressions that were no longer needed could cause bugs (e.g. Japanese phonemizer does not work well).
So I have improved that when right clicking on the UI to delete an expression, unwanted expressions with the same abbr in the same note are deleted.

## Feature Improvements:
- Remove expression when right-clicking combo box in properties panel - NotePropertyExpression.axaml/axaml.cs
- Changed to remove instead of set the value when the same value as the default value of track expression is selected in the properties panel - NotePropertiesViewModel

## Fixes:
- Fixed Phonemizer not running immediately after selecting voice color in properties panel - ExpCommand
- Fixed a case where the expression of the first phoneme of the selected note should be displayed, but the one of the second or later phonemes was displayed - NotePropertiesViewModel
- When right-clicking on the UI to delete an expression, modified to delete unwanted expressions with the same abbr in the same note - UNote, UPhoneme

## Note:
The default expressions for tracks have been implemented internally and are awaiting UI development.
In case the default values changed on a track-by-track in the future, I'm clearly separating the handling of cases where the default value is set and the value is null.