### PR TITLE
Clear caches for each phrase

### DIFF
--- a/OpenUtau.Core/Classic/ClassicRenderer.cs
+++ b/OpenUtau.Core/Classic/ClassicRenderer.cs
@@ -103,6 +103,7 @@ namespace OpenUtau.Classic {
                 string progressInfo = $"Track {trackNo + 1} : {phrase.wavtool} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
                 progress.Complete(0, progressInfo);
                 var wavPath = Path.Join(PathManager.Inst.CachePath, $"cat-{phrase.hash:x16}.wav");
+                phrase.AddCacheFile(wavPath);
                 var result = Layout(phrase);
                 if (File.Exists(wavPath)) {
                     try {

--- a/OpenUtau.Core/Classic/ResamplerItem.cs
+++ b/OpenUtau.Core/Classic/ResamplerItem.cs
@@ -5,12 +5,8 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using K4os.Hash.xxHash;
-using NAudio.Wave;
 using OpenUtau.Core;
 using OpenUtau.Core.Render;
-using OpenUtau.Core.Ustx;
-using static NetMQ.NetMQSelector;
-using static OpenUtau.Api.Phonemizer;
 
 namespace OpenUtau.Classic {
     public class ResamplerItem {
@@ -104,6 +100,9 @@ namespace OpenUtau.Classic {
             hash = Hash();
             outputFile = Path.Join(PathManager.Inst.CachePath,
                 $"res-{XXH32.DigestOf(Encoding.UTF8.GetBytes(phrase.singer.Id)):x8}-{hash:x16}.wav");
+
+            phrase.AddCacheFile(inputTemp);
+            phrase.AddCacheFile(outputFile);
         }
         public string GetFlagsString() {
             var builder = new StringBuilder();

--- a/OpenUtau.Core/Classic/WorldlineRenderer.cs
+++ b/OpenUtau.Core/Classic/WorldlineRenderer.cs
@@ -5,13 +5,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NAudio.Wave;
-using NumSharp;
 using OpenUtau.Core;
 using OpenUtau.Core.Format;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.SignalChain;
 using OpenUtau.Core.Ustx;
-using static NetMQ.NetMQSelector;
 
 namespace OpenUtau.Classic {
     public class WorldlineRenderer : IRenderer {
@@ -58,6 +56,7 @@ namespace OpenUtau.Classic {
             var task = Task.Run(() => {
                 var result = Layout(phrase);
                 var wavPath = Path.Join(PathManager.Inst.CachePath, $"wdl-{phrase.hash:x16}.wav");
+                phrase.AddCacheFile(wavPath);
                 string progressInfo = $"Track {trackNo + 1}: {this} {string.Join(" ", phrase.phones.Select(p => p.phoneme))}";
                 progress.Complete(0, progressInfo);
                 if (File.Exists(wavPath)) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerCache.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerCache.cs
@@ -16,6 +16,7 @@ namespace OpenUtau.Core.DiffSinger {
         private readonly string filename;
 
         public ulong Hash => hash;
+        public string Filename => filename;
 
         public DiffSingerCache(ulong identifier, ICollection<NamedOnnxValue> inputs) {
             using var stream = new MemoryStream();

--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -181,6 +181,7 @@ namespace OpenUtau.Core.DiffSinger
             if (linguisticOutputs is null) {
                 linguisticOutputs = linguisticModel.Run(linguisticInputs).Cast<NamedOnnxValue>().ToList();
                 linguisticCache?.Save(linguisticOutputs);
+                phrase.AddCacheFile(linguisticCache?.Filename);
             }
             Tensor<float> encoder_out = linguisticOutputs
                 .Where(o => o.Name == "encoder_out")

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -412,6 +412,7 @@ namespace OpenUtau.Core.DiffSinger {
                     acousticOutputs = acousticModel.Run(acousticInputs).Cast<NamedOnnxValue>().ToList();
                 }
                 acousticCache?.Save(acousticOutputs);
+                phrase.AddCacheFile(acousticCache?.Filename);
             }
             Tensor<float> mel = acousticOutputs.First().AsTensor<float>().Clone();
             //mel transforms for different mel base
@@ -451,6 +452,7 @@ namespace OpenUtau.Core.DiffSinger {
                     vocoderOutputs = vocoder.session.Run(vocoderInputs).Cast<NamedOnnxValue>().ToList();
                 }
                 vocoderCache?.Save(vocoderOutputs);
+                phrase.AddCacheFile(vocoderCache?.Filename);
             }
             Tensor<float> samplesTensor = vocoderOutputs.First().AsTensor<float>();
             //Check the size of samplesTensor

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -93,6 +93,7 @@ namespace OpenUtau.Core.DiffSinger {
                     }
                     var wavName = $"ds-{phrase.hash:x16}-depth{depth:f2}-steps{steps}.wav";
                     var wavPath = Path.Join(PathManager.Inst.CachePath, wavName);
+                    phrase.AddCacheFile(wavPath);
                     string progressInfo = $"Track {trackNo + 1}: {this} depth={depth:f2} steps={steps} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
                     if (File.Exists(wavPath)) {
                         try {

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -179,6 +179,7 @@ namespace OpenUtau.Core.DiffSinger{
             if (linguisticOutputs is null) {
                 linguisticOutputs = linguisticModel.Run(linguisticInputs).Cast<NamedOnnxValue>().ToList();
                 linguisticCache?.Save(linguisticOutputs);
+                phrase.AddCacheFile(linguisticCache?.Filename);
             }
             Tensor<float> encoder_out = linguisticOutputs
                 .Where(o => o.Name == "encoder_out")
@@ -262,6 +263,7 @@ namespace OpenUtau.Core.DiffSinger{
             if (varianceOutputs is null) {
                 varianceOutputs = varianceModel.Run(varianceInputs).Cast<NamedOnnxValue>().ToList();
                 varianceCache?.Save(varianceOutputs);
+                phrase.AddCacheFile(varianceCache?.Filename);
             }
             Tensor<float>? energy_pred = dsConfig.predict_energy
                 ? varianceOutputs

--- a/OpenUtau.Core/Enunu/EnunuRenderer.cs
+++ b/OpenUtau.Core/Enunu/EnunuRenderer.cs
@@ -89,6 +89,8 @@ namespace OpenUtau.Core.Enunu {
                     var enutmpPath = tmpPath + "_enutemp";
                     var wavPath = Path.Join(PathManager.Inst.CachePath, $"enu-{(phrase.hash+ hash):x16}.wav");
                     var voicebankNameHash = $"{(phrase.singer as EnunuSinger).voicebankNameHash:x16}";
+                    phrase.AddCacheFile(tmpPath);
+                    phrase.AddCacheFile(wavPath);
                     config = EnunuConfig.Load(phrase.singer);
                     if (port == null) {
                         port = EnunuUtils.SetPortNum();

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -190,6 +190,8 @@ namespace OpenUtau.Core.Render {
         internal readonly IRenderer renderer;
         public readonly string wavtool;
 
+        private List<string> cacheFiles = new List<string>();
+
         internal RenderPhrase(UProject project, UTrack track, UVoicePart part, IEnumerable<UPhoneme> phonemes) {
             var uNotes = new List<UNote> { phonemes.First().Parent };
             var endNote = phonemes.Last().Parent;
@@ -507,6 +509,28 @@ namespace OpenUtau.Core.Render {
                 phrasePhonemes.Clear();
             }
             return phrases;
+        }
+
+        public void AddCacheFile(string file) {
+            if (string.IsNullOrWhiteSpace(file)) return;
+            var filename = Path.GetFileNameWithoutExtension(file);
+            if (!cacheFiles.Contains(filename)) {
+                cacheFiles.Add(filename);
+            }
+        }
+
+        public void DeleteCacheFiles() {
+            foreach (var filename in cacheFiles) {
+                var files = Directory.EnumerateFiles(PathManager.Inst.CachePath, $"{filename}*");
+                foreach (var file in files) {
+                    try {
+                        File.Delete(file);
+                    } catch (Exception e) {
+                        Log.Error(e, $"Failed to delete file {file}");
+                    }
+                }
+            }
+            cacheFiles.Clear();
         }
     }
 }

--- a/OpenUtau.Core/Vogen/VogenRenderer.cs
+++ b/OpenUtau.Core/Vogen/VogenRenderer.cs
@@ -14,7 +14,6 @@ using OpenUtau.Core.SignalChain;
 using OpenUtau.Core.Ustx;
 using Serilog;
 using VocalShaper;
-using VocalShaper.World;
 
 namespace OpenUtau.Core.Vogen {
     public class VogenRenderer : IRenderer {
@@ -62,6 +61,7 @@ namespace OpenUtau.Core.Vogen {
                     }
                     var result = Layout(phrase);
                     var wavPath = Path.Join(PathManager.Inst.CachePath, $"vog-{phrase.hash:x16}.wav");
+                    phrase.AddCacheFile(wavPath);
                     string progressInfo = $"Track {trackNo + 1}: {this} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
                     progress.Complete(0, progressInfo);
                     if (File.Exists(wavPath)) {

--- a/OpenUtau.Core/Voicevox/VoicevoxRenderer.cs
+++ b/OpenUtau.Core/Voicevox/VoicevoxRenderer.cs
@@ -12,7 +12,6 @@ using OpenUtau.Core.Format;
 using OpenUtau.Core.Render;
 using OpenUtau.Core.Ustx;
 using Serilog;
-using static OpenUtau.Api.Phonemizer;
 
 /*
  * This source code is partially based on the VOICEVOX engine.
@@ -62,6 +61,7 @@ namespace OpenUtau.Core.Voicevox {
                     progress.Complete(0, progressInfo);
                     ulong hash = HashPhraseGroups(phrase);
                     var wavPath = Path.Join(PathManager.Inst.CachePath, $"vv-{phrase.hash:x16}-{hash:x16}.wav");
+                    phrase.AddCacheFile(wavPath);
                     var result = Layout(phrase);
                     if (!File.Exists(wavPath)) {
                         var singer = phrase.singer as VoicevoxSinger;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -3,6 +3,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <system:String x:Key="context.note.copy">Copy note</system:String>
+  <system:String x:Key="context.note.clearcache">Clear cache of phrase</system:String>
   <system:String x:Key="context.note.delete">Delete note</system:String>
   <system:String x:Key="context.note.pasteparameters">Select and paste parameters</system:String>
   <system:String x:Key="context.part.delete">Delete part</system:String>
@@ -447,6 +448,8 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>
   <system:String x:Key="prefs.utau">UTAU</system:String>
 
+  <system:String x:Key="progress.cachecleared">Cache cleared.</system:String>
+  <system:String x:Key="progress.clearingcache">Clearing cache...</system:String>
   <system:String x:Key="progress.loadingsingers">Loading Singers...</system:String>
   <system:String x:Key="progress.saved">Project saved. {0}</system:String>
   <system:String x:Key="progress.waitingrendering">Waiting Rendering</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -3,6 +3,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <system:String x:Key="context.note.copy">音符をコピー</system:String>
+  <system:String x:Key="context.note.clearcache">フレーズのキャッシュをクリア</system:String>
   <system:String x:Key="context.note.delete">音符を削除</system:String>
   <system:String x:Key="context.note.pasteparameters">パラメータを選択して貼り付け</system:String>
   <system:String x:Key="context.part.delete">パートを削除</system:String>
@@ -445,6 +446,8 @@
   <!--<system:String x:Key="prefs.rendering.wavtool">Wavtool</system:String>-->
   <!--<system:String x:Key="prefs.utau">UTAU</system:String>-->
 
+  <system:String x:Key="progress.cachecleared">キャッシュをクリアしました。</system:String>
+  <system:String x:Key="progress.clearingcache">キャッシュをクリア中...</system:String>
   <system:String x:Key="progress.loadingsingers">シンガー読み込み中...</system:String>
   <system:String x:Key="progress.saved">プロジェクトが保存されました。 {0}</system:String>
   <system:String x:Key="progress.waitingrendering">レンダリング中</system:String>

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -11,7 +11,6 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using DynamicData;
 using DynamicData.Binding;
-using NAudio.CoreAudioApi;
 using OpenUtau.App.Views;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -79,6 +79,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public double Progress { get; set; }
         public ReactiveCommand<NoteHitInfo, Unit> NoteDeleteCommand { get; set; }
         public ReactiveCommand<NoteHitInfo, Unit> NoteCopyCommand { get; set; }
+        public ReactiveCommand<NoteHitInfo, Unit> ClearPhraseCacheCommand { get; set; }
         public ReactiveCommand<PitchPointHitInfo, Unit> PitEaseInOutCommand { get; set; }
         public ReactiveCommand<PitchPointHitInfo, Unit> PitLinearCommand { get; set; }
         public ReactiveCommand<PitchPointHitInfo, Unit> PitEaseInCommand { get; set; }
@@ -97,6 +98,9 @@ namespace OpenUtau.App.ViewModels {
             });
             NoteCopyCommand = ReactiveCommand.Create<NoteHitInfo>(info => {
                 NotesViewModel.CopyNotes();
+            });
+            ClearPhraseCacheCommand = ReactiveCommand.Create<NoteHitInfo>(info => {
+                NotesViewModel.ClearPhraseCache();
             });
             PitEaseInOutCommand = ReactiveCommand.Create<PitchPointHitInfo>(info => {
                 if (NotesViewModel.Part == null) { return; }

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -652,9 +652,9 @@ namespace OpenUtau.App.Views {
 
         void OnMenuClearCache(object sender, RoutedEventArgs args) {
             Task.Run(() => {
-                DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, "Clearing cache..."));
+                DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ThemeManager.GetString("progress.clearingcache")));
                 PathManager.Inst.ClearCache();
-                DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, "Cache cleared."));
+                DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ThemeManager.GetString("progress.cachecleared")));
             });
         }
 

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -723,6 +723,10 @@ namespace OpenUtau.App.Views {
                             Header = ThemeManager.GetString("pianoroll.menu.notedefaults"),
                             Command = noteDefaultsCommand,
                         });
+                        ViewModel.NotesContextMenuItems.Add(new MenuItemViewModel() {
+                            Header = ThemeManager.GetString("context.note.clearcache"),
+                            Command = ViewModel.ClearPhraseCacheCommand,
+                        });
                         shouldOpenNotesContextMenu = true;
                         return;
                     }


### PR DESCRIPTION
## New Feature:
- Keep the cache filenames in each phrase and delete the files of phrases that contain the selected notes (partial filename match).
![image](https://github.com/user-attachments/assets/45734db5-c205-4c25-a165-6c2eb2b83509)

## Changes:
- Translate progress bar text

## Note:
I have tested with Classic Singer, but I am not fully aware of the specifications for the other renderers and may not be able to erase all caches.