### PR TITLE
Seperated steps for DiffSinger

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -284,7 +284,7 @@ namespace OpenUtau.Core.DiffSinger
             pitchInputs.Add(NamedOnnxValue.CreateFromTensor("retake",
                 new DenseTensor<bool>(retake, new int[] { retake.Length }, false)
                 .Reshape(new int[] { 1, retake.Length })));
-            var steps = Preferences.Default.DiffSingerSteps;
+            var steps = Preferences.Default.DiffSingerStepsPitch;
             if (dsConfig.useContinuousAcceleration) {
                 pitchInputs.Add(NamedOnnxValue.CreateFromTensor("steps",
                     new DenseTensor<long>(new long[] { steps }, new int[] { 1 }, false)));

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -235,7 +235,7 @@ namespace OpenUtau.Core.DiffSinger{
             varianceInputs.Add(NamedOnnxValue.CreateFromTensor("retake",
                 new DenseTensor<bool>(retake, new int[] { retake.Length }, false)
                 .Reshape(new int[] { 1, totalFrames, numVariances })));
-            var steps = Preferences.Default.DiffSingerSteps;
+            var steps = Preferences.Default.DiffSingerStepsVariance;
             if (dsConfig.useContinuousAcceleration) {
                 varianceInputs.Add(NamedOnnxValue.CreateFromTensor("steps",
                     new DenseTensor<long>(new long[] { steps }, new int[] { 1 }, false)));

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -145,7 +145,7 @@ namespace OpenUtau.Core.Util {
             public double DiffSingerDepth = 1.0;
             public int DiffSingerSteps = 20;
             public int DiffSingerStepsVariance = 20;
-            public int DiffSingerStepsPitch = 5;
+            public int DiffSingerStepsPitch = 10;
             public bool DiffSingerTensorCache = true;
             public bool SkipRenderingMutedTracks = false;
             public string Language = string.Empty;

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -144,6 +144,8 @@ namespace OpenUtau.Core.Util {
             public int OnnxGpu = 0;
             public double DiffSingerDepth = 1.0;
             public int DiffSingerSteps = 20;
+            public int DiffSingerStepsVariance = 20;
+            public int DiffSingerStepsPitch = 5;
             public bool DiffSingerTensorCache = true;
             public bool SkipRenderingMutedTracks = false;
             public string Language = string.Empty;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -424,7 +424,9 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.rendering">Rendering</system:String>
   <system:String x:Key="prefs.rendering.defaultrenderer">Default renderer (for classic voicebanks)</system:String>
   <system:String x:Key="prefs.rendering.diffsingerdepth">DiffSinger Render Depth</system:String>
-  <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps</system:String>
+  <system:String x:Key="prefs.rendering.diffsingersteps">DiffSinger Render Steps for Acoustic</system:String>
+  <system:String x:Key="prefs.rendering.diffsingerstepsvariance">DiffSinger Render Steps for Variance</system:String>
+  <system:String x:Key="prefs.rendering.diffsingerstepspitch">DiffSinger Render Steps for Pitch</system:String>
   <system:String x:Key="prefs.rendering.onnxgpu">GPU</system:String>
   <system:String x:Key="prefs.rendering.onnxrunner">Machine Learning Runner</system:String>
   <system:String x:Key="prefs.rendering.phasecomp">Phase Compensation</system:String>

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -40,8 +40,12 @@ namespace OpenUtau.App.ViewModels {
         public List<GpuInfo> OnnxGpuOptions { get; set; }
         [Reactive] public GpuInfo OnnxGpu { get; set; }
         public List<int> DiffSingerStepsOptions { get; } = new List<int> { 2, 5, 10, 20, 50, 100, 200, 500, 1000 };
+        public List<int> DiffSingerStepsVarianceOptions { get; } = new List<int> { 2, 5, 10, 20, 50, 100, 200, 500, 1000 };
+        public List<int> DiffSingerStepsPitchOptions { get; } = new List<int> { 2, 5, 10, 20, 50, 100, 200, 500, 1000 };
         [Reactive] public double DiffSingerDepth { get; set; }
         [Reactive] public int DiffSingerSteps { get; set; }
+        [Reactive] public int DiffSingerStepsVariance { get; set; }
+        [Reactive] public int DiffSingerStepsPitch { get; set; }
         [Reactive] public bool DiffSingerTensorCache { get; set; }
         [Reactive] public bool SkipRenderingMutedTracks { get; set; }
         [Reactive] public bool HighThreads { get; set; }
@@ -143,6 +147,8 @@ namespace OpenUtau.App.ViewModels {
             OnnxGpu = OnnxGpuOptions.FirstOrDefault(x => x.deviceId == Preferences.Default.OnnxGpu, OnnxGpuOptions[0]);
             DiffSingerDepth = Preferences.Default.DiffSingerDepth * 100;
             DiffSingerSteps = Preferences.Default.DiffSingerSteps;
+            DiffSingerStepsVariance = Preferences.Default.DiffSingerStepsVariance;
+            DiffSingerStepsPitch = Preferences.Default.DiffSingerStepsPitch;
             DiffSingerTensorCache = Preferences.Default.DiffSingerTensorCache;
             SkipRenderingMutedTracks = Preferences.Default.SkipRenderingMutedTracks;
             Theme = Preferences.Default.Theme;
@@ -331,6 +337,16 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.DiffSingerSteps)
                 .Subscribe(index => {
                     Preferences.Default.DiffSingerSteps = index;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.DiffSingerStepsVariance)
+                 .Subscribe(index => {
+                     Preferences.Default.DiffSingerStepsVariance = index;
+                     Preferences.Save();
+                 });
+            this.WhenAnyValue(vm => vm.DiffSingerStepsPitch)
+                .Subscribe(index => {
+                    Preferences.Default.DiffSingerStepsPitch = index;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.DiffSingerDepth)

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1123,6 +1123,21 @@ namespace OpenUtau.App.Views {
                 }
             }
 
+            if (args.Key == Key.R && args.KeyModifiers == KeyModifiers.Control) {
+                var project = DocManager.Inst.Project;
+                var part = notesVm.Part;
+                var selectedNotes = notesVm.Selection.ToList();
+
+                if (part != null && selectedNotes.Count > 0) {
+                    var docManager = DocManager.Inst;
+                    var batchEdit = new LoadRenderedPitch();
+                    batchEdit.Run(project, part, selectedNotes, docManager);
+                }
+
+                args.Handled = true;
+                return;
+            }
+
             // returns true if handled
             args.Handled = OnKeyExtendedHandler(args);
         }

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -1123,21 +1123,6 @@ namespace OpenUtau.App.Views {
                 }
             }
 
-            if (args.Key == Key.R && args.KeyModifiers == KeyModifiers.Control) {
-                var project = DocManager.Inst.Project;
-                var part = notesVm.Part;
-                var selectedNotes = notesVm.Selection.ToList();
-
-                if (part != null && selectedNotes.Count > 0) {
-                    var docManager = DocManager.Inst;
-                    var batchEdit = new LoadRenderedPitch();
-                    batchEdit.Run(project, part, selectedNotes, docManager);
-                }
-
-                args.Handled = true;
-                return;
-            }
-
             // returns true if handled
             args.Handled = OnKeyExtendedHandler(args);
         }

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -248,6 +248,10 @@
         <StackPanel>
           <TextBlock Text="{DynamicResource prefs.rendering.diffsingersteps}" Margin="0,10,0,0"/>
           <ComboBox HorizontalAlignment="Stretch"  ItemsSource="{Binding DiffSingerStepsOptions}" SelectedItem="{Binding DiffSingerSteps}"/>
+          <TextBlock Text="{DynamicResource prefs.rendering.diffsingerstepsvariance}" Margin="0,10,0,0"/>
+          <ComboBox HorizontalAlignment="Stretch"  ItemsSource="{Binding DiffSingerStepsVarianceOptions}" SelectedItem="{Binding DiffSingerStepsVariance}"/>
+          <TextBlock Text="{DynamicResource prefs.rendering.diffsingerstepspitch}" Margin="0,10,0,0"/>
+          <ComboBox HorizontalAlignment="Stretch"  ItemsSource="{Binding DiffSingerStepsPitchOptions}" SelectedItem="{Binding DiffSingerStepsPitch}"/>
           <Grid ColumnDefinitions="Auto,8,40,8,*" Margin="0,10,0,0">
               <TextBlock Grid.Column="0" Text="{DynamicResource prefs.rendering.diffsingerdepth}"/>
               <TextBlock Grid.Column="2">


### PR DESCRIPTION
Added ability to set different step values for DiffSinger models: **Acoustic**, **Variance** and **Pitch**
This will speed up the rendering and give more options.

According to my experience, only **5** steps are enough to render a good Pitch, while Variance parameters require a value around Acoustic, but can still be much lower if it doesn't contain complex parameters. So I suggest leaving it initially the same as Acoustic, so that the user can change it on their own if they see fit.

![image](https://github.com/user-attachments/assets/3d2f6cd8-e68c-4238-acf5-f4755d1857f7)