### PR TITLE
Zip file produced by voicebank publisher should use slash, not backslash

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankPublisher.cs
+++ b/OpenUtau.Core/Classic/VoicebankPublisher.cs
@@ -73,7 +73,7 @@ namespace OpenUtau.Classic {
                 {
                     index++;
                     progress.Invoke(100.0 * index / fileCount, $"Compressing {absFilePath}");
-                    string reFilePath = Path.GetRelativePath(location, absFilePath);
+                    string reFilePath = Path.GetRelativePath(location, absFilePath).Replace('\\', '/');
                     archive.CreateEntryFromFile(absFilePath, reFilePath);
                 }
             }


### PR DESCRIPTION
Before this PR, zip file produced by voicebank publisher on windows uses backslash `\`, which won't be recognized as path separator on Mac. Now it uses slash `/` on any platform.