### PR TITLE
Fixed Vibrato VolLink was not copied

### DIFF
--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -182,6 +182,30 @@ namespace OpenUtau.Core {
         };
     }
 
+    public class SetVibratoCommand : VibratoCommand {
+        readonly UNote note;
+        readonly UVibrato newVibrato;
+        readonly UVibrato oldVibrato;
+        public SetVibratoCommand(UVoicePart part, UNote note, UVibrato vibrato) : base(part, note) {
+            this.note = note;
+            newVibrato = vibrato;
+            oldVibrato = note.vibrato;
+        }
+        public override string ToString() {
+            return "Change vibrato";
+        }
+        public override void Execute() {
+            lock (Part) {
+                note.vibrato = newVibrato;
+            }
+        }
+        public override void Unexecute() {
+            lock (Part) {
+                note.vibrato = oldVibrato;
+            }
+        }
+    }
+
     public class VibratoLengthCommand : VibratoCommand {
         readonly UNote note;
         readonly float newLength;

--- a/OpenUtau.Core/Commands/NoteCommands.cs
+++ b/OpenUtau.Core/Commands/NoteCommands.cs
@@ -188,7 +188,7 @@ namespace OpenUtau.Core {
         readonly UVibrato oldVibrato;
         public SetVibratoCommand(UVoicePart part, UNote note, UVibrato vibrato) : base(part, note) {
             this.note = note;
-            newVibrato = vibrato;
+            newVibrato = vibrato.Clone();
             oldVibrato = note.vibrato;
         }
         public override string ToString() {

--- a/OpenUtau.Core/Editing/ResetBatchEdits.cs
+++ b/OpenUtau.Core/Editing/ResetBatchEdits.cs
@@ -178,14 +178,9 @@ namespace OpenUtau.Core.Editing {
         public void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager) {
             var notes = selectedNotes.Count > 0 ? selectedNotes : part.notes.ToList();
             docManager.StartUndoGroup(true);
+            var vibrato = new UVibrato();
             foreach (var note in notes) {
-                docManager.ExecuteCmd(new VibratoPeriodCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoPeriod));
-                docManager.ExecuteCmd(new VibratoDepthCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoDepth));
-                docManager.ExecuteCmd(new VibratoFadeInCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoIn));
-                docManager.ExecuteCmd(new VibratoFadeOutCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoOut));
-                docManager.ExecuteCmd(new VibratoShiftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoShift));
-                docManager.ExecuteCmd(new VibratoDriftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoDrift));
-                docManager.ExecuteCmd(new VibratoVolumeLinkCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoVolLink));
+                docManager.ExecuteCmd(new SetVibratoCommand(part, note, vibrato));
                 if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) {
                     docManager.ExecuteCmd(new VibratoLengthCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoLength));
                 } else {

--- a/OpenUtau.Core/Editing/ResetBatchEdits.cs
+++ b/OpenUtau.Core/Editing/ResetBatchEdits.cs
@@ -185,6 +185,7 @@ namespace OpenUtau.Core.Editing {
                 docManager.ExecuteCmd(new VibratoFadeOutCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoOut));
                 docManager.ExecuteCmd(new VibratoShiftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoShift));
                 docManager.ExecuteCmd(new VibratoDriftCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoDrift));
+                docManager.ExecuteCmd(new VibratoVolumeLinkCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoVolLink));
                 if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) {
                     docManager.ExecuteCmd(new VibratoLengthCommand(part, note, NotePresets.Default.DefaultVibrato.VibratoLength));
                 } else {

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -237,36 +237,45 @@ namespace OpenUtau.App.ViewModels {
                 } else if (cmd is MoveNoteCommand) {
                     Tone = MusicMath.GetToneName(note.tone);
                     this.RaisePropertyChanged(nameof(Tone));
-                } else if (cmd is VibratoLengthCommand) {
-                    if (note.vibrato.length > 0) {
-                        VibratoEnable = true;
-                    } else {
-                        VibratoEnable = false;
+                } else if (cmd is VibratoCommand) {
+                    if (cmd is VibratoLengthCommand || cmd is SetVibratoCommand) {
+                        if (note.vibrato.length > 0) {
+                            VibratoEnable = true;
+                        } else {
+                            VibratoEnable = false;
+                        }
+                        VibratoLength = note.vibrato.length;
+                        this.RaisePropertyChanged(nameof(VibratoEnable));
+                        this.RaisePropertyChanged(nameof(VibratoLength));
                     }
-                    VibratoLength = note.vibrato.length;
-                    this.RaisePropertyChanged(nameof(VibratoEnable));
-                    this.RaisePropertyChanged(nameof(VibratoLength));
-                } else if (cmd is VibratoFadeInCommand) {
-                    VibratoIn = note.vibrato.@in;
-                    this.RaisePropertyChanged(nameof(VibratoIn));
-                } else if (cmd is VibratoFadeOutCommand) {
-                    VibratoOut = note.vibrato.@out;
-                    this.RaisePropertyChanged(nameof(VibratoOut));
-                } else if (cmd is VibratoDepthCommand) {
-                    VibratoDepth = note.vibrato.depth;
-                    this.RaisePropertyChanged(nameof(VibratoDepth));
-                } else if (cmd is VibratoPeriodCommand) {
-                    VibratoPeriod = note.vibrato.period;
-                    this.RaisePropertyChanged(nameof(VibratoPeriod));
-                } else if (cmd is VibratoShiftCommand) {
-                    VibratoShift = note.vibrato.shift;
-                    this.RaisePropertyChanged(nameof(VibratoShift));
-                } else if (cmd is VibratoDriftCommand) {
-                    VibratoDrift = note.vibrato.drift;
-                    this.RaisePropertyChanged(nameof(VibratoDrift));
-                } else if (cmd is VibratoVolumeLinkCommand) {
-                    VibratoVolLink = note.vibrato.volLink;
-                    this.RaisePropertyChanged(nameof(VibratoVolLink));
+                    if (cmd is VibratoFadeInCommand || cmd is SetVibratoCommand) {
+                        VibratoIn = note.vibrato.@in;
+                        this.RaisePropertyChanged(nameof(VibratoIn));
+                    }
+                    if (cmd is VibratoFadeOutCommand || cmd is SetVibratoCommand) {
+                        VibratoOut = note.vibrato.@out;
+                        this.RaisePropertyChanged(nameof(VibratoOut));
+                    }
+                    if (cmd is VibratoDepthCommand || cmd is SetVibratoCommand) {
+                        VibratoDepth = note.vibrato.depth;
+                        this.RaisePropertyChanged(nameof(VibratoDepth));
+                    }
+                    if (cmd is VibratoPeriodCommand || cmd is SetVibratoCommand) {
+                        VibratoPeriod = note.vibrato.period;
+                        this.RaisePropertyChanged(nameof(VibratoPeriod));
+                    }
+                    if (cmd is VibratoShiftCommand || cmd is SetVibratoCommand) {
+                        VibratoShift = note.vibrato.shift;
+                        this.RaisePropertyChanged(nameof(VibratoShift));
+                    }
+                    if (cmd is VibratoDriftCommand || cmd is SetVibratoCommand) {
+                        VibratoDrift = note.vibrato.drift;
+                        this.RaisePropertyChanged(nameof(VibratoDrift));
+                    }
+                    if (cmd is VibratoVolumeLinkCommand || cmd is SetVibratoCommand) {
+                        VibratoVolLink = note.vibrato.volLink;
+                        this.RaisePropertyChanged(nameof(VibratoVolLink));
+                    }
                 }
             } else if (cmd is ExpCommand) {
                 if (cmd is PitchExpCommand) {

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -883,13 +883,7 @@ namespace OpenUtau.App.ViewModels {
                                     break;
                                 case 1:
                                     if (vm.Params[i].IsSelected) {
-                                        DocManager.Inst.ExecuteCmd(new VibratoLengthCommand(Part, note, copyNote.vibrato.length));
-                                        DocManager.Inst.ExecuteCmd(new VibratoDepthCommand(Part, note, copyNote.vibrato.depth));
-                                        DocManager.Inst.ExecuteCmd(new VibratoPeriodCommand(Part, note, copyNote.vibrato.period));
-                                        DocManager.Inst.ExecuteCmd(new VibratoFadeInCommand(Part, note, copyNote.vibrato.@in));
-                                        DocManager.Inst.ExecuteCmd(new VibratoFadeOutCommand(Part, note, copyNote.vibrato.@out));
-                                        DocManager.Inst.ExecuteCmd(new VibratoShiftCommand(Part, note, copyNote.vibrato.shift));
-                                        DocManager.Inst.ExecuteCmd(new VibratoDriftCommand(Part, note, copyNote.vibrato.drift));
+                                        DocManager.Inst.ExecuteCmd(new SetVibratoCommand(Part, note, copyNote.vibrato));
                                     }
                                     break;
                                 default:

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -878,7 +878,7 @@ namespace OpenUtau.App.ViewModels {
                             switch (i) {
                                 case 0:
                                     if (vm.Params[i].IsSelected) {
-                                        DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, copyNote.pitch.Clone()));
+                                        DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, note, copyNote.pitch));
                                     }
                                     break;
                                 case 1:


### PR DESCRIPTION
## Fixes:
- Fixed vibrato volume link not being copied when PasteSelectedParams.
- Fixed volume link not being reset by "Reset vibratos" in batch edit.


## Improvments:
- By merging the commands, PasteSelectedParams processing has been sped up.