### PR TITLE
Add pkg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,14 +138,14 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: OpenUtau-osx-${{ matrix.arch.name }}.dmg
-          path: OpenUtau-osx-${{ matrix.arch.name }}.dmg
+          name: OpenUtau-${{ matrix.arch.name }}.dmg
+          path: OpenUtau-${{ matrix.arch.name }}.dmg
         if: ${{ !inputs.release && matrix.arch.os == 'osx' }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: OpenUtau-osx-${{ matrix.arch.name }}.pkg
-          path: OpenUtau-osx-${{ matrix.arch.name }}.pkg
+          name: OpenUtau-${{ matrix.arch.name }}.pkg
+          path: OpenUtau-${{ matrix.arch.name }}.pkg
         if: ${{ !inputs.release && matrix.arch.os == 'osx' }}
 
       # Appcast

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,10 +123,6 @@ jobs:
             OpenUtau-${{ matrix.arch.name }}.pkg
         if: ${{ matrix.arch.os == 'osx' }}
 
-        # 署名（必要なら）
-        # codesign -s "Developer ID Installer: Your Name" --timestamp OpenUtau-${{ matrix.arch.name }}.pkg
-
-
       # Upload Artifacts
       - uses: actions/upload-artifact@v4
         with:
@@ -146,6 +142,12 @@ jobs:
           path: OpenUtau-osx-${{ matrix.arch.name }}.dmg
         if: ${{ !inputs.release && matrix.arch.os == 'osx' }}
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: OpenUtau-osx-${{ matrix.arch.name }}.pkg
+          path: OpenUtau-osx-${{ matrix.arch.name }}.pkg
+        if: ${{ !inputs.release && matrix.arch.os == 'osx' }}
+
       # Appcast
       - name: Appcast Windows
         shell: cmd
@@ -157,6 +159,7 @@ jobs:
       - name: Appcast MacOS
         run: |
           python appcast.py -v=${{ inputs.version }} -o=macos -r=${{ matrix.arch.name }} -f=OpenUtau-${{ matrix.arch.name }}.dmg
+          python appcast.py -v=${{ inputs.version }} -o=macos -r=${{ matrix.arch.name }}-installer  -f=OpenUtau-${{ matrix.arch.name }}.pkg
         if: ${{ inputs.release && matrix.arch.os == 'osx' }}
 
       - name: Appcast Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,23 @@ jobs:
           codesign -fvs - OpenUtau-${{ matrix.arch.name }}.dmg
         if: ${{ matrix.arch.os == 'osx' }}
 
+      # Create Pkg
+      - name: Create Pkg
+        run: |
+          mkdir -p pkgroot/Applications
+          cp -R bin/${{ matrix.arch.name }}/publish/OpenUtau.app pkgroot/Applications/
+
+          pkgbuild \
+            --root pkgroot \
+            --identifier com.openutau.installer \
+            --install-location / \
+            OpenUtau-${{ matrix.arch.name }}.pkg
+        if: ${{ matrix.arch.os == 'osx' }}
+
+        # 署名（必要なら）
+        # codesign -s "Developer ID Installer: Your Name" --timestamp OpenUtau-${{ matrix.arch.name }}.pkg
+
+
       # Upload Artifacts
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Supports installation by package and avoids the procedure of running commands from the terminal.

It is no longer necessary to enter the following commands.
```
xattr -rc /Applications/OpenUtau.app
```

I think there is a reason why it was provided in a dmg file, so I have kept the instructions for creating the dmg file.