### PR TITLE
Don't use `/usr/bin`, just use `fc-match`

### DIFF
--- a/OpenUtau/Program.cs
+++ b/OpenUtau/Program.cs
@@ -54,7 +54,7 @@ namespace OpenUtau.App {
         public static AppBuilder BuildAvaloniaApp() {
             FontManagerOptions fontOptions = new();
             if (OS.IsLinux()) {
-                using Process process = Process.Start(new ProcessStartInfo("/usr/bin/fc-match")
+                using Process process = Process.Start(new ProcessStartInfo("fc-match")
                 {
                     ArgumentList = { "-f", "%{family}" },
                     RedirectStandardOutput = true


### PR DESCRIPTION
We can just use the basename, `fc-match`. This should search `$PATH` and is therefore more robust than a hard-coded path. This way distros won't need to patch things like [this](https://github.com/NixOS/nixpkgs/blob/5630cf13cceac06cefe9fc607e8dfa8fb342dde3/pkgs/applications/audio/openutau/default.nix#L51-L53) to prevent null reference exceptions when fontconfig is installed but `fc-match` is not on the hard-coded path.