### PR TITLE
Use available screen if no primary screen is set

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -721,10 +721,11 @@ namespace OpenUtau.App.Views {
         void OnMenuLayoutHSplit13(object sender, RoutedEventArgs args) => LayoutSplit(1.0 / 4, null);
 
         private void LayoutSplit(double? x, double? y) {
-            if (Screens.Primary == null) {
+            var mainScreen = Screens.Primary != null ? Screens.Primary : Screens.All[0];
+            if (mainScreen == null) {
                 return;
             }
-            var wa = Screens.Primary.WorkingArea;
+            var wa = mainScreen.WorkingArea;
             WindowState = WindowState.Normal;
             double titleBarHeight = 20;
             if (FrameSize != null) {

--- a/OpenUtau/Views/SplashWindow.axaml.cs
+++ b/OpenUtau/Views/SplashWindow.axaml.cs
@@ -22,7 +22,7 @@ namespace OpenUtau.App.Views {
         }
 
         private void SplashWindow_Opened(object? sender, EventArgs e) {
-            if (Screens.Primary == null) {
+            if (Screens.Primary == null && Screens.ScreenCount == 0) {
                 return;
             }
 


### PR DESCRIPTION
This should fix stuck splash screen on linux when using x11.