### PR TITLE
Fix unable to paste multiline lyrics into lyrics dialog

### DIFF
--- a/OpenUtau/Views/LyricsDialog.axaml
+++ b/OpenUtau/Views/LyricsDialog.axaml
@@ -13,7 +13,7 @@
   </Window.Styles>
   <Grid Margin="10,10,10,4" RowDefinitions="*,6,Auto,4,Auto">
     <TextBox Name="DIALOG_Box" Grid.Row="0" VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
-             AcceptsReturn="False" AcceptsTab="False" TextWrapping="Wrap" Height="NaN"
+             AcceptsReturn="True" AcceptsTab="False" TextWrapping="Wrap" Height="NaN"
              Text="{Binding Text}" Focusable="True"/>
     <TextBlock Grid.Row="2" Text="" Margin="0,2" HorizontalAlignment="Right">
       <TextBlock.Text>


### PR DESCRIPTION
After openutau updated avalonia, when users paste multiline lyrics into lyrics dialog, only the first line will go into the lyrics dialog, which is fixed in this PR

However, we won't be able to apply lyrics in our lyrics dialog by pressing Enter. 
- If `AcceptsReturn="True"`, we can't catch the "Enter" key event
- If `AcceptsReturn="False"`, we can't paste multiline lyrics