### PR TITLE
Hide DiffSinger Language Code in Phoneme Canvas

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -30,7 +30,7 @@ namespace OpenUtau.Core.DiffSinger
 
         string defaultPause = "SP";
         protected virtual string GetDictionaryName()=>"dsdict.yaml";
-        protected virtual string GetLangCode()=>String.Empty;//The language code of the language the phonemizer is made for
+        public virtual string GetLangCode()=>String.Empty;//The language code of the language the phonemizer is made for
 
         private bool _singerLoaded;
 

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerARPAPlusEnglishPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerARPAPlusEnglishPhonemizer.cs
@@ -17,7 +17,7 @@ namespace OpenUtau.Core.DiffSinger {
     // plus other ds features
     {
         protected override string GetDictionaryName() => "dsdict-en.yaml";
-        protected override string GetLangCode() => "en";
+        public override string GetLangCode() => "en";
         protected override IG2p LoadBaseG2p() => new ArpabetPlusG2p();
         protected override string[] GetBaseG2pVowels() => new string[] {
             "aa", "ae", "ah", "ao", "aw", "ax", "ay", "eh", "er",

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerChinesePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerChinesePhonemizer.cs
@@ -6,7 +6,7 @@ namespace OpenUtau.Core.DiffSinger {
     [Phonemizer("DiffSinger Chinese Phonemizer", "DIFFS ZH", language: "ZH")]
     public class DiffSingerChinesePhonemizer : DiffSingerBasePhonemizer {
         protected override string GetDictionaryName()=>"dsdict-zh.yaml";
-        protected override string GetLangCode()=>"zh";
+        public override string GetLangCode()=>"zh";
         protected override string[] Romanize(IEnumerable<string> lyrics) {
             return BaseChinesePhonemizer.Romanize(lyrics);
         }

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerEnglishPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerEnglishPhonemizer.cs
@@ -7,7 +7,7 @@ namespace OpenUtau.Core.DiffSinger
     public class DiffSingerEnglishPhonemizer : DiffSingerG2pPhonemizer
     {
         protected override string GetDictionaryName()=>"dsdict-en.yaml";
-        protected override string GetLangCode()=>"en";
+        public override string GetLangCode()=>"en";
         protected override IG2p LoadBaseG2p() => new ArpabetG2p();
         protected override string[] GetBaseG2pVowels() => new string[] {
             "aa", "ae", "ah", "ao", "aw", "ay", "eh", "er", 

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerGermanPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerGermanPhonemizer.cs
@@ -7,7 +7,7 @@ namespace OpenUtau.Core.DiffSinger
     public class DiffSingerGermanPhonemizer : DiffSingerG2pPhonemizer
     {
         protected override string GetDictionaryName()=>"dsdict-de.yaml";
-        protected override string GetLangCode()=>"de";
+        public override string GetLangCode()=>"de";
         protected override IG2p LoadBaseG2p() => new GermanG2p();
         protected override string[] GetBaseG2pVowels() => new string[] {
             "aa", "ae", "ah", "ao", "aw", "ax", "ay", "ee", "eh", "er", "ex", "ih", "iy", "oe", "ohh", "ooh", "oy", "ue", "uh", "uw", "yy"

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerItalianPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerItalianPhonemizer.cs
@@ -5,7 +5,7 @@ namespace OpenUtau.Core.DiffSinger {
     [Phonemizer("DiffSinger Italian Phonemizer", "DIFFS IT", language: "IT")]
     public class DiffSingerItalianPhonemizer : DiffSingerG2pPhonemizer {
         protected override string GetDictionaryName() => "dsdict-it.yaml";
-        protected override string GetLangCode()=>"it";
+        public override string GetLangCode()=>"it";
         protected override IG2p LoadBaseG2p() => new ItalianG2p();
         protected override string[] GetBaseG2pVowels() => new string[] {
             "a", "a1", "e", "e1", "EE", "i", "i1", "o", "o1", "OO", "u", "u1"

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerJapanesePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerJapanesePhonemizer.cs
@@ -7,7 +7,7 @@ namespace OpenUtau.Core.DiffSinger {
     public class DiffSingerJapanesePhonemizer : DiffSingerBasePhonemizer {
         protected override string GetDictionaryName() => "dsdict-ja.yaml";
 
-        protected override string GetLangCode() => "ja";
+        public override string GetLangCode() => "ja";
 
         protected override string[] Romanize(IEnumerable<string> lyrics) {
             var lyricsArray = lyrics.ToArray();

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerJyutpingPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerJyutpingPhonemizer.cs
@@ -7,7 +7,7 @@ namespace OpenUtau.Core.DiffSinger {
     [Phonemizer("DiffSinger Jyutping Phonemizer", "DIFFS ZH-YUE", language: "ZH-YUE")]
     public class DiffSingerJyutpingPhonemizer : DiffSingerBasePhonemizer {
         protected override string GetDictionaryName() => "dsdict-zh-yue.yaml";
-        protected override string GetLangCode() => "yue";
+        public override string GetLangCode() => "yue";
         protected override string[] Romanize(IEnumerable<string> lyrics) {
             return Pinyin.Jyutping.Instance.HanziToPinyin(lyrics.ToList(), CanTone.Style.NORMAL, Pinyin.Error.Default).Select(res => res.pinyin).ToArray();
         }

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerKoreanG2PPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerKoreanG2PPhonemizer.cs
@@ -7,7 +7,7 @@ namespace OpenUtau.Core.DiffSinger
     public class DiffSingerKoreanG2PPhonemizer : DiffSingerG2pPhonemizer
     {
         protected override string GetDictionaryName() => "dsdict-ko.yaml";
-        protected override string GetLangCode()=>"ko";
+        public override string GetLangCode()=>"ko";
         protected override IG2p LoadBaseG2p() => new KoreanG2p();
         protected override string[] GetBaseG2pVowels() => new string[] {
             "a", "e", "eo", "eu", "i", "o", "u", "w", "y"

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerKoreanPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerKoreanPhonemizer.cs
@@ -9,7 +9,7 @@ namespace OpenUtau.Core.DiffSinger
     public class DiffSingerKoreanPhonemizer : DiffSingerBasePhonemizer
     {
         protected override string GetDictionaryName()=>"dsdict-ko.yaml";
-        protected override string GetLangCode()=>"ko";
+        public override string GetLangCode()=>"ko";
 
         public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             if (groups.Length == 0) {

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerPortuguesePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerPortuguesePhonemizer.cs
@@ -7,7 +7,7 @@ namespace OpenUtau.Core.DiffSinger
     public class DiffSingerPortuguesePhonemizer : DiffSingerG2pPhonemizer
     {
         protected override string GetDictionaryName()=>"dsdict-pt.yaml";
-        protected override string GetLangCode()=>"pt";
+        public override string GetLangCode()=>"pt";
         protected override IG2p LoadBaseG2p() => new PortugueseG2p();
         protected override string[] GetBaseG2pVowels() => new string[] {
             "E", "O", "a", "a~", "e", "e~", "i", "i~", "o", "o~", "u", "u~"

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRussianPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRussianPhonemizer.cs
@@ -7,7 +7,7 @@ namespace OpenUtau.Core.DiffSinger
     public class DiffSingerRussianPhonemizer : DiffSingerG2pPhonemizer
     {
         protected override string GetDictionaryName()=>"dsdict-ru.yaml";
-        protected override string GetLangCode()=>"ru";
+        public override string GetLangCode()=>"ru";
         protected override IG2p LoadBaseG2p() => new RussianG2p();
         protected override string[] GetBaseG2pVowels() => new string[] {
             "a", "aa", "ay", "ee", "i", "ii", "ja", "je", "jo", "ju", "oo",

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerSpanishPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerSpanishPhonemizer.cs
@@ -7,7 +7,7 @@ namespace OpenUtau.Core.DiffSinger
     public class DiffSingerSpanishPhonemizer : DiffSingerG2pPhonemizer
     {
         protected override string GetDictionaryName()=>"dsdict-es.yaml";
-        protected override string GetLangCode()=>"es";
+        public override string GetLangCode()=>"es";
         protected override IG2p LoadBaseG2p() => new SpanishG2p();
         protected override string[] GetBaseG2pVowels() => new string[] {
             "a", "e", "i", "o", "u"

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -145,6 +145,7 @@ namespace OpenUtau.Core.Util {
             public double DiffSingerDepth = 1.0;
             public int DiffSingerSteps = 20;
             public bool DiffSingerTensorCache = true;
+            public bool DiffSingerLangCodeHide = false;
             public bool SkipRenderingMutedTracks = false;
             public string Language = string.Empty;
             public string? SortingOrder = null;

--- a/OpenUtau/Controls/PhonemeCanvas.cs
+++ b/OpenUtau/Controls/PhonemeCanvas.cs
@@ -3,11 +3,10 @@ using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Core;
-using OpenUtau.Core.DiffSinger;
 using OpenUtau.Core.Ustx;
-using OpenUtau.Core.Util;
 using ReactiveUI;
 
 namespace OpenUtau.App.Controls {
@@ -100,13 +99,7 @@ namespace OpenUtau.App.Controls {
             if (Part == null || !ShowPhoneme) {
                 return;
             }
-            //DiffSinger specific phoneme trunctation for QOL improvement
-            int trackNo = Part.trackNo;
-            var track = DocManager.Inst.Project.tracks[trackNo];
-            string langCode = "";
-            if (track.Phonemizer is DiffSingerBasePhonemizer basePhonemizer) {
-                langCode = basePhonemizer.GetLangCode();
-            }
+            string langCode = PhonemeUIRender.getLangCode(Part);
             var viewModel = ((PianoRollViewModel?)DataContext)?.NotesViewModel;
             if (viewModel == null) {
                 return;
@@ -170,25 +163,14 @@ namespace OpenUtau.App.Controls {
                 // FIXME: Changing code below may break `HitTestAlias`.
                 if (viewModel.TickWidth > ViewConstants.PianoRollTickWidthShowDetails) {
                     string phonemeText = !string.IsNullOrEmpty(phoneme.phonemeMapped) ? phoneme.phonemeMapped : phoneme.phoneme;
-                    if (Preferences.Default.DiffSingerLangCodeHide && !string.IsNullOrEmpty(langCode) && phonemeText.StartsWith(langCode)) {
-                        phonemeText = phonemeText.Substring(langCode.Length + 1);
-                    }
                     if (!string.IsNullOrEmpty(phonemeText)) {
-                        var bold = phoneme.rawPhoneme != phoneme.phoneme;
-                        var textLayout = TextLayoutCache.Get(phonemeText, ThemeManager.ForegroundBrush!, 12, bold);
-                        if (x < lastTextEndX) {
-                            raiseText = !raiseText;
-                        } else {
-                            raiseText = false;
-                        }
-                        double textY = raiseText ? 2 : 18;
-                        var size = new Size(textLayout.Width + 4, textLayout.Height - 2);
-                        using (var state = context.PushTransform(Matrix.CreateTranslation(x + 2, textY))) {
+                        (double textX, double textY, Size size, TextLayout textLayout) 
+                        = PhonemeUIRender.AliasPosition(viewModel, phoneme, langCode, ref lastTextEndX, ref raiseText);
+                        using (var state = context.PushTransform(Matrix.CreateTranslation(textX + 2, textY))) {
                             var pen = mouseoverPhoneme == phoneme ? ThemeManager.AccentPen1Thickness2 : ThemeManager.NeutralAccentPenSemi;
                             context.DrawRectangle(ThemeManager.BackgroundBrush, pen, new Rect(new Point(-2, 1.5), size), 4, 4);
                             textLayout.Draw(context, new Point());
                         }
-                        lastTextEndX = x + size.Width;
                     }
                 }
             }

--- a/OpenUtau/Controls/PhonemeCanvas.cs
+++ b/OpenUtau/Controls/PhonemeCanvas.cs
@@ -104,9 +104,7 @@ namespace OpenUtau.App.Controls {
             int trackNo = Part.trackNo;
             var track = DocManager.Inst.Project.tracks[trackNo];
             string langCode = "";
-            if (track.Phonemizer is DiffSingerG2pPhonemizer g2pPhonemizer) {
-                langCode = g2pPhonemizer.GetLangCode();
-            } else if (track.Phonemizer is DiffSingerBasePhonemizer basePhonemizer) {
+            if (track.Phonemizer is DiffSingerBasePhonemizer basePhonemizer) {
                 langCode = basePhonemizer.GetLangCode();
             }
             var viewModel = ((PianoRollViewModel?)DataContext)?.NotesViewModel;

--- a/OpenUtau/Controls/PhonemeUIRender.cs
+++ b/OpenUtau/Controls/PhonemeUIRender.cs
@@ -1,0 +1,52 @@
+using Avalonia;
+using Avalonia.Media.TextFormatting;
+using OpenUtau.App.ViewModels;
+using OpenUtau.Core;
+using OpenUtau.Core.DiffSinger;
+using OpenUtau.Core.Ustx;
+using OpenUtau.Core.Util;
+
+namespace OpenUtau.App.Controls {
+    static class PhonemeUIRender{
+        public static string getLangCode(UVoicePart part){
+            int trackNo = part.trackNo;
+            var track = DocManager.Inst.Project.tracks[trackNo];
+            string langCode = "";
+            if (track.Phonemizer is DiffSingerG2pPhonemizer g2pPhonemizer) {
+                langCode = g2pPhonemizer.GetLangCode();
+            } else if (track.Phonemizer is DiffSingerBasePhonemizer basePhonemizer) {
+                langCode = basePhonemizer.GetLangCode();
+            }
+            return langCode;
+        }
+        //Calculates the position of a phoneme alias on a piano roll view, 
+        //considering factors like tick width, phoneme text, and text layout. 
+        //It returns the x-coordinate and text y-coordinate of the alias
+        public static (double textX, double textY, Size size, TextLayout textLayout) 
+            AliasPosition(NotesViewModel viewModel, UPhoneme phoneme, string? langCode, ref double lastTextEndX, ref bool raiseText){
+
+            string phonemeText = !string.IsNullOrEmpty(phoneme.phonemeMapped) ? phoneme.phonemeMapped : phoneme.phoneme;
+            if (Preferences.Default.DiffSingerLangCodeHide && !string.IsNullOrEmpty(langCode) && phonemeText.StartsWith(langCode+"/")) {
+                phonemeText = phonemeText.Substring(langCode.Length + 1);
+            }
+            var x = viewModel.TickToneToPoint(phoneme.position, 0).X;
+            var bold = phoneme.phoneme != phoneme.rawPhoneme;
+            var textLayout = TextLayoutCache.Get(phonemeText, ThemeManager.ForegroundBrush!, 12, bold);
+            if (x < lastTextEndX) {
+                raiseText = !raiseText;
+            } else {
+                raiseText = false;
+            }
+            double textY = raiseText ? 2 : 18;
+            var size = new Size(textLayout.Width + 4, textLayout.Height - 2);
+            //var rect = new Rect(new Point(x - 2, textY + 1.5), size);
+            /*if (rect.Contains(mousePos)) {
+                result.phoneme = phoneme;
+                result.hit = true;
+                return result;
+            }*/
+            lastTextEndX = x + size.Width;
+            return (x, textY, size, textLayout);
+        }
+    }
+}

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -388,6 +388,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.appearance.theme.dark">Dark</system:String>
   <system:String x:Key="prefs.appearance.theme.light">Light</system:String>
   <system:String x:Key="prefs.appearance.trackcolor">Use track color in UI</system:String>
+  <system:String x:Key="prefs.appearance.diffsingerlangcodehide">Hide language prefix from phoneme editor</system:String>
   <system:String x:Key="prefs.cache">Cache</system:String>
   <system:String x:Key="prefs.cache.clearonquit">Clear cache on quit</system:String>
   <system:String x:Key="prefs.cache.diffsingertensorcache">DiffSinger Tensor Cache</system:String>

--- a/OpenUtau/ViewModels/NotesViewModelHitTest.cs
+++ b/OpenUtau/ViewModels/NotesViewModelHitTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia;
+using Avalonia.Media.TextFormatting;
 using OpenUtau.App.Controls;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
@@ -348,6 +349,7 @@ namespace OpenUtau.App.ViewModels {
             bool raiseText = false;
             double leftTick = viewModel.TickOffset - 480;
             double rightTick = leftTick + viewModel.ViewportTicks + 480;
+            string langCode = PhonemeUIRender.getLangCode(viewModel.Part);
             // TODO: Rewrite with a faster searching algorithm, such as binary search.
             foreach (var phoneme in viewModel.Part.phonemes) {
                 double leftBound = viewModel.Project.timeAxis.MsPosToTickPos(phoneme.PositionMs - phoneme.preutter) - viewModel.Part.position;
@@ -367,23 +369,14 @@ namespace OpenUtau.App.ViewModels {
                 if (string.IsNullOrEmpty(phonemeText)) {
                     continue;
                 }
-                var x = viewModel.TickToneToPoint(phoneme.position, 0).X;
-                var bold = phoneme.phoneme != phoneme.rawPhoneme;
-                var textLayout = TextLayoutCache.Get(phonemeText, ThemeManager.ForegroundBrush!, 12, bold);
-                if (x < lastTextEndX) {
-                    raiseText = !raiseText;
-                } else {
-                    raiseText = false;
-                }
-                double textY = raiseText ? 2 : 18;
-                var size = new Size(textLayout.Width + 4, textLayout.Height - 2);
-                var rect = new Rect(new Point(x - 2, textY + 1.5), size);
+                (double textX, double textY, Size size, TextLayout textLayout) 
+                    = PhonemeUIRender.AliasPosition(viewModel, phoneme, langCode, ref lastTextEndX, ref raiseText);
+                var rect = new Rect(new Point(textX - 2, textY + 1.5), size);
                 if (rect.Contains(mousePos)) {
                     result.phoneme = phoneme;
                     result.hit = true;
                     return result;
                 }
-                lastTextEndX = x + size.Width;
             }
             return result;
         }

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -43,6 +43,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public double DiffSingerDepth { get; set; }
         [Reactive] public int DiffSingerSteps { get; set; }
         [Reactive] public bool DiffSingerTensorCache { get; set; }
+        [Reactive] public bool DiffSingerLangCodeHide { get; set; }
         [Reactive] public bool SkipRenderingMutedTracks { get; set; }
         [Reactive] public bool HighThreads { get; set; }
         [Reactive] public int Theme { get; set; }
@@ -144,6 +145,7 @@ namespace OpenUtau.App.ViewModels {
             DiffSingerDepth = Preferences.Default.DiffSingerDepth * 100;
             DiffSingerSteps = Preferences.Default.DiffSingerSteps;
             DiffSingerTensorCache = Preferences.Default.DiffSingerTensorCache;
+            DiffSingerLangCodeHide = Preferences.Default.DiffSingerLangCodeHide;
             SkipRenderingMutedTracks = Preferences.Default.SkipRenderingMutedTracks;
             Theme = Preferences.Default.Theme;
             PenPlusDefault = Preferences.Default.PenPlusDefault;
@@ -341,6 +343,11 @@ namespace OpenUtau.App.ViewModels {
             this.WhenAnyValue(vm => vm.DiffSingerTensorCache)
                 .Subscribe(useCache => {
                     Preferences.Default.DiffSingerTensorCache = useCache;
+                    Preferences.Save();
+                });
+            this.WhenAnyValue(vm => vm.DiffSingerLangCodeHide)
+                .Subscribe(useCache => {
+                    Preferences.Default.DiffSingerLangCodeHide = useCache;
                     Preferences.Save();
                 });
             this.WhenAnyValue(vm => vm.SkipRenderingMutedTracks)

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -264,6 +264,10 @@
             <TextBlock Text="{DynamicResource prefs.cache.diffsingertensorcache}" HorizontalAlignment="Left" />
             <ToggleSwitch IsChecked="{Binding DiffSingerTensorCache}" />
           </Grid>
+          <Grid Margin="0,5,0,0">
+            <TextBlock Text="{DynamicResource prefs.appearance.diffsingerlangcodehide}" HorizontalAlignment="Left" />
+            <ToggleSwitch IsChecked="{Binding DiffSingerLangCodeHide}" />
+          </Grid>
         </StackPanel>
 
         <!-- Advanced -->


### PR DESCRIPTION
This pull request will add the functionality to optionally obfuscate the DiffSinger language prefix in the phoneme editor. I have personally found this to be an annoyance while using Multi-Dictionary DiffSinger models. DiffSinger recently adopted Multi-Dictionary as the standard for voice library creation, and as such this issue will be present in all DiffSinger models.

This pull request does the following:
- Changes the `GetLangCode()` function in all applicable DiffSinger phonemizers (G2p & Base) to be a public method instead of private, so it can be accessed in `PhonemeCanvas.cs` . This may cause incompatibilities with existing plugin phonemizers, but will not cause any issues with the built-in experience.
- Adds a new toggle switch under the DiffSinger section of the preference window to turn this feature on or off. It is turned off by default.
- Removes the language prefix from the text of the phoneme in the for loop in `PhonemeCanvas.cs`, but only for the language prefix of the selected phonemizer (hence why I had to change `GetLangCode()` to be a public method.)

Example:
![ezgif-4c3070dbc39436](https://github.com/user-attachments/assets/d545c405-660e-4299-b83e-722f6b8f05ce)

