### PR TITLE
Fix textbox caret behavior

### DIFF
--- a/OpenUtau/Controls/LyricBox.axaml.cs
+++ b/OpenUtau/Controls/LyricBox.axaml.cs
@@ -27,6 +27,7 @@ namespace OpenUtau.App.Controls {
         }
 
         private void Box_LostFocus(object? sender, RoutedEventArgs e) {
+            box.CaretIndex = 0;
         }
 
         private void ListBox_KeyDown(object? sender, KeyEventArgs e) {
@@ -112,6 +113,14 @@ namespace OpenUtau.App.Controls {
                     listBox.Focus();
                     listBox.SelectedIndex = 0;
                     e.Handled = true;
+                    break;
+                case Key.Left:
+                    if (box.SelectionStart < box.SelectionEnd)
+                        box.SelectionEnd = box.SelectionStart;
+                    break;
+                case Key.Right:
+                    if (box.SelectionStart > box.SelectionEnd)
+                        box.SelectionEnd = box.SelectionStart;
                     break;
                 default:
                     break;


### PR DESCRIPTION
Fixed problems: 
According to current behavior box.SelectAll() method is called when the LyricBox appears. 
1) The selection may become invisible after modifying the text and changing caret position without saving it (clicking out of the LyricBox). 
2) Sometimes left and right arrow keys are not working properly (when there is selected text).

This problem more noticable when writing Turkish lyrics that are 1 to 8 letters long.


https://github.com/user-attachments/assets/0c2fb586-37d6-4bf1-a512-8969ff3f9488

