### PR TITLE
Support displaying real curves from DiffSinger variance predictor

### DIFF
--- a/OpenUtau.Core/Commands/ExpCommands.cs
+++ b/OpenUtau.Core/Commands/ExpCommands.cs
@@ -368,11 +368,11 @@ namespace OpenUtau.Core {
                 curve = new UCurve(descriptor);
                 Part.curves.Add(curve);
             }
-            getCurveXs(curve)!.Clear();
-            getCurveYs(curve)!.Clear();
+            getCurveXs(curve)?.Clear();
+            getCurveYs(curve)?.Clear();
             if (newXs != null && newYs != null) {
-                getCurveXs(curve)!.AddRange(newXs);
-                getCurveYs(curve)!.AddRange(newYs);
+                getCurveXs(curve)?.AddRange(newXs);
+                getCurveYs(curve)?.AddRange(newYs);
             }
         }
         public override void Unexecute() {
@@ -381,11 +381,11 @@ namespace OpenUtau.Core {
                 curve = new UCurve(descriptor);
                 Part.curves.Add(curve);
             }
-            getCurveXs(curve)!.Clear();
-            getCurveYs(curve)!.Clear();
+            getCurveXs(curve)?.Clear();
+            getCurveYs(curve)?.Clear();
             if (oldXs != null && oldYs != null) {
-                getCurveXs(curve)!.AddRange(oldXs);
-                getCurveYs(curve)!.AddRange(oldYs);
+                getCurveXs(curve)?.AddRange(oldXs);
+                getCurveYs(curve)?.AddRange(oldYs);
             }
         }
         private List<int>? getCurveXs(UCurve? curve) {

--- a/OpenUtau.Core/Commands/ExpCommands.cs
+++ b/OpenUtau.Core/Commands/ExpCommands.cs
@@ -350,14 +350,16 @@ namespace OpenUtau.Core {
         readonly int[] oldYs;
         readonly int[] newXs;
         readonly int[] newYs;
+        readonly bool setReal;
         public MergedSetCurveCommand(UProject project, UVoicePart part,
-            string abbr, int[] oldXs, int[] oldYs, int[] newXs, int[] newYs) : base(part) {
+            string abbr, int[] oldXs, int[] oldYs, int[] newXs, int[] newYs, bool setReal = false) : base(part) {
             this.project = project;
             this.abbr = abbr;
             this.oldXs = oldXs;
             this.oldYs = oldYs;
             this.newXs = newXs;
             this.newYs = newYs;
+            this.setReal = setReal;
         }
         public override string ToString() => "Edit Curve";
         public override void Execute() {
@@ -366,11 +368,11 @@ namespace OpenUtau.Core {
                 curve = new UCurve(descriptor);
                 Part.curves.Add(curve);
             }
-            curve.xs.Clear();
-            curve.ys.Clear();
+            getCurveXs(curve)!.Clear();
+            getCurveYs(curve)!.Clear();
             if (newXs != null && newYs != null) {
-                curve.xs.AddRange(newXs);
-                curve.ys.AddRange(newYs);
+                getCurveXs(curve)!.AddRange(newXs);
+                getCurveYs(curve)!.AddRange(newYs);
             }
         }
         public override void Unexecute() {
@@ -379,12 +381,18 @@ namespace OpenUtau.Core {
                 curve = new UCurve(descriptor);
                 Part.curves.Add(curve);
             }
-            curve.xs.Clear();
-            curve.ys.Clear();
+            getCurveXs(curve)!.Clear();
+            getCurveYs(curve)!.Clear();
             if (oldXs != null && oldYs != null) {
-                curve.xs.AddRange(oldXs);
-                curve.ys.AddRange(oldYs);
+                getCurveXs(curve)!.AddRange(oldXs);
+                getCurveYs(curve)!.AddRange(oldYs);
             }
+        }
+        private List<int>? getCurveXs(UCurve? curve) {
+            return setReal ? curve?.realXs : curve?.xs;
+        }
+        private List<int>? getCurveYs(UCurve? curve) {
+            return setReal ? curve?.realYs : curve?.ys;
         }
     }
 

--- a/OpenUtau.Core/Commands/ExpCommands.cs
+++ b/OpenUtau.Core/Commands/ExpCommands.cs
@@ -368,11 +368,11 @@ namespace OpenUtau.Core {
                 curve = new UCurve(descriptor);
                 Part.curves.Add(curve);
             }
-            getCurveXs(curve)?.Clear();
-            getCurveYs(curve)?.Clear();
+            GetCurveXs(curve)?.Clear();
+            GetCurveYs(curve)?.Clear();
             if (newXs != null && newYs != null) {
-                getCurveXs(curve)?.AddRange(newXs);
-                getCurveYs(curve)?.AddRange(newYs);
+                GetCurveXs(curve)?.AddRange(newXs);
+                GetCurveYs(curve)?.AddRange(newYs);
             }
         }
         public override void Unexecute() {
@@ -381,17 +381,17 @@ namespace OpenUtau.Core {
                 curve = new UCurve(descriptor);
                 Part.curves.Add(curve);
             }
-            getCurveXs(curve)?.Clear();
-            getCurveYs(curve)?.Clear();
+            GetCurveXs(curve)?.Clear();
+            GetCurveYs(curve)?.Clear();
             if (oldXs != null && oldYs != null) {
-                getCurveXs(curve)?.AddRange(oldXs);
-                getCurveYs(curve)?.AddRange(oldYs);
+                GetCurveXs(curve)?.AddRange(oldXs);
+                GetCurveYs(curve)?.AddRange(oldYs);
             }
         }
-        private List<int>? getCurveXs(UCurve? curve) {
+        private List<int>? GetCurveXs(UCurve? curve) {
             return setReal ? curve?.realXs : curve?.xs;
         }
-        private List<int>? getCurveYs(UCurve? curve) {
+        private List<int>? GetCurveYs(UCurve? curve) {
             return setReal ? curve?.realYs : curve?.ys;
         }
     }

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -476,7 +476,7 @@ namespace OpenUtau.Core.DiffSinger {
 
         public RenderPitchResult LoadRenderedPitch(RenderPhrase phrase) {
             DiffSingerSinger singer = (DiffSingerSinger) phrase.singer;
-            if (!singer.hasPitchPredictor) {
+            if (!singer.HasPitchPredictor) {
                 throw new Exception("This singer has no pitch predictor.");
             }
             var pitchPredictor = singer.getPitchPredictor()!;
@@ -490,7 +490,7 @@ namespace OpenUtau.Core.DiffSinger {
                 throw new Exception("Please enable DiffSinger tensor cache and re-render the phrase to display correct base curves.");
             }
             DiffSingerSinger singer = (DiffSingerSinger) phrase.singer;
-            if (!singer.hasVariancePredictor) {
+            if (!singer.HasVariancePredictor) {
                 return new List<RenderRealCurveResult>(0);
             }
             var variancePredictor = singer.getVariancePredictor()!;

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -503,19 +503,19 @@ namespace OpenUtau.Core.DiffSinger {
                         ENE, result.energy ?? Array.Empty<float>(),
                         phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE)?.Item2
                         ?? Enumerable.Repeat(0f, 2).ToArray(),
-                        x => Math.Clamp(x, -96, 0) / 0.96f + 100
+                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
                     ),
                     (
                         Format.Ustx.BREC, result.breathiness ?? Array.Empty<float>(), phrase.breathiness,
-                        x => Math.Clamp(x, -96, 0) / 0.96f + 100
+                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
                     ),
                     (
                         Format.Ustx.VOIC, result.voicing ?? Array.Empty<float>(), phrase.voicing,
-                        x => Math.Clamp(x, -96, 0) / 0.96f + 100
+                        x => Math.Clamp(x, -96f, 0f) / 96f + 1f
                     ),
                     (
                         Format.Ustx.TENC, result.tension ?? Array.Empty<float>(), phrase.tension,
-                        x => Math.Clamp(x, -10, 10) * 5 + 50
+                        x => Math.Clamp(x, -10f, 10f) / 20f + 0.5f
                     ),
                 }.Select(t => {
                     var abbr = t.Item1;

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -38,11 +38,21 @@ namespace OpenUtau.Core.DiffSinger {
             Format.Ustx.SHFC,
         };
 
+        private static readonly Dictionary<string, Func<float, float, float>> varianceDeltaFunctions =
+            new Dictionary<string, Func<float, float, float>>() {
+                {ENE, (x, y) => x + y * 12 / 100},
+                {Format.Ustx.BREC, (x, y) => x + y * 12 / 100},
+                {Format.Ustx.VOIC, (x, y) => x + (y - 100) * 12 / 100},
+                {Format.Ustx.TENC, (x, y) => x + y / 20},
+            };
+
         static readonly object lockObj = new object();
 
         public USingerType SingerType => USingerType.DiffSinger;
 
         public bool SupportsRenderPitch => true;
+
+        public bool SupportsRealCurve => true;
 
         public bool IsVoiceColorCurve(string abbr, out int subBankId) {
             subBankId = 0;
@@ -338,20 +348,20 @@ namespace OpenUtau.Core.DiffSinger {
                 //TODO: let user edit variance curves
                 if(singer.dsConfig.useEnergyEmbed){
                     var energyCurve = phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE);
-                    IEnumerable<double> userEnergy;
+                    IEnumerable<float> userEnergy;
                     if(energyCurve!=null){
                         userEnergy = DiffSingerUtils.SampleCurve(phrase, energyCurve.Item2,
                             0, frameMs, totalFrames, headFrames, tailFrames,
-                            x => x);
+                            x => x).Select(x => (float) x);
                     } else{
-                        userEnergy = Enumerable.Repeat(0d, totalFrames);
+                        userEnergy = Enumerable.Repeat(0f, totalFrames);
                     }
                     if (varianceResult.energy == null) {
                         throw new KeyNotFoundException(
                             "The parameter \"energy\" required by acoustic model is not found in variance predictions.");
                     }
                     var predictedEnergy = DiffSingerUtils.ResampleCurve(varianceResult.energy, totalFrames);
-                    var energy = predictedEnergy.Zip(userEnergy, (x,y)=>(float)Math.Min(x + y*12/100, 0)).ToArray();
+                    var energy = predictedEnergy.Zip(userEnergy, varianceDeltaFunctions[ENE]).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("energy",
                         new DenseTensor<float>(energy, new int[] { energy.Length })
                         .Reshape(new int[] { 1, energy.Length })));
@@ -359,13 +369,13 @@ namespace OpenUtau.Core.DiffSinger {
                 if(singer.dsConfig.useBreathinessEmbed){
                     var userBreathiness = DiffSingerUtils.SampleCurve(phrase, phrase.breathiness,
                         0, frameMs, totalFrames, headFrames, tailFrames,
-                        x => x);
+                        x => x).Select(x => (float) x);
                     if (varianceResult.breathiness == null) {
                         throw new KeyNotFoundException(
                             "The parameter \"breathiness\" required by acoustic model is not found in variance predictions.");
                     }
                     var predictedBreathiness = DiffSingerUtils.ResampleCurve(varianceResult.breathiness, totalFrames);
-                    var breathiness = predictedBreathiness.Zip(userBreathiness, (x,y)=>(float)Math.Min(x + y*12/100, 0)).ToArray();
+                    var breathiness = predictedBreathiness.Zip(userBreathiness, varianceDeltaFunctions[Format.Ustx.BREC]).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("breathiness",
                         new DenseTensor<float>(breathiness, new int[] { breathiness.Length })
                         .Reshape(new int[] { 1, breathiness.Length })));
@@ -373,13 +383,13 @@ namespace OpenUtau.Core.DiffSinger {
                 if(singer.dsConfig.useVoicingEmbed){
                     var userVoicing = DiffSingerUtils.SampleCurve(phrase, phrase.voicing,
                         0, frameMs, totalFrames, headFrames, tailFrames,
-                        x => x);
+                        x => x).Select(x => (float) x);
                     if (varianceResult.voicing == null) {
                         throw new KeyNotFoundException(
                             "The parameter \"voicing\" required by acoustic model is not found in variance predictions.");
                     }
                     var predictedVoicing = DiffSingerUtils.ResampleCurve(varianceResult.voicing, totalFrames);
-                    var voicing = predictedVoicing.Zip(userVoicing, (x,y)=>(float)Math.Min(x + (y-100)*12/100, 0)).ToArray();
+                    var voicing = predictedVoicing.Zip(userVoicing, varianceDeltaFunctions[Format.Ustx.VOIC]).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("voicing",
                         new DenseTensor<float>(voicing, new int[] { voicing.Length })
                         .Reshape(new int[] { 1, voicing.Length })));
@@ -387,13 +397,13 @@ namespace OpenUtau.Core.DiffSinger {
                 if(singer.dsConfig.useTensionEmbed){
                     var userTension = DiffSingerUtils.SampleCurve(phrase, phrase.tension,
                         0, frameMs, totalFrames, headFrames, tailFrames,
-                        x => x);
+                        x => x).Select(x => (float) x);
                     if (varianceResult.tension == null) {
                         throw new KeyNotFoundException(
                             "The parameter \"tension\" required by acoustic model is not found in variance predictions.");
                     }
                     var predictedTension = DiffSingerUtils.ResampleCurve(varianceResult.tension, totalFrames);
-                    var tension = predictedTension.Zip(userTension, (x,y)=>(float)(x + y * 5 / 100)).ToArray();
+                    var tension = predictedTension.Zip(userTension, varianceDeltaFunctions[Format.Ustx.TENC]).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("tension",
                         new DenseTensor<float>(tension, new int[] { tension.Length })
                         .Reshape(new int[] { 1, tension.Length })));
@@ -465,9 +475,64 @@ namespace OpenUtau.Core.DiffSinger {
         }
 
         public RenderPitchResult LoadRenderedPitch(RenderPhrase phrase) {
-            var pitchPredictor = (phrase.singer as DiffSingerSinger).getPitchPredictor();
-            lock(pitchPredictor){
+            DiffSingerSinger singer = (DiffSingerSinger) phrase.singer;
+            if (!singer.hasPitchPredictor) {
+                throw new Exception("This singer has no pitch predictor.");
+            }
+            var pitchPredictor = singer.getPitchPredictor()!;
+            lock (pitchPredictor) {
                 return pitchPredictor.Process(phrase);
+            }
+        }
+
+        public List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) {
+            if (!Preferences.Default.DiffSingerTensorCache) {
+                throw new Exception("Please enable DiffSinger tensor cache and re-render the phrase to display correct base curves.");
+            }
+            DiffSingerSinger singer = (DiffSingerSinger) phrase.singer;
+            if (!singer.hasVariancePredictor) {
+                return new List<RenderRealCurveResult>(0);
+            }
+            var variancePredictor = singer.getVariancePredictor()!;
+            lock (variancePredictor) {
+                var result = variancePredictor.Process(phrase);
+                var startMs = phrase.positionMs - headMs;
+                var frameMs = variancePredictor.FrameMs;
+                var realCurves = new (string, float[], float[], Func<float, float>)[] {
+                    (
+                        ENE, result.energy ?? Array.Empty<float>(),
+                        phrase.curves.FirstOrDefault(curve => curve.Item1 == ENE)?.Item2
+                        ?? Enumerable.Repeat(0f, 2).ToArray(),
+                        x => Math.Clamp(x, -96, 0) / 0.96f + 100
+                    ),
+                    (
+                        Format.Ustx.BREC, result.breathiness ?? Array.Empty<float>(), phrase.breathiness,
+                        x => Math.Clamp(x, -96, 0) / 0.96f + 100
+                    ),
+                    (
+                        Format.Ustx.VOIC, result.voicing ?? Array.Empty<float>(), phrase.voicing,
+                        x => Math.Clamp(x, -96, 0) / 0.96f + 100
+                    ),
+                    (
+                        Format.Ustx.TENC, result.tension ?? Array.Empty<float>(), phrase.tension,
+                        x => Math.Clamp(x, -10, 10) * 5 + 50
+                    ),
+                }.Select(t => {
+                    var abbr = t.Item1;
+                    var realCurve = t.Item2;
+                    var deltaCurve = DiffSingerUtils.ResampleCurve(t.Item3, realCurve.Length);
+                    var normFunc = t.Item4;
+                    return new RenderRealCurveResult {
+                        abbr = abbr,
+                        ticks = Enumerable.Range(0, realCurve.Length)
+                            .Select(i => (float)phrase.timeAxis.MsPosToTickPos(startMs + i * frameMs) - phrase.position)
+                            .ToArray(),
+                        values = realCurve.Zip(deltaCurve, varianceDeltaFunctions[abbr])
+                            .Select(normFunc)
+                            .ToArray()
+                    };
+                }).ToList();
+                return realCurves;
             }
         }
 
@@ -520,7 +585,6 @@ namespace OpenUtau.Core.DiffSinger {
                         isFlag=false,
                     }));
             }
-            //energy
 
             return result.ToArray();
         }

--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -51,6 +51,8 @@ namespace OpenUtau.Core.DiffSinger {
         public DsPitch pitchPredictor = null;
         public DiffSingerSpeakerEmbedManager speakerEmbedManager = null;
         public DsVariance variancePredictor = null;
+        public bool hasPitchPredictor => File.Exists(Path.Join(Location, "dspitch", "dsconfig.yaml"));
+        public bool hasVariancePredictor => File.Exists(Path.Join(Location,"dsvariance", "dsconfig.yaml"));
 
         public DiffSingerSinger(Voicebank voicebank) {
             this.voicebank = voicebank;
@@ -180,13 +182,12 @@ namespace OpenUtau.Core.DiffSinger {
             return vocoder;
         }
 
-        public DsPitch getPitchPredictor(){
+        public DsPitch? getPitchPredictor(){
             if(pitchPredictor is null) {
-                if(File.Exists(Path.Join(Location, "dspitch", "dsconfig.yaml"))){
+                if(hasPitchPredictor){
                     pitchPredictor = new DsPitch(Path.Join(Location, "dspitch"));
                     return pitchPredictor;
                 }
-                pitchPredictor = new DsPitch(Location);
             }
             return pitchPredictor;
         }
@@ -198,13 +199,12 @@ namespace OpenUtau.Core.DiffSinger {
             return speakerEmbedManager;
         }
 
-        public DsVariance getVariancePredictor(){
+        public DsVariance? getVariancePredictor(){
             if(variancePredictor is null) {
-                if(File.Exists(Path.Join(Location,"dsvariance", "dsconfig.yaml"))){
+                if(hasVariancePredictor){
                     variancePredictor = new DsVariance(Path.Join(Location, "dsvariance"));
                     return variancePredictor;
                 }
-                variancePredictor = new DsVariance(Location);
             }
             return variancePredictor;
         }

--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -51,8 +51,8 @@ namespace OpenUtau.Core.DiffSinger {
         public DsPitch pitchPredictor = null;
         public DiffSingerSpeakerEmbedManager speakerEmbedManager = null;
         public DsVariance variancePredictor = null;
-        public bool hasPitchPredictor => File.Exists(Path.Join(Location, "dspitch", "dsconfig.yaml"));
-        public bool hasVariancePredictor => File.Exists(Path.Join(Location,"dsvariance", "dsconfig.yaml"));
+        public bool HasPitchPredictor => File.Exists(Path.Join(Location, "dspitch", "dsconfig.yaml"));
+        public bool HasVariancePredictor => File.Exists(Path.Join(Location,"dsvariance", "dsconfig.yaml"));
 
         public DiffSingerSinger(Voicebank voicebank) {
             this.voicebank = voicebank;
@@ -184,7 +184,7 @@ namespace OpenUtau.Core.DiffSinger {
 
         public DsPitch? getPitchPredictor(){
             if(pitchPredictor is null) {
-                if(hasPitchPredictor){
+                if(HasPitchPredictor){
                     pitchPredictor = new DsPitch(Path.Join(Location, "dspitch"));
                     return pitchPredictor;
                 }
@@ -201,7 +201,7 @@ namespace OpenUtau.Core.DiffSinger {
 
         public DsVariance? getVariancePredictor(){
             if(variancePredictor is null) {
-                if(hasVariancePredictor){
+                if(HasVariancePredictor){
                     variancePredictor = new DsVariance(Path.Join(Location, "dsvariance"));
                     return variancePredictor;
                 }

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -34,6 +34,7 @@ namespace OpenUtau.Core.DiffSinger{
         const float tailMs = DiffSingerUtils.tailMs;
         DiffSingerSpeakerEmbedManager speakerEmbedManager;
 
+        public float FrameMs => frameMs;
 
         public DsVariance(string rootPath)
         {

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -687,7 +687,7 @@ namespace OpenUtau.Core.Editing {
                     xs.Add(ticks[0]);
                     ys.Add(-1);
                     xs.AddRange(ticks);
-                    ys.AddRange(result.values.Select(v => (int) v));
+                    ys.AddRange(result.values.Select(v => (int)(v * 1000.0)));
                 }
                 finished += 1;
                 setProgressCallback(finished, part.renderPhrases.Count);

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -628,4 +628,86 @@ namespace OpenUtau.Core.Editing {
             docManager.EndUndoGroup();
         }
     }
+
+    public class RefreshRealCurves : BatchEdit {
+        public virtual string Name => name;
+
+        public bool IsAsync => true;
+
+        private string name;
+
+        public RefreshRealCurves() {
+            name = "pianoroll.menu.notes.refreshrealcurves";
+        }
+
+        public void Run(UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager) {
+            RunAsync(
+                project, part, selectedNotes, docManager,
+                (current, total) => { }, CancellationToken.None);
+        }
+
+        public void RunAsync(
+            UProject project, UVoicePart part, List<UNote> selectedNotes, DocManager docManager,
+            Action<int, int> setProgressCallback, CancellationToken cancellationToken) {
+            var renderer = project.tracks[part.trackNo].RendererSettings.Renderer;
+            if (renderer == null || !renderer.SupportsRealCurve) {
+                docManager.ExecuteCmd(new ErrorMessageNotification("Not supported"));
+                return;
+            }
+
+            int finished = 0;
+            setProgressCallback(0, part.renderPhrases.Count);
+            var curveDict = new Dictionary<string, UCurve?>();
+            var newXsDict = new Dictionary<string, List<int>>();
+            var newYsDict = new Dictionary<string, List<int>>();
+            for (int ph_i = 0; ph_i < part.renderPhrases.Count; ++ph_i) {
+                var phrase = part.renderPhrases[ph_i];
+                var results = renderer.LoadRenderedRealCurves(phrase);
+                if (results.Count == 0) {
+                    continue;
+                }
+                // TODO: Optimize interpolation and command.
+                if (cancellationToken.IsCancellationRequested) break;
+                foreach (var result in results) {
+                    if (!curveDict.ContainsKey(result.abbr)) {
+                        var curve = part.curves.FirstOrDefault(c => c.abbr == result.abbr);
+                        curveDict[result.abbr] = curve;
+                        newXsDict[result.abbr] = new List<int>();
+                        newYsDict[result.abbr] = new List<int>();
+                    }
+                    var xs = newXsDict[result.abbr];
+                    var ys = newYsDict[result.abbr];
+                    var ticks = result.ticks.Select(t => phrase.position - part.position + (int)t).ToArray();
+                    if (ticks.Length == 0) {
+                        continue;
+                    }
+                    while (xs.Count > 0 && xs[^1] >= ticks[0]) {
+                        xs.RemoveAt(xs.Count - 1);
+                        ys.RemoveAt(ys.Count - 1);
+                    }
+                    xs.Add(ticks[0]);
+                    ys.Add(-1);
+                    xs.AddRange(ticks);
+                    ys.AddRange(result.values.Select(v => (int) v));
+                }
+                finished += 1;
+                setProgressCallback(finished, part.renderPhrases.Count);
+            }
+            var commands = curveDict
+                .Select(kv => new MergedSetCurveCommand(
+                    project, part, kv.Key,
+                    kv.Value?.realXs.ToArray() ?? Array.Empty<int>(),
+                    kv.Value?.realYs.ToArray() ?? Array.Empty<int>(),
+                    newXsDict[kv.Key].ToArray(),
+                    newYsDict[kv.Key].ToArray(),
+                    true))
+                .ToList();
+
+            DocManager.Inst.PostOnUIThread(() => {
+                docManager.StartUndoGroup(true);
+                commands.ForEach(docManager.ExecuteCmd);
+                docManager.EndUndoGroup();
+            });
+        }
+    }
 }

--- a/OpenUtau.Core/Editing/NoteBatchEdits.cs
+++ b/OpenUtau.Core/Editing/NoteBatchEdits.cs
@@ -666,7 +666,6 @@ namespace OpenUtau.Core.Editing {
                 if (results.Count == 0) {
                     continue;
                 }
-                // TODO: Optimize interpolation and command.
                 if (cancellationToken.IsCancellationRequested) break;
                 foreach (var result in results) {
                     if (!curveDict.ContainsKey(result.abbr)) {

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -31,13 +31,31 @@ namespace OpenUtau.Core.Render {
     }
 
     public class RenderPitchResult {
+        /// <summary>
+        /// Abbreviation of the expression.
+        /// </summary>
         public float[] ticks;
+
+        /// <summary>
+        /// Semitone values in MIDI scale.
+        /// </summary>
         public float[] tones;
     }
 
     public class RenderRealCurveResult {
+        /// <summary>
+        /// Abbreviation of the expression.
+        /// </summary>
         public string abbr;
+
+        /// <summary>
+        /// Ticks relative to the start of the phrase.
+        /// </summary>
         public float[] ticks;
+
+        /// <summary>
+        /// Values normalized between 0 and 1.
+        /// </summary>
         public float[] values;
     }
 

--- a/OpenUtau.Core/Render/IRenderer.cs
+++ b/OpenUtau.Core/Render/IRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenUtau.Core.Ustx;
@@ -34,16 +35,24 @@ namespace OpenUtau.Core.Render {
         public float[] tones;
     }
 
+    public class RenderRealCurveResult {
+        public string abbr;
+        public float[] ticks;
+        public float[] values;
+    }
+
     /// <summary>
     /// Interface of phrase-based renderer.
     /// </summary>
     public interface IRenderer {
         USingerType SingerType { get; }
         bool SupportsRenderPitch { get; }
+        bool SupportsRealCurve { get { return false; } }
         bool SupportsExpression(UExpressionDescriptor descriptor);
         RenderResult Layout(RenderPhrase phrase);
         Task<RenderResult> Render(RenderPhrase phrase, Progress progress, int trackNo, CancellationTokenSource cancellation, bool isPreRender = false);
         RenderPitchResult LoadRenderedPitch(RenderPhrase phrase);
+        List<RenderRealCurveResult> LoadRenderedRealCurves(RenderPhrase phrase) { return new List<RenderRealCurveResult>(0);}
         UExpressionDescriptor[] GetSuggestedExpressions(USinger singer, URenderSettings renderSettings);
     }
 }

--- a/OpenUtau.Core/Ustx/UCurve.cs
+++ b/OpenUtau.Core/Ustx/UCurve.cs
@@ -11,6 +11,8 @@ namespace OpenUtau.Core.Ustx {
         [YamlIgnore] public UExpressionDescriptor descriptor;
         public List<int> xs = new List<int>();
         public List<int> ys = new List<int>();
+        [YamlIgnore] public List<int> realXs = new List<int>();
+        [YamlIgnore] public List<int> realYs = new List<int>();
         public string abbr;
 
         [YamlIgnore] public bool IsEmpty => xs.Count == 0 || ys.All(y => y == 0);

--- a/OpenUtau/Colors/Brushes.axaml
+++ b/OpenUtau/Colors/Brushes.axaml
@@ -84,6 +84,12 @@
                    Color="{DynamicResource BarNumberColor}" />
   <SolidColorBrush x:Key="FinalPitchBrush"
                    Color="{DynamicResource FinalPitchColor}" />
+  <SolidColorBrush x:Key="RealCurveStrokeBrush"
+                   Color="{DynamicResource AccentColor1}" Opacity="0.25" />
+  <LinearGradientBrush x:Key="RealCurveFillBrush" StartPoint="0%,0%" EndPoint="0%,100%" Opacity="0.25">
+      <GradientStop Color="{DynamicResource AccentColor1}" Offset="0.0"/>
+      <GradientStop Color="Transparent" Offset="1.0"/>
+  </LinearGradientBrush>
   <SolidColorBrush x:Key="TrackBackgroundAltBrush"
                    Color="{DynamicResource TrackBackgroundAltColor}"/>
   <SolidColorBrush x:Key="NeutralAccentBrush"

--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -172,7 +172,10 @@ namespace OpenUtau.App.Controls {
                         while (start < baseIndexR && curve.realYs[start] < 0) ++start;
                         int end = start;
                         while (end < baseIndexR && curve.realYs[end] >= 0) ++end;
-                        if (end - start < 2) break;
+                        if (end - start < 2) {
+                            offset = end;
+                            continue;
+                        }
                         var geometry = new PathGeometry();
                         var figure = new PathFigure {
                             IsClosed = false

--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -184,7 +184,7 @@ namespace OpenUtau.App.Controls {
                             float tick = curve.realXs[i];
                             float value = curve.realYs[i];
                             double x = viewModel.TickToneToPoint(tick, 0).X;
-                            double y = Bounds.Height * (1 - value / 100.0);
+                            double y = Bounds.Height * (1 - value / 1000.0);
                             if (i == start) {
                                 figure.StartPoint = new Point(x, Bounds.Height);
                             }

--- a/OpenUtau/Controls/ExpressionCanvas.cs
+++ b/OpenUtau/Controls/ExpressionCanvas.cs
@@ -33,6 +33,11 @@ namespace OpenUtau.App.Controls {
                 nameof(Key),
                 o => o.Key,
                 (o, v) => o.Key = v);
+        public static readonly DirectProperty<ExpressionCanvas, bool> ShowRealCurveProperty =
+            AvaloniaProperty.RegisterDirect<ExpressionCanvas, bool>(
+                nameof(ShowRealCurve),
+                o => o.ShowRealCurve,
+                (o, v) => o.ShowRealCurve = v);
 
         public double TickWidth {
             get => tickWidth;
@@ -50,11 +55,16 @@ namespace OpenUtau.App.Controls {
             get => key;
             set => SetAndRaise(KeyProperty, ref key, value);
         }
+        public bool ShowRealCurve {
+            get => showRealCurve;
+            set => SetAndRaise(ShowRealCurveProperty, ref showRealCurve, value);
+        }
 
         private double tickWidth;
         private double tickOffset;
         private UVoicePart? part;
         private string key = string.Empty;
+        private bool showRealCurve = true;
 
         private HashSet<UNote> selectedNotes = new HashSet<UNote>();
         private Geometry pointGeometry;
@@ -143,6 +153,52 @@ namespace OpenUtau.App.Controls {
                     index++;
                     if (tick2 >= rTick) {
                         break;
+                    }
+                }
+                if (ShowRealCurve) {
+                    int baseIndexL = curve.realXs.BinarySearch(lTick);
+                    if (baseIndexL < 0) {
+                        baseIndexL = ~baseIndexL;
+                    }
+                    baseIndexL = Math.Max(0, baseIndexL - 1);
+                    int baseIndexR = curve.realXs.BinarySearch(rTick);
+                    if (baseIndexR < 0) {
+                        baseIndexR = ~baseIndexR;
+                    }
+                    int offset = baseIndexL;
+                    while (offset < baseIndexR) {
+                        // negative values are breakpoints
+                        int start = offset;
+                        while (start < baseIndexR && curve.realYs[start] < 0) ++start;
+                        int end = start;
+                        while (end < baseIndexR && curve.realYs[end] >= 0) ++end;
+                        if (end - start < 2) break;
+                        var geometry = new PathGeometry();
+                        var figure = new PathFigure {
+                            IsClosed = false
+                        };
+                        for (int i = start; i < end; ++i) {
+                            float tick = curve.realXs[i];
+                            float value = curve.realYs[i];
+                            double x = viewModel.TickToneToPoint(tick, 0).X;
+                            double y = Bounds.Height * (1 - value / 100.0);
+                            if (i == start) {
+                                figure.StartPoint = new Point(x, Bounds.Height);
+                            }
+                            figure.Segments!.Add(new LineSegment {
+                                Point = new Point(x, y),
+                                IsStroked = i != start
+                            });
+                            if (i == end - 1) {
+                                figure.Segments!.Add(new LineSegment {
+                                    Point = new Point(x, Bounds.Height),
+                                    IsStroked = false
+                                });
+                            }
+                        }
+                        geometry.Figures!.Add(figure);
+                        context.DrawGeometry(ThemeManager.RealCurveFillBrush, ThemeManager.RealCurvePen, geometry);
+                        offset = end;
                     }
                 }
                 return;

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -299,6 +299,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">Hanzi to pinyin</system:String>
   <system:String x:Key="pianoroll.menu.notes.lengthencrossfade">Lengthen crossfades</system:String>
   <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">Load rendered pitch</system:String>
+  <system:String x:Key="pianoroll.menu.notes.refreshrealcurves">Refresh real curves</system:String>
   <system:String x:Key="pianoroll.menu.notes.octavedown">Move an octave down</system:String>
   <system:String x:Key="pianoroll.menu.notes.octaveup">Move an octave up</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize">Quantize to grid size</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -293,6 +293,7 @@
   <system:String x:Key="pianoroll.menu.notes.hanzitopinyin">汉字转拼音</system:String>
   <system:String x:Key="pianoroll.menu.notes.lengthencrossfade">加长淡入淡出</system:String>
   <system:String x:Key="pianoroll.menu.notes.loadrenderedpitch">加载音高渲染结果</system:String>
+  <system:String x:Key="pianoroll.menu.notes.refreshrealcurves">刷新实际曲线</system:String>
   <system:String x:Key="pianoroll.menu.notes.octavedown">下移八度</system:String>
   <system:String x:Key="pianoroll.menu.notes.octaveup">上移八度</system:String>
   <system:String x:Key="pianoroll.menu.notes.quantize15">量化至1/128音符</system:String>

--- a/OpenUtau/ThemeManager.cs
+++ b/OpenUtau/ThemeManager.cs
@@ -38,6 +38,9 @@ namespace OpenUtau.App {
         public static IPen BarNumberPen = new Pen(Brushes.White);
         public static IBrush FinalPitchBrush = Brushes.Gray;
         public static IPen FinalPitchPen = new Pen(Brushes.Gray);
+        public static IBrush RealCurveFillBrush = Brushes.Gray;
+        public static IBrush RealCurveStrokeBrush = Brushes.Gray;
+        public static IPen RealCurvePen = new Pen(Brushes.Gray, 1D, DashStyle.Dash);
         public static IBrush WhiteKeyBrush = Brushes.White;
         public static IBrush WhiteKeyNameBrush = Brushes.Black;
         public static IBrush CenterKeyBrush = Brushes.White;
@@ -135,6 +138,13 @@ namespace OpenUtau.App {
             if (resDict.TryGetResource("FinalPitchBrush", themeVariant, out outVar)) {
                 FinalPitchBrush = (IBrush)outVar!;
                 FinalPitchPen = new Pen(FinalPitchBrush, 1);
+            }
+            if (resDict.TryGetResource("RealCurveFillBrush", themeVariant, out outVar)) {
+                RealCurveFillBrush = (IBrush)outVar!;
+            }
+            if (resDict.TryGetResource("RealCurveStrokeBrush", themeVariant, out outVar)) {
+                RealCurveStrokeBrush = (IBrush)outVar!;
+                RealCurvePen = new Pen(RealCurveStrokeBrush, 2, DashStyle.Dash);
             }
             SetKeyboardBrush();
             TextLayoutCache.Clear();

--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -606,13 +606,15 @@
                           TickWidth="{Binding NotesViewModel.TickWidth}"
                           TickOffset="{Binding NotesViewModel.TickOffset}"
                           Part="{Binding NotesViewModel.Part}"
-                          Key="{Binding NotesViewModel.SecondaryKey}"/>
+                          Key="{Binding NotesViewModel.SecondaryKey}"
+                          ShowRealCurve="False"/>
       <c:ExpressionCanvas Grid.Row="5" Grid.Column="1"
                           Bounds="{Binding NotesViewModel.ExpBounds, Mode=OneWayToSource}"
                           TickWidth="{Binding NotesViewModel.TickWidth}"
                           TickOffset="{Binding NotesViewModel.TickOffset}"
                           Part="{Binding NotesViewModel.Part}"
                           Key="{Binding NotesViewModel.PrimaryKey}"
+                          ShowRealCurve="True"
                           PointerPressed="ExpCanvasPointerPressed"
                           PointerMoved="ExpCanvasPointerMoved"
                           PointerReleased="ExpCanvasPointerReleased">

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -90,6 +90,7 @@ namespace OpenUtau.App.Views {
             });
             ViewModel.NoteBatchEdits.AddRange(new List<BatchEdit>() {
                 new LoadRenderedPitch(),
+                new RefreshRealCurves(),
                 new AddTailNote("-", "pianoroll.menu.notes.addtaildash"),
                 new AddTailNote("R", "pianoroll.menu.notes.addtailrest"),
                 new RemoveTailNote("-", "pianoroll.menu.notes.removetaildash"),


### PR DESCRIPTION
## Motivation
DiffSinger acoustic models take actual expression values (rather than delta values) as inputs.
However, as OpenUTAU is originally designed for delta-like expressions, DiffSinger users has been suffering for a long time since they have to tune delta values on an invisible "real curve". Though it seems quite complicated to allow direct editing to the real curve, it could be a positive step to just display it on the expressions panel.

## Changes
This PR allows user to display and refresh the real curves on their expressions panel. Major changes are:
- `UCurve` class got two new fields, `realXs` and `realYs`. These fields are YAML-ignored.
- `MergedSetCurveCommand` got a new flag parameter `setReal` to indicate whether to update the delta values or the real values
- A new batch edit `RefreshRealCurves` to update `realXs` and `realYs` in `UCurve` was added.
- `IRenderer` interface got a new property `SupportsRealCurve` (defaults to `false`) and a new method `LoadRenderedRealCurves` (returns empty list by default). Only `DiffSingerRenderer` overrides them currently.
- New brushes were added, including a brush (and pen) to stroke the real curve and a linear gradient brush to fill the area under it.
- `ExpressionCanvas` got a new reactive property `ShowRealCurve`, in order to not render the real curve of the secondary key. Drawing logic was added here.

Some details:
- `LoadRenderedRealCurves` should return a list of `RenderRealCurveResult` objects. `ticks` is the relative tick to the phrase position (same as `RenderPitchResult`). `values` should be float values normalized between 0 and 1. Negative values are internally considered as breakpoints in the drawing logic.
- Because `MergedSetCurveCommand` only accepts integers, the drawing has a quantized precision of 0.001.

## Usage and demo
This feature is available only when DiffSinger tensor cache is enabled. The new batch edit "refresh real curves" generates or loads the real curves, apply the delta values edited by user on them, and displays the final model input on the background. The real curves will not refresh automatically, so user should run the batch edit manually to sync them.

![image](https://github.com/user-attachments/assets/8113762e-9376-4385-bbd4-c6992d602482)
