### PR TITLE
Move DLLs to a subfolder

### DIFF
--- a/OpenUtau/OpenUtau.csproj
+++ b/OpenUtau/OpenUtau.csproj
@@ -49,6 +49,17 @@
         </array>          
   </CFBundleDocumentTypes>
   </PropertyGroup>
+  <PropertyGroup>
+    <BeautySharedRuntimeMode>False</BeautySharedRuntimeMode>
+    <BeautyLibsDir>./Libs</BeautyLibsDir>
+    <BeautyExcludes>OpenUtau.dll;OpenUtau.Plugin.Builtin.dll</BeautyExcludes>
+    <BeautyOnPublishOnly>False</BeautyOnPublishOnly>
+    <BeautyNoRuntimeInfo>False</BeautyNoRuntimeInfo>
+    <BeautyNBLoaderVerPolicy>auto</BeautyNBLoaderVerPolicy>
+    <BeautyEnableDebugging>True</BeautyEnableDebugging>
+    <BeautyUsePatch>True</BeautyUsePatch>
+    <BeautyLogLevel>Info</BeautyLogLevel>
+  </PropertyGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
@@ -56,6 +67,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.4" />
     <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
     <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="2.2.3" />
+    <PackageReference Include="nulastudio.NetBeauty" Version="2.1.4.6" />
     <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageReference Include="Avalonia" Version="11.2.4" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.4" />


### PR DESCRIPTION
Before this PR, there are many DLLs in the same folder with OpenUtau, which is inconvenient for new users to find the exe. After this PR, the DLLs are moved to `Libs` subfolder.

Currently this is only tested on windows. Mac and Linux devs, please test it.