### PR TITLE
[DiffSinger Phonemizers] Parse same phonetic result on lowercase and mixed lowercase/uppercase lyric notes

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -158,6 +158,21 @@ namespace OpenUtau.Core.DiffSinger
                 .ToArray();
         }
 
+        /// <summary>
+        /// Check if lyrics are all uppercase.
+        /// If true, do not parse as all lowercase.
+        /// If false (e.g. only some letters are uppercase but not all, or all letters are already lowercase), parse as lowercase.
+        /// </summary>
+        /// <param name="IsAllUpper()"></param>
+        /// <returns></returns>
+        bool IsAllUpper(string lyric) {
+            for (int i = 0; i < lyric.Length; i++) {
+                if (char.IsLetter(lyric[i]) && !char.IsUpper(lyric[i]))
+                    return false;
+            }
+            return true;
+        }
+
         string[] GetSymbols(Note note) {
             //priority:
             //1. phonetic hint
@@ -172,7 +187,7 @@ namespace OpenUtau.Core.DiffSinger
             var g2presult = g2p.Query(note.lyric)
                 ?? g2p.Query(note.lyric.ToLowerInvariant());
             if(g2presult != null) {
-                if (note.lyric != defaultPause && note.lyric != "AP") {
+                if (!IsAllUpper(note.lyric)) {
                     g2presult = g2p.Query(note.lyric.ToLowerInvariant());
                     return g2presult;
                 }

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -172,6 +172,10 @@ namespace OpenUtau.Core.DiffSinger
             var g2presult = g2p.Query(note.lyric)
                 ?? g2p.Query(note.lyric.ToLowerInvariant());
             if(g2presult != null) {
+                if (note.lyric != defaultPause && note.lyric != "AP") {
+                    g2presult = g2p.Query(note.lyric.ToLowerInvariant());
+                    return g2presult;
+                }
                 return g2presult;
             }
             //not found in g2p dictionary, treat lyric as phonetic hint

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -164,7 +164,6 @@ namespace OpenUtau.Core.DiffSinger
         /// If false (e.g. only some letters are uppercase but not all, or all letters are already lowercase), parse as lowercase.
         /// </summary>
         /// <param name="IsAllUpper()"></param>
-        /// <returns></returns>
         bool IsAllUpper(string lyric) {
             for (int i = 0; i < lyric.Length; i++) {
                 if (char.IsLetter(lyric[i]) && !char.IsUpper(lyric[i]))


### PR DESCRIPTION
This is an implementation similar to #1209 but only for DiffSinger phonemizers.

The default G2P behavior is that uppercase and lowercase lyrics give different results. This is intentional and has not been changed. However, DiffSinger users generally prefer to have the same phonetic result regardless of capitalization (akin to the UTAU phonemizers), especially when there's a capital letter at the beginning of a word (e.g. the beginning of a sentence, or languages such as German where all nouns are capitalized). As a result, I changed this behavior for DiffSinger phonemizers only.

I've created an exception for words that are all uppercase (such as abbreviations); this includes the global DiffSinger phonemes `SP` and `AP` (you'll still need to define them manually in your G2P-based `dsdict`s). This is because distinguishing all-caps words might be preferred in these cases. (Feedback on this is appreciated, however.)