### PR TITLE
Allow scrolling main view when hovering over Singer List

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -276,7 +276,8 @@
                               DataContext="{Binding TracksViewModel}"
                               TrackHeight="{Binding TrackHeight}"
                               TrackOffset="{Binding TrackOffset}"
-                              Items="{Binding Tracks}"/>
+                              Items="{Binding Tracks}"
+							  PointerWheelChanged="MainPagePointerWheelChanged"/>
           <c:TrackBackground Grid.Row="2" Grid.Column="1" Margin="0" IsHitTestVisible="False"
                             Foreground="{DynamicResource TrackBackgroundAltBrush}"
                             DataContext="{Binding TracksViewModel}"
@@ -303,7 +304,7 @@
                         PointerMoved="PartsCanvasPointerMoved"
                         PointerReleased="PartsCanvasPointerReleased"
                         DoubleTapped="PartsCanvasDoubleTapped"
-                        PointerWheelChanged="PartsCanvasPointerWheelChanged">
+                        PointerWheelChanged="MainPagePointerWheelChanged">
             <Rectangle Name="PlayPosHighlight"
                       Width="{Binding PlayPosHighlightWidth, Mode=OneWay}"
                       Height="{Binding $parent.Bounds.Height, Mode=OneWay}"

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -1117,7 +1117,7 @@ namespace OpenUtau.App.Views {
             }
         }
 
-        public void PartsCanvasPointerWheelChanged(object sender, PointerWheelEventArgs args) {
+        public void MainPagePointerWheelChanged(object sender, PointerWheelEventArgs args) {
             var delta = args.Delta;
             if (args.KeyModifiers == KeyModifiers.None || args.KeyModifiers == KeyModifiers.Shift) {
                 if (args.KeyModifiers == KeyModifiers.Shift) {


### PR DESCRIPTION
Previously scrolling with the mousewheel when hovering over the singer list wouldn't work.

This PR lets you scroll when hovering over the singers list.

(Before scrolling only worked when hovering over the green area, despite the fact that both the red and green regions scroll together)
![image](https://github.com/user-attachments/assets/ce05e4a2-bec1-4474-8f15-8d61b220e65c)
