### PR TITLE
Revert "move DLLs to a subfolder"

### DIFF
--- a/OpenUtau/OpenUtau.csproj
+++ b/OpenUtau/OpenUtau.csproj
@@ -54,7 +54,7 @@
     <BeautySharedRuntimeMode>False</BeautySharedRuntimeMode>
     <BeautyLibsDir>./Libs</BeautyLibsDir>
     <BeautyExcludes>OpenUtau.dll;OpenUtau.Plugin.Builtin.dll</BeautyExcludes>
-    <BeautyOnPublishOnly>True</BeautyOnPublishOnly>
+    <BeautyOnPublishOnly>False</BeautyOnPublishOnly>
     <BeautyNoRuntimeInfo>False</BeautyNoRuntimeInfo>
     <BeautyNBLoaderVerPolicy>auto</BeautyNBLoaderVerPolicy>
     <BeautyEnableDebugging>True</BeautyEnableDebugging>

--- a/OpenUtau/OpenUtau.csproj
+++ b/OpenUtau/OpenUtau.csproj
@@ -49,18 +49,6 @@
         </array>          
   </CFBundleDocumentTypes>
   </PropertyGroup>
-  <PropertyGroup>
-    <DisableBeauty Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'false'">True</DisableBeauty>
-    <BeautySharedRuntimeMode>False</BeautySharedRuntimeMode>
-    <BeautyLibsDir>./Libs</BeautyLibsDir>
-    <BeautyExcludes>OpenUtau.dll;OpenUtau.Plugin.Builtin.dll</BeautyExcludes>
-    <BeautyOnPublishOnly>False</BeautyOnPublishOnly>
-    <BeautyNoRuntimeInfo>False</BeautyNoRuntimeInfo>
-    <BeautyNBLoaderVerPolicy>auto</BeautyNBLoaderVerPolicy>
-    <BeautyEnableDebugging>True</BeautyEnableDebugging>
-    <BeautyUsePatch>True</BeautyUsePatch>
-    <BeautyLogLevel>Info</BeautyLogLevel>
-  </PropertyGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
@@ -68,7 +56,6 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.4" />
     <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
     <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="2.2.3" />
-    <PackageReference Include="nulastudio.NetBeauty" Version="2.1.4.6" />
     <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageReference Include="Avalonia" Version="11.2.4" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.4" />

--- a/OpenUtau/OpenUtau.csproj
+++ b/OpenUtau/OpenUtau.csproj
@@ -54,7 +54,7 @@
     <BeautySharedRuntimeMode>False</BeautySharedRuntimeMode>
     <BeautyLibsDir>./Libs</BeautyLibsDir>
     <BeautyExcludes>OpenUtau.dll;OpenUtau.Plugin.Builtin.dll</BeautyExcludes>
-    <BeautyOnPublishOnly>False</BeautyOnPublishOnly>
+    <BeautyOnPublishOnly>True</BeautyOnPublishOnly>
     <BeautyNoRuntimeInfo>False</BeautyNoRuntimeInfo>
     <BeautyNBLoaderVerPolicy>auto</BeautyNBLoaderVerPolicy>
     <BeautyEnableDebugging>True</BeautyEnableDebugging>


### PR DESCRIPTION
Because netbeauty has a bug that causes OpenUtau unable to launch if it is built with `dotnet publish`. It only works with `dotnet build`.