### PR TITLE
Fixes OpenUtau's data folders appearing in the wrong place on Linux

### DIFF
--- a/OpenUtau.Core/Util/PathManager.cs
+++ b/OpenUtau.Core/Util/PathManager.cs
@@ -28,7 +28,7 @@ namespace OpenUtau.Core {
                     }
                 } catch { }
             } else if (OS.IsLinux()) {
-                string userHome = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+                string userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                 string dataHome = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
                 if (string.IsNullOrEmpty(dataHome)) {
                     dataHome = Path.Combine(userHome, ".local", "share");


### PR DESCRIPTION
This PR shouldn't exist, however, due to #1460  , the problem under Linux haven't fix it.