### PR TITLE
Fix Up/Down keys not working

### DIFF
--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="OpenUtau.App.Views.PianoRollWindow"
         Icon="/Assets/open-utau.ico"
-        Title="{Binding NotesViewModel.WindowTitle}" MinWidth="300" MinHeight="200" KeyDown="OnKeyDown" Closing="WindowClosing"
+        Title="{Binding NotesViewModel.WindowTitle}" MinWidth="300" MinHeight="200" Closing="WindowClosing"
         Focusable="True"
         TransparencyLevelHint="None"
         Deactivated="WindowDeactivated">

--- a/OpenUtau/Views/PianoRollWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollWindow.axaml.cs
@@ -167,6 +167,8 @@ namespace OpenUtau.App.Views {
                 EditNoteDefaults();
             });
 
+            this.AddHandler(KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+
             DocManager.Inst.AddSubscriber(this);
         }
 
@@ -1119,7 +1121,7 @@ namespace OpenUtau.App.Views {
 
         #endregion
 
-        void OnKeyDown(object sender, KeyEventArgs args) {
+        void OnKeyDown(object? sender, KeyEventArgs args) {
             var notesVm = ViewModel.NotesViewModel;
             if (notesVm.Part == null) {
                 args.Handled = false;


### PR DESCRIPTION
In the pianoroll window, the up and down keys were being sucked into the menu, but adding RoutingStrategies elements solved this problem.