### PR TITLE
Add "Install Wavtool/Resampler (.exe)" in menu

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -217,6 +217,7 @@
   <system:String x:Key="menu.tools.singer.install">Install Singer...</system:String>
   <system:String x:Key="menu.tools.singer.installadv">Install Singer (Advanced)...</system:String>
   <system:String x:Key="menu.tools.singers">Singers...</system:String>
+  <system:String x:Key="menu.tools.exe.install">Install Executable (.exe)...</system:String>
   <system:String x:Key="menu.view">View</system:String>
 
   <system:String x:Key="notedefaults.lyric">Lyric</system:String>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -217,7 +217,7 @@
   <system:String x:Key="menu.tools.singer.install">Install Singer...</system:String>
   <system:String x:Key="menu.tools.singer.installadv">Install Singer (Advanced)...</system:String>
   <system:String x:Key="menu.tools.singers">Singers...</system:String>
-  <system:String x:Key="menu.tools.exe.install">Install Executable (.exe)...</system:String>
+  <system:String x:Key="menu.tools.wavtoolresampler.install">Install Wavtool/Resampler (.exe)...</system:String>
   <system:String x:Key="menu.view">View</system:String>
 
   <system:String x:Key="notedefaults.lyric">Lyric</system:String>

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -77,6 +77,7 @@
             <MenuItem Header="{DynamicResource menu.tools.singers}" Click="OnMenuSingers"/>
             <MenuItem Header="{DynamicResource menu.tools.singer.install}" Click="OnMenuInstallSinger"/>
             <MenuItem Header="{DynamicResource menu.tools.dependency.install}" Click="OnMenuInstallDependency"/>
+            <MenuItem Header="{DynamicResource menu.tools.exe.install}" Click="OnMenuInstallExe"/>
             <MenuItem Header="{DynamicResource menu.tools.prefs}" Click="OnMenuPreferences"/>
           </MenuItem>
           <MenuItem Header="{DynamicResource menu.help}">

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -77,7 +77,7 @@
             <MenuItem Header="{DynamicResource menu.tools.singers}" Click="OnMenuSingers"/>
             <MenuItem Header="{DynamicResource menu.tools.singer.install}" Click="OnMenuInstallSinger"/>
             <MenuItem Header="{DynamicResource menu.tools.dependency.install}" Click="OnMenuInstallDependency"/>
-            <MenuItem Header="{DynamicResource menu.tools.exe.install}" Click="OnMenuInstallExe"/>
+            <MenuItem Header="{DynamicResource menu.tools.wavtoolresampler.install}" Click="OnMenuInstallWavtoolResampler"/>
             <MenuItem Header="{DynamicResource menu.tools.prefs}" Click="OnMenuPreferences"/>
           </MenuItem>
           <MenuItem Header="{DynamicResource menu.help}">

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -629,6 +629,24 @@ namespace OpenUtau.App.Views {
             }
         }
 
+        async void OnMenuInstallExe(object sender, RoutedEventArgs args) {
+            var file = await FilePicker.OpenFile(
+                this, "menu.tools.dependency.install", FilePicker.EXE);
+            if (file == null) {
+                return;
+            }
+            
+            if (file.EndsWith(".exe")) {
+                var setup = new ExeSetupDialog() {
+                    DataContext = new ExeSetupViewModel(file)
+                };
+                _ = setup.ShowDialog(this);
+                if (setup.Position.Y < 0) {
+                    setup.Position = setup.Position.WithY(0);
+                }
+            }
+        }
+
         void OnMenuPreferences(object sender, RoutedEventArgs args) {
             PreferencesViewModel dataContext;
             try {

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -629,7 +629,7 @@ namespace OpenUtau.App.Views {
             }
         }
 
-        async void OnMenuInstallExe(object sender, RoutedEventArgs args) {
+        async void OnMenuInstallWavtoolResampler(object sender, RoutedEventArgs args) {
             var file = await FilePicker.OpenFile(
                 this, "menu.tools.dependency.install", FilePicker.EXE);
             if (file == null) {


### PR DESCRIPTION
Since drag and dropping doesn't work on Linux (based on my testing), I think it's better to add "Install Wavtool/Resampler (.exe)" in menu.

![image](https://github.com/user-attachments/assets/49e0ff32-ff40-4d71-b534-c136406aa228)