### PR TITLE
Fixed translated error messages being overwritten by upper level abstract messages

### DIFF
--- a/OpenUtau.Core/Format/USTx.cs
+++ b/OpenUtau.Core/Format/USTx.cs
@@ -106,7 +106,7 @@ namespace OpenUtau.Core.Format {
                 Preferences.Save();
                 DocManager.Inst.Recovered = false;
             } catch (Exception ex) {
-                var e = new MessageCustomizableException("Failed to save ustx: {filePath}", $"<translate:errors.failed.save>: {filePath}", ex);
+                var e = new MessageCustomizableException($"Failed to save ustx: {filePath}", $"<translate:errors.failed.save>: {filePath}", ex);
                 DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(e));
             }
         }
@@ -133,7 +133,7 @@ namespace OpenUtau.Core.Format {
             project.AfterLoad();
             project.ValidateFull();
             if (project.ustxVersion > kUstxVersion) {
-                throw new MessageCustomizableException("Project file is newer than software.", $"<translate:errors.failed.opennewerproject>: {filePath}", new FileFormatException("Project file is newer than software."));
+                throw new MessageCustomizableException($"Project file is newer than software: {filePath}", $"<translate:errors.failed.opennewerproject>:\n{filePath}", new FileFormatException("Project file is newer than software."));
             }
             if (project.ustxVersion < kUstxVersion) {
                 Log.Information($"Upgrading project from {project.ustxVersion} to {kUstxVersion}");

--- a/OpenUtau.Core/Util/MessageCustomizableException.cs
+++ b/OpenUtau.Core/Util/MessageCustomizableException.cs
@@ -18,11 +18,19 @@ namespace OpenUtau.Core {
         /// <paramref name="e">underlying exception</paramref>
         /// <paramref name="showStackTrace">Can be omitted. Default is true.</paramref>
         public MessageCustomizableException(string message, string translatableMessage, Exception e, bool showStackTrace = true, object[]? replaces = null) {
-            Message = message;
-            TranslatableMessage = translatableMessage;
-            SubstanceException = e;
-            ShowStackTrace = showStackTrace;
-            Replaces = replaces;
+            if (e is MessageCustomizableException mce) {
+                Message = mce.Message;
+                TranslatableMessage = mce.TranslatableMessage;
+                SubstanceException = mce.SubstanceException;
+                ShowStackTrace = mce.ShowStackTrace;
+                Replaces = mce.Replaces;
+            } else {
+                Message = message;
+                TranslatableMessage = translatableMessage;
+                SubstanceException = e;
+                ShowStackTrace = showStackTrace;
+                Replaces = replaces;
+            }
         }
 
         public override string ToString() {

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -319,13 +319,7 @@ namespace OpenUtau.App.ViewModels {
                         }
                     } catch (Exception e) {
                         Log.Error(e, $"Failed to install singer {file}");
-                        MessageCustomizableException mce;
-                        if(e is MessageCustomizableException){
-                            mce = (MessageCustomizableException)e;
-                        } else {
-                            mce = new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e);
-                        }
-                        _ = await MessageBox.ShowError(mainWindow, mce);
+                        _ = await MessageBox.ShowError(mainWindow, new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e));
                     }
                 })
             });

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Reactive;
 using System.Threading.Tasks;
 using Avalonia;
-using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Primitives;
@@ -143,8 +142,6 @@ namespace OpenUtau.App.Views {
             DocManager.Inst.ExecuteCmd(new DelTempoChangeCommand(project, tick));
             DocManager.Inst.EndUndoGroup();
         }
-
-
 
         void OnMenuRemapTimeaxis(object sender, RoutedEventArgs e) {
             var project = DocManager.Inst.Project;
@@ -607,13 +604,7 @@ namespace OpenUtau.App.Views {
                 }
             } catch (Exception e) {
                 Log.Error(e, $"Failed to install singer {file}");
-                MessageCustomizableException mce;
-                if (e is MessageCustomizableException) {
-                    mce = (MessageCustomizableException)e;
-                } else {
-                    mce = new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e);
-                }
-                _ = await MessageBox.ShowError(this, mce);
+                _ = await MessageBox.ShowError(this, new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e));
             }
         }
 
@@ -872,13 +863,7 @@ namespace OpenUtau.App.Views {
                     }
                 } catch (Exception e) {
                     Log.Error(e, $"Failed to install singer {file}");
-                    MessageCustomizableException mce;
-                    if (e is MessageCustomizableException) {
-                        mce = (MessageCustomizableException)e;
-                    } else {
-                        mce = new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e);
-                    }
-                    _ = await MessageBox.ShowError(this, mce);
+                    _ = await MessageBox.ShowError(this, new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e));
                 }
             } else if (ext == Core.Vogen.VogenSingerInstaller.FileExt) {
                 Core.Vogen.VogenSingerInstaller.Install(file);


### PR DESCRIPTION
For example, the ustx version error had been replaced by the more abstract “Failed to open file”.