### PR TITLE
MOD+ related bug fixes

### DIFF
--- a/OpenUtau.Core/Classic/ClassicSinger.cs
+++ b/OpenUtau.Core/Classic/ClassicSinger.cs
@@ -44,7 +44,7 @@ namespace OpenUtau.Classic {
         OtoWatcher otoWatcher;
 
         public bool? UseFilenameAsAlias { get => voicebank.UseFilenameAsAlias; set => voicebank.UseFilenameAsAlias = value; }
-        public Dictionary<string, Frq> Frqs { get; set; } = new Dictionary<string, Frq>();
+        public Dictionary<string, IFrqFiles> Frqs { get; set; } = new Dictionary<string, IFrqFiles>();
 
         public ClassicSinger(Voicebank voicebank) {
             this.voicebank = voicebank;

--- a/OpenUtau.Core/Classic/Frq.cs
+++ b/OpenUtau.Core/Classic/Frq.cs
@@ -14,49 +14,61 @@ namespace OpenUtau.Classic {
         public int hopSize;
         public bool loaded = false;
 
-        public OtoFrq(UOto oto, Dictionary<string, Frq> dict) {
-            if (!dict.TryGetValue(oto.File, out var frq)) {
-                frq = new Frq();
-                if (frq.Load(oto.File)){
-                    dict.Add(oto.File, frq);
-                } else {
-                    frq = null;
+        public OtoFrq(UOto oto, Dictionary<string, IFrqFiles> dict) {
+            if (!dict.TryGetValue(oto.File, out IFrqFiles? frq)) {
+                var result = Load(oto.File, out frq);
+                if (result) {
+                    dict.Add(oto.File, frq!);
                 }
             }
-            if(frq != null && frq.wavSampleLength != - 1) {
-                this.hopSize = frq.hopSize;
 
-                if (frq.wavSampleLength == 0) {
+            if(frq != null) {
+                hopSize = frq.hopSize;
+                /*  Might be needed in the future if the frequency files of engines that can handle wav's other than 44100Hz are supported.
+                if (frq.wavSampleRate == 0) {
                     try {
                         using (var waveStream = Core.Format.Wave.OpenFile(oto.File)) {
                             var sampleProvider = waveStream.ToSampleProvider();
-                            if (sampleProvider.WaveFormat.SampleRate == 44100) {
-                                frq.wavSampleLength = Core.Format.Wave.GetSamples(sampleProvider).Length;
-                            } else {
-                                frq.wavSampleLength = -1;
-                            }
+                            frq.wavSampleRate = sampleProvider.WaveFormat.SampleRate;
                         }
                     } catch {
-                        frq.wavSampleLength = - 1;
+                        frq.wavSampleRate = 44100;
                     }
-                }
+                }*/
 
-                if (frq.wavSampleLength > 0) {
-                    int offset = (int)Math.Floor(oto.Offset * 44100 / 1000 / frq.hopSize); // frq samples
-                    int consonant = (int)Math.Floor((oto.Offset + oto.Consonant) * 44100 / 1000 / frq.hopSize);
-                    int cutoff = oto.Cutoff < 0 ?
-                        (int)Math.Floor((oto.Offset - oto.Cutoff) * 44100 / 1000 / frq.hopSize)
-                        : frq.wavSampleLength - (int)Math.Floor(oto.Cutoff * 44100 / 1000 / frq.hopSize);
-                    var completionF0 = Completion(frq.f0);
-                    var averageTone = MusicMath.FreqToTone(frq.averageF0);
-                    toneDiffFix = completionF0.Skip(offset).Take(consonant - offset).Select(f => MusicMath.FreqToTone(f) - averageTone).ToArray();
-                    toneDiffStretch = completionF0.Skip(consonant).Take(cutoff - consonant).Select(f => MusicMath.FreqToTone(f) - averageTone).ToArray();
+                int offset = ConvertMsToFrqLength(frq, oto.Offset);
+                int consonant = ConvertMsToFrqLength(frq, oto.Offset + oto.Consonant);
+                int cutoff = oto.Cutoff < 0 ?
+                    ConvertMsToFrqLength(frq, oto.Offset - oto.Cutoff)
+                    : frq.f0.Length - ConvertMsToFrqLength(frq, oto.Cutoff);
+                var completionF0 = Completion(frq.f0);
+                var averageTone = MusicMath.FreqToTone(frq.averageF0);
+                toneDiffFix = completionF0.Skip(offset).Take(consonant - offset).Select(f => MusicMath.FreqToTone(f) - averageTone).ToArray();
+                toneDiffStretch = completionF0.Skip(consonant).Take(cutoff - consonant).Select(f => MusicMath.FreqToTone(f) - averageTone).ToArray();
 
-                    loaded = true;
-                }
+                loaded = true;
             }
         }
 
+        private bool Load(string otoPath, out IFrqFiles? frqFile) {
+            var frq = new Frq();
+            if (frq.Load(otoPath)) {
+                frqFile = frq;
+                return true;
+            }
+            // Please write a code to read other frequency files!
+
+            frqFile = null;
+            return false;
+        }
+
+        private int ConvertMsToFrqLength(IFrqFiles frq, double lengthMs) {
+            return (int)Math.Floor(lengthMs / 1000 * frq.wavSampleRate / frq.hopSize);
+        }
+
+        /// <summary>
+        /// When a pitch is out of tune, it is complemented by the preceding and following pitches.
+        /// </summary>
         private double[] Completion(double[] frqs) {
             var list = new List<double>();
             for (int i = 0; i < frqs.Length; i++) {
@@ -94,18 +106,27 @@ namespace OpenUtau.Classic {
         }
     }
 
-    public class Frq {
-        public const int kHopSize = 256;
-
-        public int hopSize;
-        public double averageF0;
-        public double[] f0 = new double[0];
-        public double[] amp = new double[0];
-        public int wavSampleLength = 0;
+    public interface IFrqFiles {
+        public int hopSize { get; }
+        public double averageF0 { get; }
+        public double[] f0 { get; }
+        public int wavSampleRate { get; set; }
 
         /// <summary>
         /// If the wav path is null (machine learning voicebank), return false.
-        /// <summary>
+        /// </summary>
+        public bool Load(string wavPath);
+    }
+
+    public class Frq : IFrqFiles {
+        public const int kHopSize = 256;
+
+        public int hopSize { get; private set; }
+        public double averageF0 { get; private set; }
+        public double[] f0 { get; private set; } = new double[0];
+        public double[] amp { get; private set; } = new double[0];
+        public int wavSampleRate { get; set; }
+
         public bool Load(string wavPath) {
             if (string.IsNullOrEmpty(wavPath)) {
                 return false;

--- a/OpenUtau.Core/Render/RenderPhrase.cs
+++ b/OpenUtau.Core/Render/RenderPhrase.cs
@@ -531,6 +531,13 @@ namespace OpenUtau.Core.Render {
                 }
             }
             cacheFiles.Clear();
+
+            if (singer is ClassicSinger cSinger && cSinger.Frqs != null) {
+                foreach (var oto in phones.Select(p => p.oto).Distinct()) {
+                    oto.Frq = null;
+                    cSinger.Frqs.Remove(oto.File);
+                }
+            }
         }
     }
 }

--- a/OpenUtau.Core/Ustx/USinger.cs
+++ b/OpenUtau.Core/Ustx/USinger.cs
@@ -52,7 +52,7 @@ namespace OpenUtau.Core.Ustx {
                 NotifyPropertyChanged(nameof(Overlap));
             }
         }
-        public OtoFrq Frq { get;set; }
+        public OtoFrq? Frq { get; set; }
         public List<string> SearchTerms { get; private set; }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
## Fixes:
- Fixed incorrect calculation of cutoffs.
- Faster by not loading the wav to calculate the cutoff length.

## Changes:
- When clear cache, frq are now cleared as well.
- Implemented an interface to allow future reading of pitches from other frequency files.