### PR TITLE
Added play file button to singers dialog

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -488,7 +488,8 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="singers.otoview.showall">Show All</system:String>
   <system:String x:Key="singers.otoview.zoomin">Zoom In</system:String>
   <system:String x:Key="singers.otoview.zoomout">Zoom Out</system:String>
-  <system:String x:Key="singers.playsample">Play sample</system:String>
+  <system:String x:Key="singers.playsample">Play Sample</system:String>
+  <system:String x:Key="singers.playselectedfile">Play Selected File</system:String>
   <system:String x:Key="singers.publish">Publish Singer</system:String>
   <system:String x:Key="singers.publish.description">Create an optimized zip package of your singer for distribution.</system:String>
   <system:String x:Key="singers.publish.ignoretypes">Ignore these file types during packaging (gitignore syntax):</system:String>

--- a/OpenUtau/Views/SingersDialog.axaml
+++ b/OpenUtau/Views/SingersDialog.axaml
@@ -27,9 +27,9 @@
       <RowDefinition Height="10"/>
     </Grid.RowDefinitions>
     <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="1*" MinWidth="495"/>
+      <ColumnDefinition Width="1*" MinWidth="555"/>
       <ColumnDefinition Width="10"/>
-      <ColumnDefinition Width="1*" MinWidth="340"/>
+      <ColumnDefinition Width="1*" MinWidth="300"/>
     </Grid.ColumnDefinitions>
     <Image Grid.Row="0" Width="100" Height="100" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,10,0,0" Source="{Binding Avatar}"/>
     <ComboBox Grid.Row="0" x:Name="name" HorizontalAlignment="Stretch" Margin="120,10,0,0" VerticalAlignment="Top"
@@ -144,7 +144,7 @@
     <StackPanel Grid.Row="0" Spacing="5" Margin="0,0,0,0" Height="20"
             Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Bottom">
       <Button Margin="0" Content="{DynamicResource singers.readme}" Click="OnOpenReadme"/>
-      <Button Margin="0" Content="{DynamicResource singers.playsample}" Click="OnPlaySample"/>
+      <Button Margin="0" Content="{DynamicResource singers.playsample}" Click="OnPlayCharacterSample"/>
     </StackPanel>
     <StackPanel Grid.Row="0" Grid.Column="2" Spacing="5" Margin="0" Height="20"
                 Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom">
@@ -240,20 +240,37 @@
     </StackPanel>
     <StackPanel Grid.Row="6" Grid.ColumnSpan="3" Margin="10,0" Orientation="Horizontal" Spacing="3"
                 HorizontalAlignment="Right">
-      <Border BorderThickness="1" CornerRadius="4" ClipToBounds="True"
-              BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}">
-        <ToggleButton Classes="normal" Background="Transparent" IsChecked="{Binding ZoomInMel}">
-          <Path Fill="{DynamicResource SystemControlForegroundBaseHighBrush}"
-                Data="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z">
-            <Path.RenderTransform>
-              <TransformGroup>
-                <ScaleTransform ScaleX=".75" ScaleY=".75" />
-                <TranslateTransform X="-1" Y="-1"/>
-              </TransformGroup>
-            </Path.RenderTransform>
-          </Path>
-        </ToggleButton>
-      </Border>
+        <Border BorderThickness="1" CornerRadius="4" ClipToBounds="True"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}">
+            <Button Margin="0" Padding="8,0,8,0" Classes="normal" Background="Transparent" Click="OnPlaySelectedFile">
+                <Button.Content>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                        <Path Fill="{DynamicResource SystemControlForegroundBaseHighBrush}" VerticalAlignment="Center" HorizontalAlignment="Center" Data="M 0 0 L 7 6.5 L 0 13 Z">
+                            <Path.RenderTransform>
+                                <TransformGroup>
+                                    <ScaleTransform ScaleX=".95" ScaleY=".95" />
+                                </TransformGroup>
+                            </Path.RenderTransform>
+                        </Path>
+                        <TextBlock Margin="6,0,0,0" Text="{DynamicResource singers.playselectedfile}" />
+                    </StackPanel>
+                </Button.Content>
+            </Button>
+        </Border>
+        <Border BorderThickness="1" CornerRadius="4" ClipToBounds="True"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}">
+            <ToggleButton Classes="normal" Background="Transparent" IsChecked="{Binding ZoomInMel}">
+                <Path Fill="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                    Data="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z">
+                    <Path.RenderTransform>
+                        <TransformGroup>
+                            <ScaleTransform ScaleX=".75" ScaleY=".75" />
+                            <TranslateTransform X="-1" Y="-1"/>
+                        </TransformGroup>
+                    </Path.RenderTransform>
+                </Path>
+            </ToggleButton>
+        </Border>
     </StackPanel>
     <StackPanel Grid.Row="8" Grid.ColumnSpan="3" Margin="10,0" Orientation="Horizontal" Spacing="3">
       <Border Margin="0" BorderThickness="1" CornerRadius="4"

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -326,11 +326,16 @@ namespace OpenUtau.App.Views {
             return null;
         }
 
-        public void OnPlaySample(object sender, RoutedEventArgs e) {
+        public void OnPlayCharacterSample(object sender, RoutedEventArgs e) {
             var viewModel = (DataContext as SingersViewModel)!;
             var playBack = PlaybackManager.Inst.AudioOutput;
             var playbackState = playBack.PlaybackState;
             if (viewModel.Singer != null) {
+                // Stop other sounds to play sample
+                if (playbackState == PlaybackState.Playing) {
+                    playBack.Stop();
+                }
+
                 var sample = FindSample(viewModel.Singer);
                 if(sample == null){
                     return;
@@ -343,10 +348,31 @@ namespace OpenUtau.App.Views {
                     return;
                 }
                 playBack.Play();
-                if (playbackState == PlaybackState.Playing) {
-                    playBack.Stop();
-                }
             }
+        }
+
+        public void OnPlaySelectedFile(object sender, RoutedEventArgs e) {
+            var oto = OtoGrid?.SelectedItem as UOto;
+            if (oto == null) {
+                return;
+            }
+
+            var playBack = PlaybackManager.Inst.AudioOutput;
+            var playbackState = playBack.PlaybackState;
+
+            // If currently playing something, stop it to play sample right away
+            if (playbackState == PlaybackState.Playing) {
+                playBack.Stop();
+            }
+
+            try {
+                var playSound = Wave.OpenFile(oto.File);
+                playBack.Init(playSound.ToSampleProvider());
+            } catch (Exception ex) {
+                Log.Error(ex, $"Failed to load sample {oto.File}.");
+                return;
+            }
+            playBack.Play();
         }
 
         void RegenFrq(object sender, RoutedEventArgs args) {


### PR DESCRIPTION
This PR adds a new button to the Singers dialog located below the spectrogram which plays the currently selected file for quick reference.

![image](https://github.com/user-attachments/assets/5e07f6ce-f93b-4f05-8266-362cde140a25)
