### PR TITLE
Use Wine directly instead of wrappers on Mac and Linux

### DIFF
--- a/OpenUtau.Core/Classic/ExeInstaller.cs
+++ b/OpenUtau.Core/Classic/ExeInstaller.cs
@@ -15,16 +15,6 @@ namespace Classic {
                 : PathManager.Inst.ResamplersPath;
             string destName = Path.Combine(destPath, fileName);
             File.Copy(filePath, destName, true);
-            
-            if (OS.IsMacOS()) {
-                //reference: https://github.com/stakira/OpenUtau/wiki/Resamplers-and-Wavtools#macos
-                string MacWrapper = $"#!/bin/sh\r\nRELPATH=\"{fileName}\"\r\n\r\nABSPATH=$(cd \"$(dirname \"$0\")\"; pwd -P)\r\nABSPATH=\"$ABSPATH/$RELPATH\"\r\nif [[ ! -x \"$ABSPATH\" ]]\r\nthen\r\n    chmod +x \"$ABSPATH\"\r\nfi\r\nexec /usr/local/bin/wine32on64 \"$ABSPATH\" \"$@\"";
-                File.WriteAllText(Path.ChangeExtension(destName, ".sh"), MacWrapper, new UTF8Encoding(false));
-            } else if (OS.IsLinux()) {
-                //reference: https://github.com/stakira/OpenUtau/wiki/Resamplers-and-Wavtools#linux
-                string LinuxWrapper = $"#!/bin/bash\r\nLANG=\"ja_JP.UTF8\" wine \"{destName}\" \"${{@,-1}}\"";
-                File.WriteAllText(Path.ChangeExtension(destName, null), LinuxWrapper, new UTF8Encoding(false));
-            }
 
             new Task(() => {
                 DocManager.Inst.ExecuteCmd(new SingersChangedNotification());

--- a/OpenUtau.Core/Classic/Plugin.cs
+++ b/OpenUtau.Core/Classic/Plugin.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using OpenUtau.Core.Util;
 
 namespace OpenUtau.Classic {
     public class Plugin : IPlugin {
@@ -16,9 +17,12 @@ namespace OpenUtau.Classic {
             if (!File.Exists(Executable)) {
                 throw new FileNotFoundException($"Executable {Executable} not found.");
             }
+            string winePath = Preferences.Default.WinePath;
+            bool useWine = !OS.IsWindows() && !string.IsNullOrEmpty(winePath);
             var startInfo = new ProcessStartInfo() {
-                FileName = Executable,
-                Arguments = $"\"{tempFile}\"",
+                FileName = useWine ? winePath : Executable,
+                Arguments = useWine ? $"\"{Executable}\" \"{tempFile}\"" : $"\"{tempFile}\"",
+                Environment = {{"LANG", "ja_JP.utf8"}},
                 WorkingDirectory = Path.GetDirectoryName(Executable),
                 UseShellExecute = UseShell,
             };

--- a/OpenUtau.Core/Classic/ToolsManager.cs
+++ b/OpenUtau.Core/Classic/ToolsManager.cs
@@ -38,14 +38,10 @@ namespace OpenUtau.Classic {
                 return null;
             }
             string ext = Path.GetExtension(filePath).ToLower();
-            if (OS.IsWindows()) {
-                if (ext == ".exe" || ext == ".bat") {
-                    return new ExeResampler(filePath, basePath);
-                }
-            } else {
-                if (ext == ".sh" || string.IsNullOrEmpty(ext)) {
-                    return new ExeResampler(filePath, basePath);
-                }
+            if ((OS.IsWindows() || !string.IsNullOrEmpty(Preferences.Default.WinePath)) && (ext == ".exe" || ext == ".bat")) {
+                return new ExeResampler(filePath, basePath);
+            } else if (ext == ".sh" || string.IsNullOrEmpty(ext)) {
+                return new ExeResampler(filePath, basePath);
             }
             return null;
         }
@@ -55,14 +51,10 @@ namespace OpenUtau.Classic {
                 return null;
             }
             string ext = Path.GetExtension(filePath).ToLower();
-            if (OS.IsWindows()) {
-                if (ext == ".exe" || ext == ".bat") {
-                    return new ExeWavtool(filePath, basePath);
-                }
-            } else {
-                if (ext == ".sh" || string.IsNullOrEmpty(ext)) {
-                    return new ExeWavtool(filePath, basePath);
-                }
+            if ((OS.IsWindows() || !string.IsNullOrEmpty(Preferences.Default.WinePath)) && (ext == ".exe" || ext == ".bat")) {
+                return new ExeWavtool(filePath, basePath);
+            } else if (ext == ".sh" || string.IsNullOrEmpty(ext)) {
+                return new ExeWavtool(filePath, basePath);
             }
             return null;
         }

--- a/OpenUtau.Core/Classic/ToolsManager.cs
+++ b/OpenUtau.Core/Classic/ToolsManager.cs
@@ -40,7 +40,8 @@ namespace OpenUtau.Classic {
             string ext = Path.GetExtension(filePath).ToLower();
             if ((OS.IsWindows() || !string.IsNullOrEmpty(Preferences.Default.WinePath)) && (ext == ".exe" || ext == ".bat")) {
                 return new ExeResampler(filePath, basePath);
-            } else if (ext == ".sh" || string.IsNullOrEmpty(ext)) {
+            } 
+            if (!OS.IsWindows() && (ext == ".sh" || string.IsNullOrEmpty(ext))) {
                 return new ExeResampler(filePath, basePath);
             }
             return null;
@@ -53,7 +54,8 @@ namespace OpenUtau.Classic {
             string ext = Path.GetExtension(filePath).ToLower();
             if ((OS.IsWindows() || !string.IsNullOrEmpty(Preferences.Default.WinePath)) && (ext == ".exe" || ext == ".bat")) {
                 return new ExeWavtool(filePath, basePath);
-            } else if (ext == ".sh" || string.IsNullOrEmpty(ext)) {
+            } 
+            if (!OS.IsWindows() && (ext == ".sh" || string.IsNullOrEmpty(ext))) {
                 return new ExeWavtool(filePath, basePath);
             }
             return null;

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -189,6 +189,7 @@ namespace OpenUtau.Core.Util {
             public bool RememberUst = true;
             public bool RememberVsqx = true;
             public int ImportTempo = 0;
+            public string WinePath = string.Empty;
             public string PhoneticAssistant = string.Empty;
             public string RecentOpenSingerDirectory = string.Empty;
             public string RecentOpenProjectDirectory = string.Empty;

--- a/OpenUtau.Core/Util/ProcessRunner.cs
+++ b/OpenUtau.Core/Util/ProcessRunner.cs
@@ -14,6 +14,7 @@ namespace OpenUtau.Core.Util {
             var threadId = Thread.CurrentThread.ManagedThreadId;
             using (var proc = new Process()) {
                 proc.StartInfo = new ProcessStartInfo(file, args) {
+                    Environment = {{"LANG", "ja_JP.utf8"}},
                     UseShellExecute = false,
                     RedirectStandardOutput = DebugSwitch,
                     RedirectStandardError = true,

--- a/OpenUtau/FilePicker.cs
+++ b/OpenUtau/FilePicker.cs
@@ -56,6 +56,10 @@ namespace OpenUtau.App {
         public static FilePickerFileType OUDEP { get; } = new("OpenUtau dependency") {
             Patterns = new[] { "*.oudep" },
         };
+        public static FilePickerFileType UnixExecutable { get; } = new("Executable") {
+            MimeTypes = new[] { "application/x-executable" },
+            AppleUniformTypeIdentifiers = new[] { "public.unix-executable" },
+        };
 
         public async static Task<string?> OpenFile(
             Window window, string titleKey, params FilePickerFileType[] types) {

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -383,6 +383,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.advanced.resamplerlogging.warn">Stores resampler output in log files. This option slows down UI and rendering.</system:String>
   <system:String x:Key="prefs.advanced.stable">Stable</system:String>
   <system:String x:Key="prefs.advanced.vlabelerpath">vLabeler Path</system:String>
+  <system:String x:Key="prefs.advanced.winepath">Wine Path (set to enable wine for compatibility)</system:String>
   <system:String x:Key="prefs.appearance">Appearance</system:String>
   <system:String x:Key="prefs.appearance.degree">Scale degree display style</system:String>
   <system:String x:Key="prefs.appearance.degree.numbered">Numbered (1 2 3 4 5 6 7)</system:String>
@@ -416,6 +417,7 @@ Warning: this option removes custom presets.</system:String>
   <system:String x:Key="prefs.paths.loaddeepfolders">Load all depth folders</system:String>
   <system:String x:Key="prefs.paths.reset">Reset</system:String>
   <system:String x:Key="prefs.paths.select">Select</system:String>
+  <system:String x:Key="prefs.paths.detect">Detect</system:String>
   <system:String x:Key="prefs.penplus">Set Pen Plus Tool as Default</system:String>
   <system:String x:Key="prefs.playback">Playback</system:String>
   <system:String x:Key="prefs.playback.autoscroll">Auto-Scroll</system:String>

--- a/OpenUtau/ViewModels/ExeSetupViewModel.cs
+++ b/OpenUtau/ViewModels/ExeSetupViewModel.cs
@@ -6,13 +6,17 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public string message { get; set; }
         public ExeSetupViewModel(string filePath) {
             this.filePath = filePath;
-            message = "installing " + filePath;
+            message = $"Installing {filePath}...\n\n";
             if (OS.IsMacOS()) {
-                message += "To use exe resamplers or wavtools on MacOS, please install wine32on64 using following commands:\n"
-                    + "brew tap gcenx/wine\n"
-                    + "brew install --cask --no-quarantine wine-crossover";
-            }else if(OS.IsLinux()) {
-                message += "To use exe resamplers or wavtools on Linux, please install wine from https://www.winehq.org/";
+                message += "To use exe resamplers or wavtools on MacOS:\n"
+                    + "1. Install wine using following commands:\n"
+                    + "      % brew tap gcenx/wine\n"
+                    + "      % brew install --cask --no-quarantine wine-crossover\n"
+                    + "2. Set wine path in Preferences > Advanced > Wine Path";
+            } else if(OS.IsLinux()) {
+                message += "To use exe resamplers or wavtools on Linux:\n"
+                    + "1. Install wine from https://www.winehq.org/\n" 
+                    + "2. Set wine path in Preferences > Advanced > Wine Path";
             }
         }
     }

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -60,6 +60,7 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public int OtoEditor { get; set; }
         public string VLabelerPath => Preferences.Default.VLabelerPath;
         public string SetParamPath => Preferences.Default.SetParamPath;
+        public string WinePath => Preferences.Default.WinePath;
         [Reactive] public bool ClearCacheOnQuit { get; set; }
         public int LogicalCoreCount {
             get => Environment.ProcessorCount;
@@ -403,6 +404,13 @@ namespace OpenUtau.App.ViewModels {
             Preferences.Default.SetParamPath = path;
             Preferences.Save();
             this.RaisePropertyChanged(nameof(SetParamPath));
+        }
+
+        public void SetWinePath(string path) {
+            Preferences.Default.WinePath = path;
+            Preferences.Save();
+            ToolsManager.Inst.Initialize();
+            this.RaisePropertyChanged(nameof(WinePath));
         }
     }
 }

--- a/OpenUtau/Views/ExeSetupDialog.axaml
+++ b/OpenUtau/Views/ExeSetupDialog.axaml
@@ -2,7 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" Width="400" Height="200"
+        mc:Ignorable="d" Width="400" Height="220"
         x:Class="OpenUtau.App.Views.ExeSetupDialog"
         Icon="/Assets/open-utau.ico"
         Title="Installing exe">

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -296,6 +296,20 @@
             <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.never}"/>
             <ComboBoxItem Content="{DynamicResource prefs.advanced.importtempo.ask}"/>
           </ComboBox>
+          <TextBlock Text="{DynamicResource prefs.advanced.winepath}" 
+                      IsVisible="{OnPlatform Windows=False, Default=True}" Margin="0,10,0,0"/>
+          <TextBlock HorizontalAlignment="Stretch" Margin="4"
+                      TextWrapping="Wrap" FontSize="11" Text="{Binding WinePath}"
+                      IsVisible="{OnPlatform Windows=False, Default=True}" />
+          <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*,10,*"
+                IsVisible="{OnPlatform Windows=False, Default=True}">
+            <Button Grid.Column="0" Content="{DynamicResource prefs.paths.reset}"
+                    HorizontalAlignment="Stretch" Click="ResetWinePath"/>
+            <Button Grid.Column="2" Content="{DynamicResource prefs.paths.select}"
+                    HorizontalAlignment="Stretch" Click="SelectWinePath"/>
+            <Button Grid.Column="4" Content="{DynamicResource prefs.paths.detect}"
+                    HorizontalAlignment="Stretch" Click="DetectWinePath"/>
+          </Grid>
         </StackPanel>
       </Carousel>
     </ScrollViewer>

--- a/OpenUtau/Views/PreferencesDialog.axaml.cs
+++ b/OpenUtau/Views/PreferencesDialog.axaml.cs
@@ -63,5 +63,37 @@ namespace OpenUtau.App.Views {
                 ((PreferencesViewModel)DataContext!).SetSetParamPath(path);
             }
         }
+
+        void ResetWinePath(object sender, RoutedEventArgs e) {
+            ((PreferencesViewModel)DataContext!).SetWinePath(string.Empty);
+        }
+
+        async void SelectWinePath(object sender, RoutedEventArgs e) {
+            var path = await FilePicker.OpenFile(this, "prefs.advanced.winepath", FilePicker.UnixExecutable);
+            if (string.IsNullOrEmpty(path)) {
+                return;
+            }
+            if (File.Exists(path)) {
+                ((PreferencesViewModel)DataContext!).SetWinePath(path);
+            }
+        }
+
+        void DetectWinePath(object sender, RoutedEventArgs e) {
+            string[] wineNames = { "wine", "wine64", "wine32", "wine32on64" };
+            string winePath = string.Empty;
+
+            foreach (string wineName in wineNames) {
+                winePath = OS.WhereIs(wineName);
+                if (!string.IsNullOrEmpty(winePath)) {
+                    break;
+                }
+            }
+
+            if (string.IsNullOrEmpty(winePath)) {
+                return;
+            }
+
+            ((PreferencesViewModel)DataContext!).SetWinePath(winePath);
+        }
     }
 }


### PR DESCRIPTION
Changes:
- Add Wine Path setting in preferences

![image](https://github.com/user-attachments/assets/6e73ba9b-b036-4155-9be2-ddea1cff3c60)

- Use Wine directly when rendering using windows only resamplers and wavtools

https://github.com/user-attachments/assets/80186081-3617-41ca-b538-b8bef53b333e

- Add Support for Legacy Plugins on Mac and Linux

https://github.com/user-attachments/assets/70156715-4d30-4113-bcdd-492d7f5db7bc

- Add Support for Wavtools on Mac

Extra:
- Add Unix Executable in FilePicker file types.

---
Special thanks to @kkgarfin for testing this on Mac.