### PR TITLE
[DiffSinger] Fix weired error message

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -40,9 +40,8 @@ namespace OpenUtau.Core.DiffSinger
             }
             //Load language id if needed
             if(dsConfig.use_lang_id){
-                if(dsConfig.languages == null){
-                    Log.Error("\"languages\" field is not specified in dsconfig.yaml");
-                    return;
+                if(dsConfig.languages == null) {
+                    throw new Exception("\"languages\" field is not specified in dsconfig.yaml");
                 }
                 var langIdPath = Path.Join(rootPath, dsConfig.languages);
                 try {
@@ -53,9 +52,15 @@ namespace OpenUtau.Core.DiffSinger
                 }
             }
             //Load phonemes list
+            if (dsConfig.phonemes == null) {
+                throw new Exception("Configuration key \"phonemes\" is null.");
+            }
             string phonemesPath = Path.Combine(rootPath, dsConfig.phonemes);
             phonemeTokens = DiffSingerUtils.LoadPhonemes(phonemesPath);
             //Load models
+            if (dsConfig.linguistic == null) {
+                throw new Exception("Configuration key \"linguistic\" is null.");
+            }
             var linguisticModelPath = Path.Join(rootPath, dsConfig.linguistic);
             var linguisticModelBytes = File.ReadAllBytes(linguisticModelPath);
             linguisticHash = XXH64.DigestOf(linguisticModelBytes);

--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -186,7 +186,6 @@ namespace OpenUtau.Core.DiffSinger {
             if(pitchPredictor is null) {
                 if(HasPitchPredictor){
                     pitchPredictor = new DsPitch(Path.Join(Location, "dspitch"));
-                    return pitchPredictor;
                 }
             }
             return pitchPredictor;
@@ -203,7 +202,6 @@ namespace OpenUtau.Core.DiffSinger {
             if(variancePredictor is null) {
                 if(HasVariancePredictor){
                     variancePredictor = new DsVariance(Path.Join(Location, "dsvariance"));
-                    return variancePredictor;
                 }
             }
             return variancePredictor;

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -42,11 +42,13 @@ namespace OpenUtau.Core.DiffSinger{
             dsConfig = Yaml.DefaultDeserializer.Deserialize<DsConfig>(
                 File.ReadAllText(Path.Combine(rootPath, "dsconfig.yaml"),
                     Encoding.UTF8));
+            if(dsConfig.variance == null){
+                throw new Exception("This voicebank doesn't contain a variance model");
+            }
             //Load language id if needed
             if(dsConfig.use_lang_id){
                 if(dsConfig.languages == null){
-                    Log.Error("\"languages\" field is not specified in dsconfig.yaml");
-                    return;
+                    throw new Exception("\"languages\" field is not specified in dsconfig.yaml");
                 }
                 var langIdPath = Path.Join(rootPath, dsConfig.languages);
                 try {
@@ -57,9 +59,15 @@ namespace OpenUtau.Core.DiffSinger{
                 }
             }
             //Load phonemes list
+            if (dsConfig.phonemes == null) {
+                throw new Exception("Configuration key \"phonemes\" is null.");
+            }
             string phonemesPath = Path.Combine(rootPath, dsConfig.phonemes);
             phonemeTokens = DiffSingerUtils.LoadPhonemes(phonemesPath);
             //Load models
+            if (dsConfig.linguistic == null) {
+                throw new Exception("Configuration key \"linguistic\" is null.");
+            }
             var linguisticModelPath = Path.Join(rootPath, dsConfig.linguistic);
             var linguisticModelBytes = File.ReadAllBytes(linguisticModelPath);
             linguisticHash = XXH64.DigestOf(linguisticModelBytes);


### PR DESCRIPTION
When a path string is `Path.Join`ed with a null value, the result is the original path itself, with no exception raised. In DiffSinger config file, some model path is obtained by joining a directory and a relative path. If the relative path is not given or is null, the result will be a directory rather than a file. When OpenUTAU attempts to read bytes from it, an exception is raised saying "Access to path ... is denied."

![9F48B73AF088B5452C813AE0733983E7](https://github.com/user-attachments/assets/fc0cd67e-af87-4469-95b4-548caa3ba10f)

This PR adds checks for null relative paths to give user a more understandable message about the root cause.
