### PR TITLE
Fix manifest loading

### DIFF
--- a/OpenUtau.Core/Classic/ResamplerManifest.cs
+++ b/OpenUtau.Core/Classic/ResamplerManifest.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
@@ -13,9 +13,16 @@ namespace OpenUtau.Classic {
         public ResamplerManifest() { }
 
         public static ResamplerManifest Load(string path) {
-            return Yaml.DefaultDeserializer.Deserialize<ResamplerManifest>(
+            var manifest = Yaml.DefaultDeserializer.Deserialize<ResamplerManifest>(
                 File.ReadAllText(path, encoding: Encoding.UTF8)
                 );
+            manifest.expressions = manifest.expressions
+                                .GroupBy(kvp => kvp.Key.ToLower())
+                                .ToDictionary(
+                                    group => group.Key,
+                                    group => group.First().Value
+                                );
+            return manifest;
         }
     }
 }


### PR DESCRIPTION
Convert the key for the expression settings in Manifest to lowercase and load the expression settings.

Fixed an issue where the key (`abbr`) of the ExpressionDescriptor in `Resampler Manifest` did not match the `abbr` of the ExpressionDescriptor loaded into the project.

This fixes an issue where manually corrected or manually created `expression_filter` in `Resampler Manifest` did not work as intended.