### PR TITLE
fix osx upload-artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,8 +125,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: OpenUtau-osx-${{ matrix.arch.name }}.dmg
-          path: OpenUtau-osx-${{ matrix.arch.name }}.dmg
+          name: OpenUtau-${{ matrix.arch.name }}.dmg
+          path: OpenUtau-${{ matrix.arch.name }}.dmg
         if: ${{ !inputs.release && matrix.arch.os == 'osx' }}
 
       # Appcast


### PR DESCRIPTION
Before: 
```bash
Run actions/upload-artifact@v4
  with:
    name: OpenUtau-osx-osx-arm64.dmg
    path: OpenUtau-osx-osx-arm64.dmg

Warning: No files were found with the provided path: OpenUtau-osx-osx-arm64.dmg. No artifacts will be uploaded.
```

Removed the extra ```osx-``` in ```build.yaml``` to correctly match the generated artifact file name.