### PR TITLE
Beta won't ask for downgrading to stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,9 @@ jobs:
         run: dotnet publish OpenUtau -c Release -r ${{ matrix.arch.rid }} --self-contained true -o bin/${{ matrix.arch.name }}/
         if: ${{ matrix.arch.os != 'osx' }}
 
+      - name: Write release channel info
+        run: echo "${{ inputs.beta && 'beta' || 'stable' }}" > bin/${{ matrix.arch.name }}/release-channel.txt
+
       # Create Zip
       - name: DirectML
         shell: cmd

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -28,6 +29,20 @@ namespace OpenUtau.Core.Util {
 
         public static void Reset() {
             Default = new SerializablePreferences();
+            try
+            {
+                string exePath = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+                string releaseChannelPath = Path.Combine(exePath, "release-channel.txt");
+                if (File.Exists(releaseChannelPath)) {
+                    string channel = File.ReadAllText(releaseChannelPath);
+                    if (channel == "beta")
+                    {
+                        Default.Beta = true;
+                    }
+                }
+            } catch(Exception e){
+                Log.Error(e, "Failed to load release-channel.txt");
+            }
             Save();
         }
 


### PR DESCRIPTION
Before this PR, if the user downloaded the beta version from GitHub, it will ask the user to "upgrade" to the stable release, which is misleading, especially for diffsinger users who have to use beta version.
After this PR, beta packages downloaded from GitHub will default to beta release channel.