### PR TITLE
Fix unable to load empty ust

### DIFF
--- a/OpenUtau.Core/Classic/Ust.cs
+++ b/OpenUtau.Core/Classic/Ust.cs
@@ -82,7 +82,7 @@ namespace OpenUtau.Classic {
 
             var blocks = Ini.ReadBlocks(reader, file, @"\[#\w+\]");
             ParsePart(project, part, blocks);
-            part.Duration = part.notes.Select(note => note.End).Max() + project.resolution;
+            part.Duration = part.notes.LastOrDefault()?.End ?? 0 + project.resolution;
 
             return project;
         }


### PR DESCRIPTION
Before this PR, when importing an empty ust into OpenUtau, it will say "Failed to open"
Though no one would actually import an empty ust into OpenUtau, it should be fixed.

![image](https://github.com/user-attachments/assets/0c3e9681-4863-4e8b-a4fc-4704ef47ddee)
