### PR TITLE
Translate Exe Setup Dialog

### DIFF
--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -97,6 +97,17 @@
   <system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>
 
+  <system:String x:Key="exesetup.installing">Installing "{0}"...</system:String>
+  <system:String x:Key="exesetup.linux">To use exe resamplers or wavtools on Linux:
+1. Install wine from {0}
+2. Set wine path in Preferences > Advanced > Wine Path</system:String>
+  <system:String x:Key="exesetup.mac">To use exe resamplers or wavtools on MacOS:
+1. Install wine using following commands
+2. Set wine path in Preferences > Advanced > Wine Path</system:String>
+  <system:String x:Key="exesetup.resampler">Install as resampler</system:String>
+  <system:String x:Key="exesetup.title">Installing Exe File</system:String>
+  <system:String x:Key="exesetup.wavtool">Install as wavtool</system:String>
+  
   <system:String x:Key="exps.abbr">Abbreviation</system:String>
   <system:String x:Key="exps.apply">Apply</system:String>
   <system:String x:Key="exps.caption">Expressions</system:String>

--- a/OpenUtau/ViewModels/ExeSetupViewModel.cs
+++ b/OpenUtau/ViewModels/ExeSetupViewModel.cs
@@ -6,17 +6,11 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public string message { get; set; }
         public ExeSetupViewModel(string filePath) {
             this.filePath = filePath;
-            message = $"Installing {filePath}...\n\n";
+            message = string.Format(ThemeManager.GetString("exesetup.installing"), filePath);
             if (OS.IsMacOS()) {
-                message += "To use exe resamplers or wavtools on MacOS:\n"
-                    + "1. Install wine using following commands:\n"
-                    + "      % brew tap gcenx/wine\n"
-                    + "      % brew install --cask --no-quarantine wine-crossover\n"
-                    + "2. Set wine path in Preferences > Advanced > Wine Path";
+                message += "\n\n" + ThemeManager.GetString("exesetup.mac");
             } else if(OS.IsLinux()) {
-                message += "To use exe resamplers or wavtools on Linux:\n"
-                    + "1. Install wine from https://www.winehq.org/\n" 
-                    + "2. Set wine path in Preferences > Advanced > Wine Path";
+                message += "\n\n" + string.Format(ThemeManager.GetString("exesetup.linux"), "https://www.winehq.org/");
             }
         }
     }

--- a/OpenUtau/Views/ExeSetupDialog.axaml
+++ b/OpenUtau/Views/ExeSetupDialog.axaml
@@ -2,17 +2,20 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" Width="400" Height="220"
+        mc:Ignorable="d" SizeToContent="WidthAndHeight"
         x:Class="OpenUtau.App.Views.ExeSetupDialog"
         Icon="/Assets/open-utau.ico"
-        Title="Installing exe">
-  <Grid Margin="{Binding $parent.WindowDecorationMargin}">
+        Title="{DynamicResource exesetup.title}">
+  <Grid Margin="10">
     <Grid.RowDefinitions>
       <RowDefinition Height="*"/>
+      <RowDefinition Height="Auto"/>
       <RowDefinition Height="50"/>
     </Grid.RowDefinitions>
     <TextBlock Margin="20" Grid.Row="0" HorizontalAlignment="Center" VerticalAlignment="Center" Name="Text" TextWrapping="Wrap" MaxWidth="560" Text="{Binding message}"/>
-    <StackPanel Grid.Row="1" HorizontalAlignment="Center" Orientation="Horizontal" Name="Buttons">
+    <TextBox Margin="30,0,30,20" Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{OnPlatform False, macOS=True}" TextWrapping="Wrap" Height="36"
+             Text="% brew tap gcenx/wine&#x0a;% brew install --cask --no-quarantine wine-crossover" />
+    <StackPanel Grid.Row="2" HorizontalAlignment="Center" Orientation="Horizontal" Name="Buttons">
       <StackPanel.Styles>
         <Style Selector="Button">
           <Setter Property="Margin" Value="15,0,15,0"/>
@@ -22,8 +25,8 @@
           <Setter Property="TextAlignment" Value="Center"/>
         </Style>
       </StackPanel.Styles>
-      <Button Click="InstallAsResampler">Install as resampler</Button>
-      <Button Click="InstallAsWavtool">Install as wavtool</Button>
+      <Button Click="InstallAsResampler" Content="{DynamicResource exesetup.resampler}"/>
+      <Button Click="InstallAsWavtool" Content="{DynamicResource exesetup.wavtool}"/>
     </StackPanel>
   </Grid>
 </Window>


### PR DESCRIPTION
- Exe Setup Dialog can now be translated.
- Changed to show commands for MacOS in TextBox so that they can be copied.
![image](https://github.com/user-attachments/assets/ce81f66d-db84-4e7d-9624-5c946e110200)
