### PR TITLE
Fix OpenUtau crashing when oto.ini contains two `#Charset:` lines

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -316,6 +316,10 @@ namespace OpenUtau.Classic {
 
         public static OtoSet ParseOtoSet(string filePath, Encoding encoding, bool? useFilenameAsAlias) {
             try {
+                var otoDeclaredEncoding = GetOtoDeclaredEncoding(filePath);
+                if (otoDeclaredEncoding != null) {
+                    encoding = otoDeclaredEncoding;
+                }
                 using (var stream = File.OpenRead(filePath)) {
                     var otoSet = ParseOtoSet(stream, filePath, encoding);
                     if (!IsTest) {
@@ -356,10 +360,6 @@ namespace OpenUtau.Classic {
 
         public static OtoSet ParseOtoSet(Stream stream, string filePath, Encoding encoding) {
             OtoSet otoSet;
-            var otoDeclaredEncoding = GetOtoDeclaredEncoding(filePath);
-            if (otoDeclaredEncoding != null) {
-                encoding = otoDeclaredEncoding;
-            }
             using (var reader = new StreamReader(stream, encoding)) {
                 var trace = new FileTrace { file = filePath, lineNumber = 0 };
                 otoSet = new OtoSet() {

--- a/OpenUtau.Core/Classic/VoicebankLoader.cs
+++ b/OpenUtau.Core/Classic/VoicebankLoader.cs
@@ -333,8 +333,33 @@ namespace OpenUtau.Classic {
             return null;
         }
 
+        // Oto.ini can declare its own encoding at the beginning of the file with #Charset:
+        static Encoding? GetOtoDeclaredEncoding(string filePath) {
+            using (var reader = new StreamReader(filePath, Encoding.GetEncoding("shift_jis"))) {
+                for (var i = 0; i < 10; i++) {
+                    var line = reader.ReadLine();
+                    if (line == null) {
+                        break;
+                    }
+                    line = line.Trim();
+                    if (line.StartsWith("#Charset:")) {
+                        try {
+                            return Encoding.GetEncoding(line.Replace("#Charset:", ""));
+                        } catch (ArgumentException) {
+                            return null;
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
         public static OtoSet ParseOtoSet(Stream stream, string filePath, Encoding encoding) {
             OtoSet otoSet;
+            var otoDeclaredEncoding = GetOtoDeclaredEncoding(filePath);
+            if (otoDeclaredEncoding != null) {
+                encoding = otoDeclaredEncoding;
+            }
             using (var reader = new StreamReader(stream, encoding)) {
                 var trace = new FileTrace { file = filePath, lineNumber = 0 };
                 otoSet = new OtoSet() {
@@ -342,15 +367,6 @@ namespace OpenUtau.Classic {
                 };
                 while (!reader.EndOfStream) {
                     var line = reader.ReadLine().Trim();
-                    if (line.StartsWith("#Charset:")) {
-                        try {
-                            var charset = Encoding.GetEncoding(line.Replace("#Charset:", ""));
-                            if (encoding != charset) {
-                                stream.Position = 0;
-                                return ParseOtoSet(stream, filePath, charset);
-                            }
-                        } catch { }
-                    }
                     trace.line = line;
                     try {
                         Oto oto = ParseOto(line, trace);


### PR DESCRIPTION
Before this change, if the oto.ini contains two `#Charset:` lines that declare different encodings, OpenUtau will crash. After this change, it will only use the first `#Charset:` line.

(Like the empty ust pr #1594, this is a case that users won't actually meet in daily usage, but it should still be handled correctly rather than crashing the entire OpenUtau.)

