### PR TITLE
Oto validation before worldline rendering

### DIFF
--- a/OpenUtau.Core/Classic/WorldlineRenderer.cs
+++ b/OpenUtau.Core/Classic/WorldlineRenderer.cs
@@ -76,7 +76,23 @@ namespace OpenUtau.Classic {
                         double lengthMs = item.phone.envelope[4].X - item.phone.envelope[0].X;
                         double fadeInMs = item.phone.envelope[1].X - item.phone.envelope[0].X;
                         double fadeOutMs = item.phone.envelope[4].X - item.phone.envelope[3].X;
-                        phraseSynth.AddRequest(item, posMs, skipMs, lengthMs, fadeInMs, fadeOutMs);
+                        try {
+                            phraseSynth.AddRequest(item, posMs, skipMs, lengthMs, fadeInMs, fadeOutMs);
+                        } catch (SynthRequestError e) {
+                            if(e is CutOffExceedDurationError cee) {
+                                throw new MessageCustomizableException(
+                                    $"Failed to render\n Oto error: cutoff exceeds audio duration \n{item.phone.phoneme}",
+                                    $"<translate:errors.failed.synth.cutoffexceedduration>\n{item.phone.phoneme}",
+                                    e);
+                            }
+                            if(e is CutOffBeforeOffsetError cbe) {
+                                throw new MessageCustomizableException(
+                                    $"Failed to render\n Oto error: cutoff before offset \n{item.phone.phoneme}",
+                                    $"<translate:errors.failed.synth.cutoffbeforeoffset>\n{item.phone.phoneme}",
+                                    e);
+                            }
+                            throw e;
+                        }
                     }
                     int frames = (int)Math.Ceiling(result.estimatedLengthMs / frameMs);
                     var f0 = SampleCurve(phrase, phrase.pitches, 0, frames, x => MusicMath.ToneToFreq(x * 0.01));

--- a/OpenUtau.Core/Classic/WorldlineResampler.cs
+++ b/OpenUtau.Core/Classic/WorldlineResampler.cs
@@ -16,7 +16,23 @@ namespace OpenUtau.Classic {
         }
 
         public float[] DoResampler(ResamplerItem item, ILogger logger) {
-            return Worldline.Resample(item);
+            try {
+                return Worldline.Resample(item);
+            } catch (SynthRequestError e) {
+                if (e is CutOffExceedDurationError cee) {
+                    throw new MessageCustomizableException(
+                        $"Failed to render\n Oto error: cutoff exceeds audio duration \n{item.phone.phoneme}",
+                        $"<translate:errors.failed.synth.cutoffexceedduration>\n{item.phone.phoneme}",
+                        e);
+                }
+                if (e is CutOffBeforeOffsetError cbe) {
+                    throw new MessageCustomizableException(
+                        $"Failed to render\n Oto error: cutoff before offset \n{item.phone.phoneme}",
+                        $"<translate:errors.failed.synth.cutoffbeforeoffset>\n{item.phone.phoneme}",
+                        e);
+                }
+                throw e;
+            }
         }
 
         public string DoResamplerReturnsFile(ResamplerItem item, ILogger logger) {

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -93,6 +93,8 @@
   <system:String x:Key="errors.failed.save">Failed to save</system:String>
   <system:String x:Key="errors.failed.savesingerconfig">Failed to save singer config file</system:String>
   <system:String x:Key="errors.failed.searchsinger">Failed to search singers</system:String>
+  <system:String x:Key="errors.failed.synth.cutoffbeforeoffset">Oto error: cutoff before offset</system:String>
+  <system:String x:Key="errors.failed.synth.cutoffexceedduration">Oto error: cutoff exceeds audio duration</system:String>
   <system:String x:Key="errors.install.cpp">Try installing the latest Visual C++ Redistributable. https://learn.microsoft.com/en-US/cpp/windows/latest-supported-vc-redist?view=msvc-170</system:String>
   <system:String x:Key="errors.lyrics.regex">Character not allowed in regular expression</system:String>
   <system:String x:Key="errors.lyrics.regexpreview">- regular expression error -</system:String>


### PR DESCRIPTION
Before this PR, if the oto contains the following errors, OpenUtau will crash when rendering it with worldline. 

- cutoff exceeds audio duration
- cutoff before offset

After this PR, it won't crash. It will show error dialog:

<img width="1204" height="476" alt="image" src="https://github.com/user-attachments/assets/fa432d48-357e-4bc1-9508-6e82cd9c7b30" />
