### PR TITLE
Added font settings for macOS

### DIFF
--- a/OpenUtau/Program.cs
+++ b/OpenUtau/Program.cs
@@ -67,6 +67,10 @@ namespace OpenUtau.App {
                     string [] fontFamilies = fontFamily.Split(',');
                     fontOptions.DefaultFamilyName = fontFamilies[0];
                 }
+            } else if (OS.IsMacOS()) {
+                //To avoid text display corruption, specify Hiragino Sans characters first.
+                //Due to the specification of AvaloniaUI, this only affects when the language is set to Japanese.
+                fontOptions.DefaultFamilyName = "Hiragino Sans, Segoe UI, San Francisco, Helvetica Neue";
             }
             return AppBuilder.Configure<App>()
                 .UsePlatformDetect()


### PR DESCRIPTION
In the `BuildAvaloniaApp` method, we added code to specify a specific font family for macOS. This will use the fonts ‘Hiragino Sans, Segoe UI, San Francisco, Helvetica Neue’ to avoid text display corruption when Japanese is set.

Split fix from PR #1470.

MacOS
Before
![スクリーンショット 2025-03-28 8 25 52](https://github.com/user-attachments/assets/270c772e-24b0-4b19-b9c8-b85a0f1bb29e)
![スクリーンショット 2025-03-28 8 26 02](https://github.com/user-attachments/assets/cdc2fff1-78b1-4bae-b1b2-46102fdcefd4)
![スクリーンショット 2025-03-28 8 26 38](https://github.com/user-attachments/assets/d3d93be7-60a4-4656-bc23-e5a3383b5a3f)

After
![スクリーンショット 2025-03-28 8 10 44](https://github.com/user-attachments/assets/dcc780a9-1445-4dd2-ad74-f6bc1fe498d8)
![スクリーンショット 2025-03-28 8 21 20](https://github.com/user-attachments/assets/bcce26d7-64a0-4b9d-9bd1-8e6cfe43614a)
![スクリーンショット 2025-03-28 8 23 26](https://github.com/user-attachments/assets/6a66e328-4896-48f7-a76a-9d7429736333)

Win11
![image](https://github.com/user-attachments/assets/4ae5da69-593a-47d6-94d0-9ca04b877a4c)
![image](https://github.com/user-attachments/assets/373f3dd7-780d-4b62-bf2c-a04265a296b1)
![image](https://github.com/user-attachments/assets/36d9ef6f-1dfc-488d-ab80-989dac8574c2)

