### PR TITLE
Fix playhead resets to its initial position when using 'Do nothing' on pause.

### DIFF
--- a/OpenUtau/ViewModels/PlaybackViewModel.cs
+++ b/OpenUtau/ViewModels/PlaybackViewModel.cs
@@ -32,8 +32,9 @@ namespace OpenUtau.App.ViewModels {
         public void PlayOrPause(int tick = -1, int endTick = -1, int trackNo = -1) {
             PlaybackManager.Inst.PlayOrPause(tick: tick, endTick: endTick, trackNo: trackNo);
             var lockStartTime = Convert.ToBoolean(Preferences.Default.LockStartTime);
-            if (!PlaybackManager.Inst.Playing && !PlaybackManager.Inst.StartingToPlay && lockStartTime) {
-                DocManager.Inst.ExecuteCmd(new SeekPlayPosTickNotification(PlaybackManager.Inst.StartTick, true));
+            if (!PlaybackManager.Inst.Playing && !PlaybackManager.Inst.StartingToPlay) {
+                int startTick = lockStartTime ? PlaybackManager.Inst.StartTick : DocManager.Inst.playPosTick;
+                DocManager.Inst.ExecuteCmd(new SeekPlayPosTickNotification(startTick, true));
             }
         }
         public void Pause() {


### PR DESCRIPTION
Before this change:

https://github.com/user-attachments/assets/9a4df52b-163a-466c-9f44-e44fd96cf051

After this change:

https://github.com/user-attachments/assets/d370f0ba-dd58-4c63-92f1-2da472a86253

Other "On Pausing" options still work as expected.