### PR TITLE
Fix playhead moving when playing samples

### DIFF
--- a/OpenUtau.Core/PlaybackManager.cs
+++ b/OpenUtau.Core/PlaybackManager.cs
@@ -10,6 +10,7 @@ using OpenUtau.Core.Render;
 using OpenUtau.Core.SignalChain;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Util;
+using OpenUtau.Core.Format;
 using Serilog;
 
 namespace OpenUtau.Core {
@@ -80,6 +81,21 @@ namespace OpenUtau.Core {
             AudioOutput.Play();
             return sineGen;
         }
+
+        public void PlayFile(string file) {
+            masterMix = null;
+            if (AudioOutput.PlaybackState == PlaybackState.Playing) {
+                AudioOutput.Stop();
+            }
+            try{
+                var playSound = Wave.OpenFile(file);
+                AudioOutput.Init(playSound.ToSampleProvider());
+            } catch (Exception ex) {
+                Log.Error(ex, $"Failed to load sample {file}.");
+                return;
+            }
+            AudioOutput.Play();
+        } 
 
         public void PlayOrPause(int tick = -1, int endTick = -1, int trackNo = -1) {
             if (Playing) {

--- a/OpenUtau/Views/SingersDialog.axaml.cs
+++ b/OpenUtau/Views/SingersDialog.axaml.cs
@@ -13,7 +13,6 @@ using NWaves.Audio;
 using OpenUtau.App.ViewModels;
 using OpenUtau.Classic;
 using OpenUtau.Core;
-using OpenUtau.Core.Format;
 using OpenUtau.Core.Ustx;
 using Serilog;
 
@@ -342,26 +341,13 @@ namespace OpenUtau.App.Views {
 
         public void OnPlayCharacterSample(object sender, RoutedEventArgs e) {
             var viewModel = (DataContext as SingersViewModel)!;
-            var playBack = PlaybackManager.Inst.AudioOutput;
-            var playbackState = playBack.PlaybackState;
             if (viewModel.Singer != null) {
-                // Stop other sounds to play sample
-                if (playbackState == PlaybackState.Playing) {
-                    playBack.Stop();
-                }
-
                 var sample = FindSample(viewModel.Singer);
                 if(sample == null){
                     return;
                 }
-                try{
-                    var playSound = Wave.OpenFile(sample);
-                    playBack.Init(playSound.ToSampleProvider());
-                } catch (Exception ex) {
-                    Log.Error(ex, $"Failed to load sample {sample}.");
-                    return;
-                }
-                playBack.Play();
+
+                PlaybackManager.Inst.PlayFile(sample);
             }
         }
 
@@ -371,22 +357,7 @@ namespace OpenUtau.App.Views {
                 return;
             }
 
-            var playBack = PlaybackManager.Inst.AudioOutput;
-            var playbackState = playBack.PlaybackState;
-
-            // If currently playing something, stop it to play sample right away
-            if (playbackState == PlaybackState.Playing) {
-                playBack.Stop();
-            }
-
-            try {
-                var playSound = Wave.OpenFile(oto.File);
-                playBack.Init(playSound.ToSampleProvider());
-            } catch (Exception ex) {
-                Log.Error(ex, $"Failed to load sample {oto.File}.");
-                return;
-            }
-            playBack.Play();
+            PlaybackManager.Inst.PlayFile(oto.File);
         }
 
         void RegenFrq(object sender, RoutedEventArgs args) {


### PR DESCRIPTION
We can also just call PlaybackManager.Inst.PlayFile if we want to play other audio files in the future.

Before this fix:

https://github.com/user-attachments/assets/7e639586-e473-4b53-adc4-19f949096ae2

After this fix:

https://github.com/user-attachments/assets/1c49d094-7109-48f2-b3a3-7367875f7eed

