### PR TITLE
Auto focus to the text field when opening edit dialogs

### DIFF
--- a/OpenUtau/Views/TypeInDialog.axaml.cs
+++ b/OpenUtau/Views/TypeInDialog.axaml.cs
@@ -10,6 +10,7 @@ namespace OpenUtau.App.Views {
         public TypeInDialog() {
             InitializeComponent();
             OkButton.Click += OkButtonClick;
+            TextBox.AttachedToVisualTree += (s, e) => TextBox.SelectAll();
         }
 
         public void SetPrompt(string prompt) {


### PR DESCRIPTION
Add accessibility feature suggested by https://github.com/stakira/OpenUtau/discussions/1348
Automatically focus (and select all text) to the textbox when opening dialogs.