### PR TITLE
Add feature to merge vocal parts

### DIFF
--- a/OpenUtau.Core/Ustx/UCurve.cs
+++ b/OpenUtau.Core/Ustx/UCurve.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using SharpCompress;
 using YamlDotNet.Serialization;
 
 namespace OpenUtau.Core.Ustx {
@@ -158,6 +159,26 @@ namespace OpenUtau.Core.Ustx {
             double area = 0.5 * Math.Abs(x1 * (y2 - y) + x2 * (y - y1) + x * (y1 - y2));
             double bottom = Math.Sqrt(Math.Pow(x1 - x2, 2) + Math.Pow(y1 - y2, 2));
             return area / bottom * 2;
+        }
+        public static List<UCurve> MergeCurves(params List<UCurve>[] merging) {
+            var merged = new Dictionary<UExpressionDescriptor, UCurve>();
+            merging.ForEach(curves => {
+                foreach (var curve in curves) {
+                    if (curve.descriptor == null) continue;
+                    if (!merged.TryGetValue(curve.descriptor, out var existing)) {
+                        merged[curve.descriptor] = curve.Clone();
+                    } else {
+                        // Merge xs and ys, keeping them sorted by xs
+                        var xs = existing.xs.Concat(curve.xs).ToList();
+                        var ys = existing.ys.Concat(curve.ys).ToList();
+                        var zipped = xs.Zip(ys, (x, y) => (x, y)).ToList();
+                        zipped.Sort((a, b) => a.x.CompareTo(b.x));
+                        existing.xs = zipped.Select(z => z.x).ToList();
+                        existing.ys = zipped.Select(z => z.y).ToList();
+                    }
+                }
+            });
+            return merged.Values.ToList();
         }
     }
 }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -8,6 +8,7 @@
   <system:String x:Key="context.note.pasteparameters">Select and paste parameters</system:String>
   <system:String x:Key="context.part.delete">Delete part</system:String>
   <system:String x:Key="context.part.gotofile">View file location</system:String>
+  <system:String x:Key="context.part.merge">Merge parts</system:String>
   <system:String x:Key="context.part.rename">Rename part</system:String>
   <system:String x:Key="context.part.replaceaudio">Reselect audio file</system:String>
   <system:String x:Key="context.part.transcribe">Transcribe audio to create a note part</system:String>
@@ -42,6 +43,8 @@
   <system:String x:Key="dialogs.installdependency.message">Installing </system:String>
   <system:String x:Key="dialogs.installdll.caption">Installing phonemizer</system:String>
   <system:String x:Key="dialogs.installdll.message">Installing </system:String>
+  <system:String x:Key="dialogs.merge.caption">Merging Parts</system:String>
+  <system:String x:Key="dialogs.merge.multitracks">Parts on different tracks cannot be merged.</system:String>
   <system:String x:Key="dialogs.messagebox.cancel">Cancel</system:String>
   <system:String x:Key="dialogs.messagebox.copy">Copy error to clipboard</system:String>
   <system:String x:Key="dialogs.messagebox.no">No</system:String>

--- a/OpenUtau/ViewModels/MainWindowViewModel.cs
+++ b/OpenUtau/ViewModels/MainWindowViewModel.cs
@@ -23,6 +23,7 @@ namespace OpenUtau.App.ViewModels {
         public ReactiveCommand<UPart, Unit>? PartGotoFileCommand { get; set; }
         public ReactiveCommand<UPart, Unit>? PartReplaceAudioCommand { get; set; }
         public ReactiveCommand<UPart, Unit>? PartTranscribeCommand { get; set; }
+        public ReactiveCommand<UPart, Unit>? PartMergeCommand { get; set; }
     }
 
     public class RecentFileInfo {

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -361,6 +361,10 @@
                           IsVisible="{Binding IsWavePart}"
                           Command="{Binding PartTranscribeCommand}"
                           CommandParameter="{Binding Part}"/>
+                <MenuItem Header="{DynamicResource context.part.merge}"
+                          IsVisible="{Binding IsVoicePart}"
+                          Command="{Binding PartMergeCommand}"
+                          CommandParameter="{Binding Part}"/>
               </ContextMenu>
             </c:PartsCanvas.ContextMenu>
           </c:PartsCanvas>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -45,6 +45,7 @@ namespace OpenUtau.App.Views {
         private readonly ReactiveCommand<UPart, Unit> PartGotoFileCommand;
         private readonly ReactiveCommand<UPart, Unit> PartReplaceAudioCommand;
         private readonly ReactiveCommand<UPart, Unit> PartTranscribeCommand;
+        private readonly ReactiveCommand<UPart, Unit> PartMergeCommand;
 
         public MainWindow() {
             Log.Information("Creating main window.");
@@ -74,6 +75,7 @@ namespace OpenUtau.App.Views {
             PartGotoFileCommand = ReactiveCommand.Create<UPart>(part => GotoFile(part));
             PartReplaceAudioCommand = ReactiveCommand.Create<UPart>(part => ReplaceAudio(part));
             PartTranscribeCommand = ReactiveCommand.Create<UPart>(part => Transcribe(part));
+            PartMergeCommand = ReactiveCommand.Create<UPart>(part => MergePart(part));
 
             AddHandler(DragDrop.DropEvent, OnDrop);
 
@@ -1028,6 +1030,7 @@ namespace OpenUtau.App.Views {
                             PartReplaceAudioCommand = PartReplaceAudioCommand,
                             PartRenameCommand = PartRenameCommand,
                             PartTranscribeCommand = PartTranscribeCommand,
+                            PartMergeCommand = PartMergeCommand,
                         };
                         shouldOpenPartsContextMenu = true;
                     }
@@ -1235,6 +1238,19 @@ namespace OpenUtau.App.Views {
                     MessageBox.ShowError(this, e);
                 }
             }
+        }
+
+        void MergePart(UPart part) {
+            List<UPart> selectedParts = viewModel.TracksViewModel.SelectedParts;
+            if (!selectedParts.All(p => p.trackNo.Equals(part.trackNo))) {
+                _ = MessageBox.Show(
+                    this,
+                    ThemeManager.GetString("dialogs.merge.multitracks"),
+                    ThemeManager.GetString("dialogs.merge.caption"),
+                    MessageBox.MessageBoxButtons.Ok);
+                return;
+            }
+            // Todo: Add MergePartsCommand from PartCommands
         }
 
         public async void OnWelcomeRecent(object sender, PointerPressedEventArgs args) {


### PR DESCRIPTION
Implemented a feature to let you merge/combine multiple vocal parts into one, while preserving the notes, note settings, and expression curves.
Based on an [idea suggestion](https://discord.com/channels/551606189386104834/1087458736777482400) in the OpenUtau Discord server.

Usage: Select two or more vocal parts, right click on any of those parts, and select "Merge parts"