### PR TITLE
Fix note editing tool toggle button behavior

### DIFF
--- a/OpenUtau/Views/PianoRollWindow.axaml
+++ b/OpenUtau/Views/PianoRollWindow.axaml
@@ -344,7 +344,7 @@
             </ToggleButton>
             <Border Width="12"/>
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                          IsChecked="{Binding NotesViewModel.CursorTool, Mode=OneWay}"
+                          IsChecked="{Binding NotesViewModel.CursorTool}"
                           Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="1"
                           ToolTip.Tip="{DynamicResource pianoroll.tool.selectionv2}">
               <Grid Width="18" Height="18">
@@ -359,7 +359,7 @@
               </Grid>
             </ToggleButton>
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                          IsChecked="{Binding NotesViewModel.PenTool, Mode=OneWay}"
+                          IsChecked="{Binding NotesViewModel.PenTool}"
                           Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="2"
                           ToolTip.Tip="{DynamicResource pianoroll.tool.penv2}">
               <Grid Width="18" Height="18">
@@ -374,7 +374,7 @@
               </Grid>
             </ToggleButton>
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                          IsChecked="{Binding NotesViewModel.PenPlusTool, Mode=OneWay}"
+                          IsChecked="{Binding NotesViewModel.PenPlusTool}"
                           Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="2+"
                           ToolTip.Tip="{DynamicResource pianoroll.tool.penplus}">
               <Grid Width="18" Height="18">
@@ -389,7 +389,7 @@
               </Grid>
             </ToggleButton>
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                          IsChecked="{Binding NotesViewModel.EraserTool, Mode=OneWay}"
+                          IsChecked="{Binding NotesViewModel.EraserTool}"
                           Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="3"
                           ToolTip.Tip="{DynamicResource pianoroll.tool.eraser}">
               <Grid Width="18" Height="18">
@@ -404,7 +404,7 @@
               </Grid>
             </ToggleButton>
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                          IsChecked="{Binding NotesViewModel.DrawPitchTool, Mode=OneWay}"
+                          IsChecked="{Binding NotesViewModel.DrawPitchTool}"
                           Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="4"
                           ToolTip.Tip="{DynamicResource pianoroll.tool.drawpitch}">
               <Grid Width="18" Height="18">
@@ -419,7 +419,7 @@
               </Grid>
             </ToggleButton>
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                          IsChecked="{Binding NotesViewModel.OverwritePitchTool, Mode=OneWay}"
+                          IsChecked="{Binding NotesViewModel.OverwritePitchTool}"
                           Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="4+"
                           ToolTip.Tip="{DynamicResource pianoroll.tool.overwritepitch}">
               <Grid Width="18" Height="18">
@@ -434,7 +434,7 @@
               </Grid>
             </ToggleButton>
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                          IsChecked="{Binding NotesViewModel.DrawLinePitchTool, Mode=OneWay}"
+                          IsChecked="{Binding NotesViewModel.DrawLinePitchTool}"
                           Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="4++"
                           ToolTip.Tip="{DynamicResource pianoroll.tool.drawlinepitch}">
               <Grid Width="18" Height="18">
@@ -449,7 +449,7 @@
               </Grid>
             </ToggleButton>
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20"
-                          IsChecked="{Binding NotesViewModel.KnifeTool, Mode=OneWay}"
+                          IsChecked="{Binding NotesViewModel.KnifeTool}"
                           Command="{Binding NotesViewModel.SelectToolCommand}" CommandParameter="5"
                           ToolTip.Tip="{DynamicResource pianoroll.tool.knife}">
               <Grid Width="18" Height="18">


### PR DESCRIPTION
## Overview
Fixed a minor GUI issue when clicking on the tool icon that is already selected, it will lose its highlighting (which I believe is not the intended behavior).

## Details
Let's say the pencil tool is currently selected.
<img width="400" height="50" alt="fix-tool-toggle-3" src="https://github.com/user-attachments/assets/ea4b7280-f538-4b0a-9b22-36c796f6e671" />
You can reproduce this issue by simply clicking on the pencil tool.
<img width="2451" height="1515" alt="fix-tool-toggle-1" src="https://github.com/user-attachments/assets/39176f3a-e6c8-4849-a322-b4858dac5c88" />

Now, the tool icon is no longer highlighted/shadowed. Note that this does not affect the function of the mouse curser, meaning you're still using the pencil tool. This will possibly appear confusing for users to know what tool they're using.
<img width="400" height="50" alt="fix-tool-toggle-4" src="https://github.com/user-attachments/assets/d3f963c0-b93f-4f9e-9c82-afbb3076d05f" />
<img width="2451" height="1515" alt="fix-tool-toggle-2" src="https://github.com/user-attachments/assets/76db490e-81ff-4a8a-a168-ea990ed688ff" />

This problem is fixed, making the tool icon keep its highlighting/shadowing after being clicked while already selected.
