### PR TITLE
Adds P0 to [- C]s in the Japanese Presamp Phonemizer

### DIFF
--- a/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/JapanesePresampPhonemizer.cs
@@ -216,6 +216,9 @@ namespace OpenUtau.Plugin.Builtin {
                     if (color != null) {
                         result[0].expressions.Add(new PhonemeExpression() { abbr = Core.Format.Ustx.CLR, value = (int)color });
                     }
+                    if (presamp.CFlags == "p0") {
+                        result.First(p => p.index == 2).expressions.Add(new PhonemeExpression() { abbr = Core.Format.Ustx.NORM, value = 0 });
+                    }
                 }
             }
 


### PR DESCRIPTION
Only works if "CFLAGS" in the Presamp.ini is set to "p0", by default it is.