### PR TITLE
Install NSIS in github acitons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           node-version: 20
       - uses: repolevedavaj/install-nsis@v1.0.3
         with:
-          nsis-version: '3.10'
+          nsis-version: '3.11'
         if: ${{ matrix.arch.os == 'win' }}
       - uses: justalemon/VersionPatcher@v0.7.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - uses: repolevedavaj/install-nsis@v1.0.3
+        with:
+          nsis-version: '3.10'
+        if: ${{ matrix.arch.os == 'win' }}
       - uses: justalemon/VersionPatcher@v0.7.1
         with:
           version: ${{ inputs.version }}


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/12677 , NSIS is removed from github actions runner images. So we have to install it in github actions script.