### PR TITLE
Add save dialog when opening file with Open Recent menu

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -52,7 +52,10 @@ namespace OpenUtau.App.Views {
             Log.Information("Creating main window.");
             InitializeComponent();
             Log.Information("Initialized main window component.");
-            DataContext = viewModel = new MainWindowViewModel();
+            DataContext = viewModel = new MainWindowViewModel {
+                // give the viewmodel a way to prompt/save using the view's existing method
+                AskIfSaveAndContinue = AskIfSaveAndContinue
+            };
 
             viewModel.NewProject();
             viewModel.AddTempoChangeCmd = ReactiveCommand.Create<int>(tick => AddTempoChange(tick));


### PR DESCRIPTION
### Overview
Should fix issue <https://github.com/stakira/OpenUtau/issues/1686>.
> When working on a project and opening an existing project from the recent list, OU does not prompt to save as it usually does for the "New" and "Open..." options but instead opens the project, discarding the previous one.

With this pull request, the dialog prompting user to save current project will show up for "Open Recent" menu as well.
"New From Template" menu item may have had the same problem (didn't test it though), which should also be fixed with this change.