### PR TITLE
convert `-` to `+~` instead of `+` when importing other formats

### DIFF
--- a/OpenUtau.Core/Format/MidiWriter.cs
+++ b/OpenUtau.Core/Format/MidiWriter.cs
@@ -207,7 +207,7 @@ namespace OpenUtau.Core.Format {
                                 lyric = defaultLyric;
                             }
                             if (lyric == "-") {
-                                lyric = "+";
+                                lyric = "+~";
                             }
                             note.lyric = lyric;
                             if (NotePresets.Default.AutoVibratoToggle && note.duration >= NotePresets.Default.AutoVibratoNoteDuration) {
@@ -269,7 +269,7 @@ namespace OpenUtau.Core.Format {
                                 continue;
                             }
                             string lyric = note.lyric;
-                            if (lyric == "+") {
+                            if (lyric == "+~" || lyric == "+*") {
                                 lyric = "-";
                             }
                             events.Add(new TimedEvent(new LyricEvent(lyric), note.position + partOffset));

--- a/OpenUtau.Core/Format/Ufdata.cs
+++ b/OpenUtau.Core/Format/Ufdata.cs
@@ -104,6 +104,9 @@ namespace OpenUtau.Core.Format
                     ufNote.tickOff - ufNote.tickOn
                 );
                 note.lyric = ufNote.lyric;
+                if (note.lyric == "-") {
+                    note.lyric = "+~";
+                }
                 part.notes.Add(note);
             }
             part.Duration = ufTrack.notes[^1].tickOff;

--- a/OpenUtau.Core/Format/VSQx.cs
+++ b/OpenUtau.Core/Format/VSQx.cs
@@ -179,7 +179,7 @@ namespace OpenUtau.Core.Format {
                         unote.tone = int.Parse(note.SelectSingleNode(notenumPath, nsmanager).InnerText);
                         unote.lyric = note.SelectSingleNode(lyricPath, nsmanager).InnerText;
                         if (unote.lyric == "-") {
-                            unote.lyric = "+";
+                            unote.lyric = "+~";
                         }
 
                         unote.phonemeExpressions.Add(new UExpression(Ustx.VEL) {


### PR DESCRIPTION
Most other SVS softwares use `-` for slur, or extending the syllable of previous note to current note. 
Before this change, `-` is converted to `+` when importing .mid, .vsqx and .ufdata files. This is OK for east Asian languages (Chinese, Japanese, Korean and Vietnamese), but it isn't desired for european languages like English, because `+` means putting the next syllable of the word onto the current note, while `+~` means slur note.
After this change, `-` is converted to `+~`.
 