### PR TITLE
Fixed link to download Linux x64 latest version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Open singing synthesis platform / Open source UTAU successor
 [macOS x64](https://github.com/stakira/OpenUtau/releases/latest/download/OpenUtau-osx-x64.dmg){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Installation Guide](https://github.com/stakira/OpenUtau/wiki/Getting-Started#macos){: .btn .fs-5 .mb-4 .mb-md-0 }
 
-[Linux x64](https://github.com/stakira/OpenUtau/releases/latest/download/OpenUtau-linux-x64.tar.gz){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Linux x64](https://github.com/stakira/OpenUtau/releases/latest/download/OpenUtau-linux-x64.zip){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Installation Guide](https://github.com/stakira/OpenUtau/wiki/Getting-Started#linux){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 If you plan to use DiffSinger or the arm64 version for macOS, please download the latest beta from [here](https://github.com/stakira/openutau/releases).


### PR DESCRIPTION
## Issue
If your click on main website to download last version on Linux then the link is broken.
<img width="795" height="416" alt="image" src="https://github.com/user-attachments/assets/23ae202a-5a8d-4fb6-8cbc-41d3a52db48d" />
<img width="1051" height="279" alt="image" src="https://github.com/user-attachments/assets/1f111141-c628-4402-a7af-94d237ee0430" />

It was fixed the link to download it rightly. https://github.com/stakira/OpenUtau/releases/latest/download/OpenUtau-linux-x64.zip

