### PR TITLE
Only display samples that need to be rendered in the progress bar

### DIFF
--- a/OpenUtau.Core/Classic/ClassicRenderer.cs
+++ b/OpenUtau.Core/Classic/ClassicRenderer.cs
@@ -80,8 +80,10 @@ namespace OpenUtau.Classic {
                         if (!(item.resampler is WorldlineResampler)) {
                             VoicebankFiles.Inst.CopyBackMetaFiles(item.inputFile, item.inputTemp);
                         }
+                        progress.Complete(1, $"Track {trackNo + 1}: {item.resampler} \"{item.phone.phoneme}\"");
+                        return;
                     }
-                    progress.Complete(1, $"Track {trackNo + 1}: {item.resampler} \"{item.phone.phoneme}\"");
+                    progress.Complete(1);
                 });
                 var result = Layout(phrase);
                 var wavtool = new SharpWavtool(true);
@@ -101,7 +103,6 @@ namespace OpenUtau.Classic {
             }
             var task = Task.Run(() => {
                 string progressInfo = $"Track {trackNo + 1} : {phrase.wavtool} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
-                progress.Complete(0, progressInfo);
                 var wavPath = Path.Join(PathManager.Inst.CachePath, $"cat-{phrase.hash:x16}.wav");
                 phrase.AddCacheFile(wavPath);
                 var result = Layout(phrase);
@@ -113,6 +114,7 @@ namespace OpenUtau.Classic {
                     } catch (Exception e) {
                         Log.Error(e, $"Failed to render: failed to open {wavPath}");
                     }
+                    progress.Complete(phrase.phones.Length);
                 }
                 if (result.samples == null) {
                     foreach (var item in resamplerItems) {
@@ -123,8 +125,8 @@ namespace OpenUtau.Classic {
                     foreach (var item in resamplerItems) {
                         VoicebankFiles.Inst.CopyBackMetaFiles(item.inputFile, item.inputTemp);
                     }
+                    progress.Complete(phrase.phones.Length, progressInfo);
                 }
-                progress.Complete(phrase.phones.Length, progressInfo);
                 if (result.samples != null) {
                     Renderers.ApplyDynamics(phrase, result);
                 }

--- a/OpenUtau.Core/Classic/WorldlineRenderer.cs
+++ b/OpenUtau.Core/Classic/WorldlineRenderer.cs
@@ -58,11 +58,11 @@ namespace OpenUtau.Classic {
                 var wavPath = Path.Join(PathManager.Inst.CachePath, $"wdl-{phrase.hash:x16}.wav");
                 phrase.AddCacheFile(wavPath);
                 string progressInfo = $"Track {trackNo + 1}: {this} {string.Join(" ", phrase.phones.Select(p => p.phoneme))}";
-                progress.Complete(0, progressInfo);
                 if (File.Exists(wavPath)) {
                     using (var waveStream = Wave.OpenFile(wavPath)) {
                         result.samples = Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
                     }
+                    progress.Complete(phrase.phones.Length);
                 }
                 if (result.samples == null) {
                     using var phraseSynth = new Worldline.PhraseSynth();
@@ -106,8 +106,8 @@ namespace OpenUtau.Classic {
                     var source = new WaveSource(0, 0, 0, 1);
                     source.SetSamples(result.samples);
                     WaveFileWriter.CreateWaveFile16(wavPath, new ExportAdapter(source).ToMono(1, 0));
+                    progress.Complete(phrase.phones.Length, progressInfo);
                 }
-                progress.Complete(phrase.phones.Length, progressInfo);
                 if (result.samples != null) {
                     Renderers.ApplyDynamics(phrase, result);
                 }

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -113,6 +113,7 @@ namespace OpenUtau.Core.DiffSinger {
                         } catch (Exception e) {
                             Log.Error(e, "Failed to render.");
                         }
+                        progress.Complete(phrase.phones.Length);
                     }
                     if (result.samples == null) {
                         result.samples = InvokeDiffsinger(phrase, depth, steps, cancellation);
@@ -121,11 +122,11 @@ namespace OpenUtau.Core.DiffSinger {
                             source.SetSamples(result.samples);
                             WaveFileWriter.CreateWaveFile16(wavPath, new ExportAdapter(source).ToMono(1, 0));
                         }
+                        progress.Complete(phrase.phones.Length, progressInfo);
                     }
                     if (result.samples != null) {
                         Renderers.ApplyDynamics(phrase, result);
                     }
-                    progress.Complete(phrase.phones.Length, progressInfo);
                     return result;
                 }
             });

--- a/OpenUtau.Core/Enunu/EnunuRenderer.cs
+++ b/OpenUtau.Core/Enunu/EnunuRenderer.cs
@@ -177,8 +177,8 @@ namespace OpenUtau.Core.Enunu {
                             source.SetSamples(result.samples);
                             WaveFileWriter.CreateWaveFile16(wavPath, new ExportAdapter(source).ToMono(1, 0));
                         }
+                        progress.Complete(phrase.phones.Length, progressInfo);
                     }
-                    progress.Complete(phrase.phones.Length, progressInfo);
                     if (File.Exists(wavPath)) {
                         using (var waveStream = Wave.OpenFile(wavPath)) {
                             result.samples = Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
@@ -186,6 +186,7 @@ namespace OpenUtau.Core.Enunu {
                         if (result.samples != null) {
                             Renderers.ApplyDynamics(phrase, result);
                         }
+                        progress.Complete(phrase.phones.Length);
                     } else {
                         result.samples = new float[0];
                     }

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -16,9 +16,11 @@ namespace OpenUtau.Core.Render {
             this.total = total;
         }
 
-        public void Complete(int n, string info) {
+        public void Complete(int n, string? info = null) {
             Interlocked.Add(ref completed, n);
-            Notify(completed * 100.0 / total, info);
+            if (!string.IsNullOrEmpty(info)) {
+                Notify(completed * 100.0 / total, info);
+            }
         }
 
         public void Clear() {
@@ -239,6 +241,7 @@ namespace OpenUtau.Core.Render {
                 var phrase = tuple.Item1;
                 var source = tuple.Item2;
                 var request = tuple.Item3;
+                
                 var task = phrase.renderer.Render(phrase, progress, request.trackNo, cancellation, true);
                 task.Wait();
                 if (cancellation.IsCancellationRequested) {

--- a/OpenUtau.Core/Vogen/VogenRenderer.cs
+++ b/OpenUtau.Core/Vogen/VogenRenderer.cs
@@ -63,7 +63,6 @@ namespace OpenUtau.Core.Vogen {
                     var wavPath = Path.Join(PathManager.Inst.CachePath, $"vog-{phrase.hash:x16}.wav");
                     phrase.AddCacheFile(wavPath);
                     string progressInfo = $"Track {trackNo + 1}: {this} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
-                    progress.Complete(0, progressInfo);
                     if (File.Exists(wavPath)) {
                         try {
                             using (var waveStream = Wave.OpenFile(wavPath)) {
@@ -72,17 +71,18 @@ namespace OpenUtau.Core.Vogen {
                         } catch (Exception e) {
                             Log.Error(e, "Failed to render.");
                         }
+                        progress.Complete(phrase.phones.Length);
                     }
                     if (result.samples == null) {
                         result.samples = InvokeVogen(phrase);
                         var source = new WaveSource(0, 0, 0, 1);
                         source.SetSamples(result.samples);
                         WaveFileWriter.CreateWaveFile16(wavPath, new ExportAdapter(source).ToMono(1, 0));
+                        progress.Complete(phrase.phones.Length, progressInfo);
                     }
                     if (result.samples != null) {
                         Renderers.ApplyDynamics(phrase, result);
                     }
-                    progress.Complete(phrase.phones.Length, progressInfo);
                     return result;
                 }
             });

--- a/OpenUtau.Core/Voicevox/VoicevoxRenderer.cs
+++ b/OpenUtau.Core/Voicevox/VoicevoxRenderer.cs
@@ -64,7 +64,6 @@ namespace OpenUtau.Core.Voicevox {
                         return new RenderResult();
                     }
                     string progressInfo = $"Track {trackNo + 1}: {this} \"{string.Join(" ", phrase.phones.Select(p => p.phoneme))}\"";
-                    progress.Complete(0, progressInfo);
                     var wavPath = Path.Join(PathManager.Inst.CachePath, $"vv-{phrase.hash:x16}.wav");
                     phrase.AddCacheFile(wavPath);
                     var result = Layout(phrase);
@@ -138,8 +137,8 @@ namespace OpenUtau.Core.Voicevox {
                                 return new RenderResult();
                             }
                         }
+                        progress.Complete(phrase.phones.Length, progressInfo);
                     }
-                    progress.Complete(phrase.phones.Length, progressInfo);
                     if (File.Exists(wavPath)) {
                         using (var waveStream = new WaveFileReader(wavPath)) {
 
@@ -148,6 +147,7 @@ namespace OpenUtau.Core.Voicevox {
                         if (result.samples != null) {
                             Renderers.ApplyDynamics(phrase, result);
                         }
+                        progress.Complete(phrase.phones.Length);
                     }
                     return result;
                 }


### PR DESCRIPTION
Before this change, the progress bar moves too quickly when a sample was already cached, causing the UI to lag as it tries to catch up:

https://github.com/user-attachments/assets/7f6837f9-394a-4118-a944-392de382fbf9


After this change, only samples that needs to be rendered are displayed in progress bar:

https://github.com/user-attachments/assets/301ab992-0e21-4236-b5e2-67531f4050a0
