### PR TITLE
Support import multiple audios at once; remove 'import midi' menu item

### DIFF
--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -35,8 +35,6 @@
             <MenuItem Header="-" Height="1"/>
             <MenuItem Header="{DynamicResource menu.file.importtracks}" Click="OnMenuImportTracks"/>
             <MenuItem Header="{DynamicResource menu.file.importaudio}" Click="OnMenuImportAudio"/>
-            <MenuItem Header="{DynamicResource menu.file.importmidi}" Click="OnMenuImportMidi">
-            </MenuItem>
             <MenuItem Header="-" Height="1"/>
             <MenuItem Header="{DynamicResource menu.file.exportaudio}">
               <MenuItem Header="{DynamicResource menu.file.exportwav}" Click="OnMenuExportWav"/>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -347,30 +347,18 @@ namespace OpenUtau.App.Views {
         }
 
         async void OnMenuImportAudio(object sender, RoutedEventArgs args) {
-            var file = await FilePicker.OpenFileAboutProject(
+            var files = await FilePicker.OpenFilesAboutProject(
                 this, "menu.file.importaudio", FilePicker.AudioFiles);
-            if (file == null) {
+            if (files == null || files.Length == 0) {
                 return;
             }
-            try {
-                viewModel.ImportAudio(file);
-            } catch (Exception e) {
-                Log.Error(e, "Failed to import audio");
-                _ = await MessageBox.ShowError(this, new MessageCustomizableException("Failed to import audio", "<translate:errors.failed.importaudio>", e));
-            }
-        }
-
-        async void OnMenuImportMidi(object sender, RoutedEventArgs args) {
-            var file = await FilePicker.OpenFileAboutProject(
-                this, "menu.file.importmidi", FilePicker.MIDI);
-            if (file == null) {
-                return;
-            }
-            try {
-                viewModel.ImportMidi(file);
-            } catch (Exception e) {
-                Log.Error(e, "Failed to import midi");
-                _ = await MessageBox.ShowError(this, new MessageCustomizableException("Failed to import midi", "<translate:errors.failed.importmidi>", e));
+            foreach (var file in files) {
+                try {
+                    viewModel.ImportAudio(file);
+                } catch (Exception e) {
+                    Log.Error(e, "Failed to import audio");
+                    _ = await MessageBox.ShowError(this, new MessageCustomizableException("Failed to import audio", "<translate:errors.failed.importaudio>", e));
+                }
             }
         }
 


### PR DESCRIPTION
- After this change, in "File → Import Audio" menu, we can import multiple audio files at once.
- The "File → Import midi" menu item is removed, because we already have "File → Import tracks"