### PR TITLE
[SBP update] Instance-based Dictionary

### DIFF
--- a/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
@@ -233,7 +233,7 @@ namespace OpenUtau.Plugin.Builtin {
         protected bool isDictionaryLoading => dictionaries[GetType()] == null;
         protected double TransitionBasicLengthMs => 100;
 
-        private static Dictionary<Type, IG2p> dictionaries = new Dictionary<Type, IG2p>();
+        private Dictionary<Type, IG2p> dictionaries = new Dictionary<Type, IG2p>();
         private const string FORCED_ALIAS_SYMBOL = "?";
         private string error = "";
         private readonly string[] wordSeparators = new[] { " ", "_" };


### PR DESCRIPTION
This means every SBP phonemizer instance (each time OpenUtau assigns it to a singer or track) gets its own dictionary, instead of overriding the old instance with the new instance’s dictionary data.