### PR TITLE
Fix auto focused text field in dialogs not accepting keyboard inputs

### DIFF
--- a/OpenUtau/Views/TypeInDialog.axaml.cs
+++ b/OpenUtau/Views/TypeInDialog.axaml.cs
@@ -10,7 +10,7 @@ namespace OpenUtau.App.Views {
         public TypeInDialog() {
             InitializeComponent();
             OkButton.Click += OkButtonClick;
-            TextBox.AttachedToVisualTree += (s, e) => TextBox.SelectAll();
+            TextBox.AttachedToVisualTree += (s, e) => { TextBox.SelectAll(); TextBox.Focus(); };
         }
 
         public void SetPrompt(string prompt) {


### PR DESCRIPTION
Fixed an issue regarding auto focusing on text field dialogs (feature added in: <https://github.com/stakira/OpenUtau/pull/1638>).
When a dialog box is shown with its text field selected, it could not be typed in (as the text field was technically not focused). This PR should fix this problem.
Thanks to @maiko3tattun for pointing out this issue.