### PR TITLE
Support for install.txt and Plugin Installation

### DIFF
--- a/OpenUtau.Core/Classic/ZipInstaller.cs
+++ b/OpenUtau.Core/Classic/ZipInstaller.cs
@@ -10,7 +10,7 @@ using SharpCompress.Readers;
 
 namespace OpenUtau.Classic {
 
-    public class VoicebankInstaller {
+    public class ZipInstaller {
         const string kCharacterTxt = "character.txt";
         const string kCharacterYaml = "character.yaml";
         const string kInstallTxt = "install.txt";
@@ -19,16 +19,20 @@ namespace OpenUtau.Classic {
         private readonly Action<double, string> progress;
         private readonly Encoding archiveEncoding;
         private readonly Encoding textEncoding;
+        private string destinationDir;
+        private string sourceDir;
 
-        public VoicebankInstaller(string basePath, Action<double, string> progress, Encoding archiveEncoding, Encoding textEncoding) {
+        public ZipInstaller(string basePath, Action<double, string> progress, Encoding archiveEncoding, Encoding textEncoding, string destinationDir, string sourceDir) {
             Directory.CreateDirectory(basePath);
             this.basePath = basePath;
             this.progress = progress;
             this.archiveEncoding = archiveEncoding;
             this.textEncoding = textEncoding;
+            this.destinationDir = destinationDir;
+            this.sourceDir = sourceDir;
         }
 
-        public void Install(string path, string singerType) {
+        public void InstallSinger(string path, string singerType) {
             progress.Invoke(0, "Analyzing archive...");
             var readerOptions = new ReaderOptions {
                 ArchiveEncoding = new ArchiveEncoding {
@@ -89,16 +93,76 @@ namespace OpenUtau.Classic {
             }
         }
 
+        public void InstallPlugin(string path) {
+            progress.Invoke(0, "Analyzing archive...");
+
+            basePath = Path.Combine(basePath, destinationDir);
+            Directory.CreateDirectory(basePath);
+            var readerOptions = new ReaderOptions {
+                ArchiveEncoding = new ArchiveEncoding {
+                    Forced = archiveEncoding,
+                }
+            };
+            if (!string.IsNullOrWhiteSpace(sourceDir)) {
+                sourceDir = sourceDir + "/"; // The separator contained in IArchiveEntry is fixed.
+            }
+            var extractionOptions = new ExtractionOptions {
+                Overwrite = true,
+            };
+            using (var archive = ArchiveFactory.Open(path, readerOptions)) {
+                if (string.IsNullOrWhiteSpace(sourceDir)) {
+                    var rootDirs = archive.Entries
+                        .Where(e => e.IsDirectory)
+                        .Where(e => e.Key != null
+                                && (e.Key.IndexOf('\\') < 0 || e.Key.IndexOf('\\') == e.Key.Length - 1)
+                                && (e.Key.IndexOf('/') < 0 || e.Key.IndexOf('/') == e.Key.Length - 1))
+                        .ToArray();
+                    var rootFiles = archive.Entries
+                        .Where(e => !e.IsDirectory)
+                        .Where(e => e.Key != null && !e.Key.Contains('\\') && !e.Key.Contains('/') && e.Key != kInstallTxt)
+                        .ToArray();
+                    if (rootFiles.Count() == 0 && rootDirs.Count() == 1) {
+                        sourceDir = rootDirs.First().Key!;
+                    }
+                }
+
+                var entries = archive.Entries.Where(e => !e.IsDirectory && e.Key != kInstallTxt);
+                int total = entries.Count();
+                int count = 0;
+                foreach (var entry in entries) {
+                    if (entry.Key == null) {
+                        continue;
+                    }
+                    progress.Invoke(100.0 * ++count / total, entry.Key);
+                    string relativePath = entry.Key;
+                    if (!string.IsNullOrWhiteSpace(sourceDir)) {
+                        if (!entry.Key.StartsWith(sourceDir)) {
+                            continue;
+                        }
+                        relativePath = entry.Key.Substring(sourceDir.Length);
+                    }
+
+                    string destinationPath = Path.Combine(basePath, relativePath);
+                    string dir = Path.GetDirectoryName(destinationPath);
+                    if (!Directory.Exists(dir)) {
+                        Directory.CreateDirectory(dir);
+                    }
+                    entry.WriteToFile(destinationPath, extractionOptions);
+                }
+            }
+        }
+
         private void AdjustBasePath(IArchive archive, string archivePath, List<string> touches) {
             var dirsAndFiles = archive.Entries.Select(e => e.Key).ToHashSet();
             var rootDirs = archive.Entries
                 .Where(e => e.IsDirectory)
-                .Where(e => (e.Key.IndexOf('\\') < 0 || e.Key.IndexOf('\\') == e.Key.Length - 1)
-                         && (e.Key.IndexOf('/') < 0 || e.Key.IndexOf('/') == e.Key.Length - 1))
+                .Where(e => e.Key != null
+                        && (e.Key.IndexOf('\\') < 0 || e.Key.IndexOf('\\') == e.Key.Length - 1)
+                        && (e.Key.IndexOf('/') < 0 || e.Key.IndexOf('/') == e.Key.Length - 1))
                 .ToArray();
             var rootFiles = archive.Entries
                 .Where(e => !e.IsDirectory)
-                .Where(e => !e.Key.Contains('\\') && !e.Key.Contains('/') && e.Key != kInstallTxt)
+                .Where(e => e.Key != null && !e.Key.Contains('\\') && !e.Key.Contains('/') && e.Key != kInstallTxt)
                 .ToArray();
             if (rootFiles.Count() > 0) {
                 // Need to create root folder.

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -85,6 +85,7 @@ OpenUtau aims to be an open source editing environment for UTAU community, with 
   <system:String x:Key="errors.failed.importaudio">Failed to import audio</system:String>
   <system:String x:Key="errors.failed.importfiles">Failed to import files</system:String>
   <system:String x:Key="errors.failed.importmidi">Failed to import midi</system:String>
+  <system:String x:Key="errors.failed.install">Failed to install</system:String>
   <system:String x:Key="errors.failed.installsinger">Failed to install singer</system:String>
   <system:String x:Key="errors.failed.load">Failed to load</system:String>
   <system:String x:Key="errors.failed.loadprefs">Failed to load prefs. Initialize it.</system:String>
@@ -575,14 +576,20 @@ The voicebank may not work on another OS.</system:String>
   <system:String x:Key="singers.subbanks.toneranges">Tone Ranges</system:String>
   <system:String x:Key="singers.usefilename">Use filename as alias</system:String>
   <system:String x:Key="singers.visitwebsite">Visit Website</system:String>
-
+  
+  <system:String x:Key="singersetup.agreement">If you agree to the file's terms of use, press Next.</system:String>
+  <system:String x:Key="singersetup.alreadyexists">Content is already exists</system:String>
   <system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>
   <system:String x:Key="singersetup.archivefileencoding.prompt">Choose an encoding that make file names look right.</system:String>
   <system:String x:Key="singersetup.back">Back</system:String>
-  <system:String x:Key="singersetup.failed">Failed to install singer.</system:String>
+  <system:String x:Key="singersetup.description">Install "{0}" as {1}.</system:String>
+  <system:String x:Key="singersetup.failed">Failed to install.</system:String>
   <system:String x:Key="singersetup.install">Install</system:String>
   <system:String x:Key="singersetup.missinginfo">Please add the following settings to this voicebank's character.yaml.</system:String>
   <system:String x:Key="singersetup.next">Next</system:String>
+  <system:String x:Key="singersetup.plugin">plugin</system:String>
+  <system:String x:Key="singersetup.plugintitle">Plugin Setup</system:String>
+  <system:String x:Key="singersetup.singer">singer</system:String>
   <system:String x:Key="singersetup.singertype">Singer Type</system:String>
   <system:String x:Key="singersetup.succeeded">Installation succeeded.</system:String>
   <system:String x:Key="singersetup.textfileencoding">Text File Encoding</system:String>

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -578,7 +578,7 @@ The voicebank may not work on another OS.</system:String>
   <system:String x:Key="singers.visitwebsite">Visit Website</system:String>
   
   <system:String x:Key="singersetup.agreement">If you agree to the file's terms of use, press Next.</system:String>
-  <system:String x:Key="singersetup.alreadyexists">Content is already exists</system:String>
+  <system:String x:Key="singersetup.alreadyexists">Folder "{0}" already exists. Existing data and installation data will be merged.</system:String>
   <system:String x:Key="singersetup.archivefileencoding">Archive File Encoding</system:String>
   <system:String x:Key="singersetup.archivefileencoding.prompt">Choose an encoding that make file names look right.</system:String>
   <system:String x:Key="singersetup.back">Back</system:String>

--- a/OpenUtau/ViewModels/SingerSetupViewModel.cs
+++ b/OpenUtau/ViewModels/SingerSetupViewModel.cs
@@ -119,13 +119,13 @@ namespace OpenUtau.App.ViewModels {
                 var directory = Path.Combine(basePath, destinationDir);
                 if (Directory.Exists(directory)) {
                     var ex = new MessageCustomizableException(
-                        $"Content is already exists: {directory}",
-                        $"<translate:singersetup.alreadyexists>: {directory}",
-                        new IOException($"Content is already exists:\n{directory}"),
-                        false
+                        $"The folder already exists: {directory}",
+                        $"<translate:singersetup.alreadyexists>",
+                        new IOException($"The folder already exists:\n{directory}"),
+                        false,
+                        [directory]
                     );
                     DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
-                    return;
                 }
             }
             Step++;

--- a/OpenUtau/ViewModels/SingerSetupViewModel.cs
+++ b/OpenUtau/ViewModels/SingerSetupViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,7 +16,10 @@ using SharpCompress.Readers;
 
 namespace OpenUtau.App.ViewModels {
     public class SingerSetupViewModel : ViewModelBase {
+        public bool IsSinger => fileType == 0;
+        [Reactive] public string Title { get; set; } = ThemeManager.GetString("singersetup.title");
         [Reactive] public int Step { get; set; }
+        [Reactive] public string Description { get; set; } = string.Empty;
         public ObservableCollection<string> TextItems => textItems;
         [Reactive] public string ArchiveFilePath { get; set; } = string.Empty;
         public Encoding[] Encodings { get; set; } = new Encoding[] {
@@ -33,6 +37,10 @@ namespace OpenUtau.App.ViewModels {
         public string[] SingerTypes { get; set; } = new[] { "utau", "enunu", "diffsinger" };
         [Reactive] public string SingerType { get; set; }
 
+        private int fileType = 0; // 0: voiceset, 1: editplugin
+        private string destinationDir = string.Empty;
+        private string sourceDir = string.Empty;
+        private string basePath => fileType == 1 ? PathManager.Inst.PluginsPath : PathManager.Inst.SingersInstallPath;
         private ObservableCollectionExtended<string> textItems;
 
         public SingerSetupViewModel() {
@@ -68,16 +76,63 @@ namespace OpenUtau.App.ViewModels {
                 .Subscribe(_ => RefreshTextItems());
         }
 
+        public void CheckFileType() {
+            // Specifications for install.txt: http://utau2008.blog47.fc2.com/blog-entry-379.html
+            string description = string.Empty;
+            try {
+                using (ZipArchive archive = ZipFile.OpenRead(ArchiveFilePath)) {
+                    var installTxt = archive.Entries.FirstOrDefault(entry => entry.FullName.Equals("install.txt"));
+                    if (installTxt != null) {
+                        using (StreamReader reader = new StreamReader(installTxt.Open(), TextEncoding)) {
+                            string? line;
+                            while ((line = reader.ReadLine()) != null) {
+                                if (line == "type=editplugin") {
+                                    fileType = 1;
+                                    Title = ThemeManager.GetString("singersetup.plugintitle");
+                                } else if (line.StartsWith("folder=")) {
+                                    destinationDir = line.Replace("folder=", "").Trim();
+                                } else if (line.StartsWith("contentsdir=")) {
+                                    sourceDir = line.Replace("contentsdir=", "").Trim();
+                                } else if (line.StartsWith("description=")) {
+                                    description = line.Replace("\\n", "\n").Replace("description=", "\n\n----------------\n\n");
+                                }
+                            }
+                        }
+                    }
+                }
+                if (string.IsNullOrEmpty(destinationDir)) {
+                    destinationDir = Path.GetFileNameWithoutExtension(ArchiveFilePath).Trim();
+                }
+                string type = ThemeManager.GetString(fileType == 1 ? "singersetup.plugin" : "singersetup.singer");
+                Description = string.Format(ThemeManager.GetString("singersetup.description"), [destinationDir, type]) + description;
+            } catch (Exception ex) {
+                DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
+            }
+        }
+
         public void Back() {
             Step--;
         }
 
         public void Next() {
+            if (Step == 0) {
+                var directory = Path.Combine(basePath, destinationDir);
+                if (Directory.Exists(directory)) {
+                    var ex = new MessageCustomizableException(
+                        $"Content is already exists: {directory}",
+                        $"<translate:singersetup.alreadyexists>: {directory}",
+                        new IOException($"Content is already exists:\n{directory}"),
+                        false
+                    );
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
+                    return;
+                }
+            }
             Step++;
         }
 
         private void RefreshArchiveItems() {
-            if (Step != 0) {
+            if (Step != 1) {
                 return;
             }
             if (string.IsNullOrEmpty(ArchiveFilePath)) {
@@ -114,39 +169,40 @@ namespace OpenUtau.App.ViewModels {
         }
 
         private void RefreshTextItems() {
-            if (Step != 1) {
-                return;
-            }
-            if (string.IsNullOrEmpty(ArchiveFilePath)) {
-                textItems.Clear();
-                return;
-            }
-            var readerOptions = new ReaderOptions {
-                ArchiveEncoding = new ArchiveEncoding { Forced = ArchiveEncoding },
-            };
-            using (var archive = ArchiveFactory.Open(ArchiveFilePath, readerOptions)) {
-                try {
+            if (Step == 0 && !string.IsNullOrEmpty(ArchiveFilePath)) {
+                CheckFileType();
+            } else if (Step == 2) {
+                if (string.IsNullOrEmpty(ArchiveFilePath)) {
                     textItems.Clear();
-                    foreach (var entry in archive.Entries.Where(entry => entry.Key!.EndsWith("character.txt") || entry.Key.EndsWith("oto.ini"))) {
-                        using (var stream = entry.OpenEntryStream()) {
-                            using var reader = new StreamReader(stream, TextEncoding);
-                            textItems.Add($"------ {entry.Key} ------");
-                            int count = 0;
-                            while (count < 256 && !reader.EndOfStream) {
-                                string? line = reader.ReadLine();
-                                if (!string.IsNullOrWhiteSpace(line)) {
-                                    textItems.Add(line);
-                                    count++;
+                    return;
+                }
+                var readerOptions = new ReaderOptions {
+                    ArchiveEncoding = new ArchiveEncoding { Forced = ArchiveEncoding },
+                };
+                using (var archive = ArchiveFactory.Open(ArchiveFilePath, readerOptions)) {
+                    try {
+                        textItems.Clear();
+                        foreach (var entry in archive.Entries.Where(entry => entry.Key!.EndsWith("character.txt") || entry.Key.EndsWith("oto.ini"))) {
+                            using (var stream = entry.OpenEntryStream()) {
+                                using var reader = new StreamReader(stream, TextEncoding);
+                                textItems.Add($"------ {entry.Key} ------");
+                                int count = 0;
+                                while (count < 256 && !reader.EndOfStream) {
+                                    string? line = reader.ReadLine();
+                                    if (!string.IsNullOrWhiteSpace(line)) {
+                                        textItems.Add(line);
+                                        count++;
+                                    }
+                                }
+                                if (!reader.EndOfStream) {
+                                    textItems.Add($"...");
                                 }
                             }
-                            if (!reader.EndOfStream) {
-                                textItems.Add($"...");
-                            }
                         }
+                    } catch (Exception ex) {
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
+                        Step--;
                     }
-                } catch (Exception ex) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(ex));
-                    Step--;
                 }
             }
         }
@@ -157,11 +213,14 @@ namespace OpenUtau.App.ViewModels {
             var textEncoding = TextEncoding;
             return Task.Run(() => {
                 try {
-                    var basePath = PathManager.Inst.SingersInstallPath;
-                    var installer = new VoicebankInstaller(basePath, (progress, info) => {
+                    var installer = new ZipInstaller(basePath, (progress, info) => {
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(progress, info));
-                    }, archiveEncoding, textEncoding);
-                    installer.Install(archiveFilePath, SingerType);
+                    }, archiveEncoding, textEncoding, destinationDir, sourceDir);
+                    if (fileType == 1) {
+                        installer.InstallPlugin(archiveFilePath);
+                    } else {
+                        installer.InstallSinger(archiveFilePath, SingerType);
+                    }
 
                     new Task(() => {
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, ThemeManager.GetString("singersetup.succeeded")));

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -313,19 +313,20 @@ namespace OpenUtau.App.ViewModels {
                             DependencyInstaller.Install(file);
                             return;
                         }
-
+                        var vm = new SingerSetupViewModel() {
+                            ArchiveFilePath = file,
+                        };
+                        vm.CheckFileType();
                         var setup = new SingerSetupDialog() {
-                            DataContext = new SingerSetupViewModel() {
-                                ArchiveFilePath = file,
-                            },
+                            DataContext = vm,
                         };
                         _ = setup.ShowDialog(mainWindow);
                         if (setup.Position.Y < 0) {
                             setup.Position = setup.Position.WithY(0);
                         }
                     } catch (Exception e) {
-                        Log.Error(e, $"Failed to install singer {file}");
-                        _ = await MessageBox.ShowError(mainWindow, new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e));
+                        Log.Error(e, $"Failed to install {file}");
+                        _ = await MessageBox.ShowError(mainWindow, new MessageCustomizableException($"Failed to install {file}", $"<translate:errors.failed.install>: {file}", e));
                     }
                 })
             });

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -586,18 +586,20 @@ namespace OpenUtau.App.Views {
                     return;
                 }
 
+                var vm = new SingerSetupViewModel() {
+                    ArchiveFilePath = file,
+                };
+                vm.CheckFileType();
                 var setup = new SingerSetupDialog() {
-                    DataContext = new SingerSetupViewModel() {
-                        ArchiveFilePath = file,
-                    },
+                    DataContext = vm,
                 };
                 _ = setup.ShowDialog(this);
                 if (setup.Position.Y < 0) {
                     setup.Position = setup.Position.WithY(0);
                 }
             } catch (Exception e) {
-                Log.Error(e, $"Failed to install singer {file}");
-                _ = await MessageBox.ShowError(this, new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e));
+                Log.Error(e, $"Failed to install {file}");
+                _ = await MessageBox.ShowError(this, new MessageCustomizableException($"Failed to install {file}", $"<translate:errors.failed.install>: {file}", e));
             }
         }
 
@@ -863,18 +865,21 @@ namespace OpenUtau.App.Views {
                 }
             } else if (ext == ".zip" || ext == ".rar" || ext == ".uar") {
                 try {
-                    var setup = new SingerSetupDialog() {
-                        DataContext = new SingerSetupViewModel() {
-                            ArchiveFilePath = file,
-                        },
+                    var vm = new SingerSetupViewModel() {
+                        ArchiveFilePath = file,
                     };
+                    vm.CheckFileType();
+                    var setup = new SingerSetupDialog() {
+                        DataContext = vm,
+                    };
+
                     _ = setup.ShowDialog(this);
                     if (setup.Position.Y < 0) {
                         setup.Position = setup.Position.WithY(0);
                     }
                 } catch (Exception e) {
-                    Log.Error(e, $"Failed to install singer {file}");
-                    _ = await MessageBox.ShowError(this, new MessageCustomizableException($"Failed to install singer {file}", $"<translate:errors.failed.installsinger>: {file}", e));
+                    Log.Error(e, $"Failed to install {file}");
+                    _ = await MessageBox.ShowError(this, new MessageCustomizableException($"Failed to install {file}", $"<translate:errors.failed.install>: {file}", e));
                 }
             } else if (ext == Core.Vogen.VogenSingerInstaller.FileExt) {
                 Core.Vogen.VogenSingerInstaller.Install(file);

--- a/OpenUtau/Views/SingerSetupDialog.axaml
+++ b/OpenUtau/Views/SingerSetupDialog.axaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d" Width="600" Height="400" MinWidth="600" MinHeight="400"
         x:Class="OpenUtau.App.Views.SingerSetupDialog"
         Icon="/Assets/open-utau.ico"
-        Title="{DynamicResource singersetup.title}"
+        Title="{Binding Title}"
         WindowStartupLocation="CenterScreen">
   <Window.Resources>
     <vm:EncodingNameConverter x:Key="encodingNameConverter"/>
@@ -15,6 +15,32 @@
     <vm:SingerSetupViewModel/>
   </Design.DataContext>
   <Carousel SelectedIndex="{Binding Step}" Margin="{Binding $parent.WindowDecorationMargin}">
+    <!--Information-->
+    <Grid>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="40"/>
+        <RowDefinition Height="1*"/>
+        <RowDefinition Height="40"/>
+      </Grid.RowDefinitions>
+      <StackPanel Grid.Row="0" Margin="10" Spacing="10" Orientation="Horizontal" HorizontalAlignment="Right">
+        <TextBlock Margin="0,1,0,0" Text="{DynamicResource singersetup.textfileencoding}"/>
+        <ComboBox Grid.Row="0" Width="240" Margin="0" ItemsSource="{Binding Encodings}" SelectedItem="{Binding TextEncoding}">
+          <ComboBox.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Text="{Binding Converter={StaticResource encodingNameConverter}}"/>
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
+      </StackPanel>
+      <TextBlock Margin="20" Grid.Row="1" Text="{Binding Description}" TextWrapping="Wrap"/>
+      <Grid Grid.Row="2" Margin="10" HorizontalAlignment="Stretch">
+        <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="10">
+          <TextBlock Margin="0,1,0,0" Text="{DynamicResource singersetup.agreement}"/>
+          <Button Margin="0" Command="{Binding Next}"
+                  Content="{DynamicResource singersetup.next}"/>
+        </StackPanel>
+      </Grid>
+    </Grid>
     <!--Archive File Encoding-->
     <Grid>
       <Grid.RowDefinitions>
@@ -34,10 +60,14 @@
       </StackPanel>
       <ListBox Grid.Row="1" Margin="10,0" Focusable="False" ItemsSource="{Binding TextItems}"/>
       <Grid Grid.Row="2" Margin="10" HorizontalAlignment="Stretch">
+        <Button Margin="0" Command="{Binding Back}" HorizontalAlignment="Left"
+                 Content="{DynamicResource singersetup.back}"/>
         <StackPanel HorizontalAlignment="Right" Orientation="Horizontal" Spacing="10">
-          <TextBlock Margin="0,1,0,0" Text="{DynamicResource singersetup.archivefileencoding.prompt}"></TextBlock>
-          <Button Margin="0" Command="{Binding Next}"
+          <TextBlock Margin="0,1,0,0" Text="{DynamicResource singersetup.archivefileencoding.prompt}"/>
+          <Button Margin="0" Command="{Binding Next}" IsVisible="{Binding IsSinger}"
                   Content="{DynamicResource singersetup.next}"/>
+          <Button Margin="0" Click="InstallClicked" IsVisible="{Binding !IsSinger}"
+                  Content="{DynamicResource singersetup.install}"/>
         </StackPanel>
       </Grid>
     </Grid>

--- a/OpenUtau/Views/SingerSetupDialog.axaml.cs
+++ b/OpenUtau/Views/SingerSetupDialog.axaml.cs
@@ -20,7 +20,7 @@ namespace OpenUtau.App.Views {
             var task = viewModel.Install();
             task.ContinueWith((task) => {
                 if (task.IsFaulted) {
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(new MessageCustomizableException("Failed to install singer.", "<translate:singersetup.failed>", task.Exception)));
+                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(new MessageCustomizableException("Failed to install.", "<translate:singersetup.failed>", task.Exception)));
                 }
             }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, scheduler);
             Close();


### PR DESCRIPTION
## Development Background
It is common practice to include an install.txt file (http://utau2008.blog47.fc2.com/blog-entry-379.html) in voice bank and plugin ZIP archives.
By consulting install.txt, the installation process should branch based on whether the files should be installed as a voice bank or as a plugin.

## Changes
- Rename `VoicebankInstaller.cs` to `ZipInstaller.cs`
- When install.txt contains `type=editplugin`, it installs as a plugin.
- When install.txt contains `folder=`, sets the plugin installation folder to the specified folder name (voice banks not yet supported).
- When install.txt contains `contentsdir=`, only the specified folder within the zip file is copied (voice banks not yet supported).
- When install.txt contains `description=`, it is displayed during installation.
- A dialog is displayed if the destination folder already exists.

## Translation memo
ファイルの利用規約に同意する場合は次へを押してください。
"{0}" を{1}としてインストールします。
インストール先フォルダ "{0}" が既に存在します。既存のデータとインストールデータは統合されます。