### PR TITLE
Fix builds due to syntax error

### DIFF
--- a/OpenUtau.Core/Util/Onnx.cs
+++ b/OpenUtau.Core/Util/Onnx.cs
@@ -43,10 +43,10 @@ namespace OpenUtau.Core {
                 "CPU",
                 "NNAPI"
                 };
+            } 
             return new List<string> {
                 "CPU"
                 };
-            }
         }
 
         public static List<GpuInfo> getGpuInfo() {


### PR DESCRIPTION
Fix failing builds caused by a missing bracket in Onnx.cs, accidentally caused by #1812

Edit: seems #1812 is not applicable at all and should be reverted. That would also make this PR obsolete