### PR TITLE
Fix yaml timing entry overrides with new instance of the phonemizer

### DIFF
--- a/OpenUtau.Plugin.Builtin/ArpasingPlusPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ArpasingPlusPhonemizer.cs
@@ -27,7 +27,7 @@ namespace OpenUtau.Plugin.Builtin {
         "aam", "am", "axm", "aem", "ahm", "aom", "om", "awm", "aum", "aym", "aim", "ehm", "em", "eym", "eim", "ihm", "iym", "im", "owm", "oum", "oym", "oim", "uhm", "uwm", "um", "oh",
         "eu", "oe", "yw", "yx", "wx", "ox", "ex", "ea", "ia", "oa", "ua", "ean", "eam", "eang"
         };
-        private readonly string[] consonants = "b,ch,d,dh,dr,dx,f,g,hh,jh,k,l,m,n,nx,ng,p,q,r,s,sh,t,th,tr,v,w,y,z,zh".Split(',');
+        private string[] consonants = "".Split(',');
         private static string[] affricate = "".Split(',');
         private static string[] fricative = "".Split(',');
         private static string[] aspirate = "".Split(',');
@@ -36,7 +36,7 @@ namespace OpenUtau.Plugin.Builtin {
         private static string[] nasal = "".Split(',');
         private static string[] stop = "".Split(',');
         private static string[] tap = "".Split(',');
-        private static Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
+        private Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
 
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;

--- a/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
@@ -38,7 +38,7 @@ namespace OpenUtau.Plugin.Builtin {
         private static string[] nasal = "".Split(',');
         private static string[] stop = "".Split(',');
         private static string[] tap = "".Split(',');
-        private static Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
+        private Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
 
         private Dictionary<string, string> dictionaryReplacements = ("aa=A;ae={;ah=V;ao=O;aw=aU;ax=@;ay=aI;" +
             "b=b;ch=tS;d=d;dh=D;" + "dx=4;eh=E;el=@l;em=@m;en=@n;eng=@N;er=3;ey=eI;f=f;g=g;hh=h;ih=I;iy=i;jh=dZ;k=k;l=l;m=m;n=n;ng=N;ow=oU;oy=OI;" +

--- a/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
@@ -29,7 +29,7 @@ namespace OpenUtau.Plugin.Builtin {
         };
         private static string[] diphthongs = { "ay", "ey", "oy", "aw", "ow" };
         private static string[] c_cR = { "n" };
-        private static string[] consonants = "b,ch,d,dh,dr,dx,f,g,hh,jh,k,l,m,n,nx,ng,p,q,r,s,sh,t,th,tr,v,w,y,z,zh".Split(',');
+        private static string[] consonants = "".Split(',');
         private static string[] affricate = "".Split(',');
         private static string[] fricative = "".Split(',');
         private static string[] aspirate = "".Split(',');
@@ -77,7 +77,7 @@ namespace OpenUtau.Plugin.Builtin {
             value => value.Last().ToString()
         );
 
-        private static Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
+        private Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
 
         private readonly string[] ccvException = { "ch", "dh", "dx", "fh", "gh", "hh", "jh", "kh", "ph", "ng", "sh", "th", "vh", "wh", "zh" };
         private readonly string[] RomajiException = { "a", "e", "i", "o", "u" };

--- a/OpenUtau.Plugin.Builtin/FilipinoPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/FilipinoPhonemizer.cs
@@ -18,7 +18,7 @@ namespace OpenUtau.Plugin.Builtin {
         private string[] vowels = {
         "a", "e", "i", "o", "u", "ay", "ey", "oy", "uy", "aw", "ew", "ow", "iw"
         };
-        private readonly string[] consonants = "b,ch,d,dh,f,g,hh,jh,k,l,m,n,ng,p,q,r,s,sh,t,th,v,w,y,z,zh".Split(',');
+        private string[] consonants = "".Split(',');
         private static string[] affricate = "".Split(',');
         private static string[] fricative = "".Split(',');
         private static string[] aspirate = "".Split(',');
@@ -27,7 +27,7 @@ namespace OpenUtau.Plugin.Builtin {
         private static string[] nasal = "".Split(',');
         private static string[] stop = "".Split(',');
         private static string[] tap = "".Split(',');
-        private static Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
+        private Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "";


### PR DESCRIPTION
- Fix bug with yaml defined phoneme timings (same bug with dictionary entries before when a new instance of the same phonemizer overrides the loaded data with the new one)