### PR TITLE
Support for Multiple Custom Themes

### DIFF
--- a/OpenUtau.Core/Util/PathManager.cs
+++ b/OpenUtau.Core/Util/PathManager.cs
@@ -83,7 +83,7 @@ namespace OpenUtau.Core {
         public string LogsPath => Path.Combine(DataPath, "Logs");
         public string LogFilePath => Path.Combine(DataPath, "Logs", "log.txt");
         public string PrefsFilePath => Path.Combine(DataPath, "prefs.json");
-        public string ThemeFilePath => Path.Combine(DataPath, "theme.yaml");
+        public string ThemesPath => Path.Combine(DataPath, "Themes");
         public string NotePresetsFilePath => Path.Combine(DataPath, "notepresets.json");
         public string BackupsPath => Path.Combine(DataPath, "Backups");
 

--- a/OpenUtau.Core/Util/Preferences.cs
+++ b/OpenUtau.Core/Util/Preferences.cs
@@ -142,7 +142,7 @@ namespace OpenUtau.Core.Util {
             public int? PlaybackDeviceIndex;
             public bool ShowPrefs = true;
             public bool ShowTips = true;
-            public int Theme;
+            public string ThemeName = "Light";
             public bool PenPlusDefault = false;
             public int DegreeStyle;
             public bool UseTrackColor = false;

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -95,22 +95,24 @@ namespace OpenUtau.App {
             var light = (IResourceDictionary) Current.Resources["themes-light"]!;
             var dark = (IResourceDictionary) Current.Resources["themes-dark"]!;
             var custom = (IResourceDictionary) Current.Resources["themes-custom"]!;
-            if (Core.Util.Preferences.Default.Theme == 0) {
-                ApplyTheme(light);
-                Current.RequestedThemeVariant = ThemeVariant.Light;
-            } 
-            if (Core.Util.Preferences.Default.Theme == 1) {
-                ApplyTheme(dark);
-                Current.RequestedThemeVariant = ThemeVariant.Dark;
-            }
-            if (Core.Util.Preferences.Default.Theme == 2) {
-                ApplyTheme(custom);
-                CustomTheme.ApplyTheme();
-                if (CustomTheme.Default.IsDarkMode == true) {
-                    Current.RequestedThemeVariant = ThemeVariant.Dark;
-                } else {
+            switch (Core.Util.Preferences.Default.ThemeName) { 
+                case "Light":
+                    ApplyTheme(light);
                     Current.RequestedThemeVariant = ThemeVariant.Light;
-                }
+                    break;
+                case "Dark":
+                    ApplyTheme(dark);
+                    Current.RequestedThemeVariant = ThemeVariant.Dark;
+                    break;
+                default:
+                    ApplyTheme(custom);
+                    CustomTheme.ApplyTheme(Core.Util.Preferences.Default.ThemeName);
+                    if (CustomTheme.Default.IsDarkMode == true) {
+                        Current.RequestedThemeVariant = ThemeVariant.Dark;
+                    } else {
+                        Current.RequestedThemeVariant = ThemeVariant.Light;
+                    }
+                    break;
             }
             ThemeManager.LoadTheme();
         }

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -93,19 +92,22 @@ namespace OpenUtau.App {
             if (Current == null) {
                 return;
             }
-            var light = (IResourceDictionary) Current.Resources["themes-light"]!;
-            var dark = (IResourceDictionary) Current.Resources["themes-dark"]!;
-            var custom = (IResourceDictionary) Current.Resources["themes-custom"]!;
+            var light = (IResourceProvider)Current.Resources["themes-light"]!;
+            var dark = (IResourceProvider)Current.Resources["themes-dark"]!;
+            var custom = (IResourceProvider)Current.Resources["themes-custom"]!;
+            Current.Resources.MergedDictionaries.Remove(light);
+            Current.Resources.MergedDictionaries.Remove(dark);
+            Current.Resources.MergedDictionaries.Remove(custom);
             if (Core.Util.Preferences.Default.Theme == 0) {
-                OverrideTheme(light);
+                Current.Resources.MergedDictionaries.Add(light);
                 Current.RequestedThemeVariant = ThemeVariant.Light;
             } 
             if (Core.Util.Preferences.Default.Theme == 1) {
-                OverrideTheme(dark);
+                Current.Resources.MergedDictionaries.Add(dark);
                 Current.RequestedThemeVariant = ThemeVariant.Dark;
             }
             if (Core.Util.Preferences.Default.Theme == 2) {
-                OverrideTheme(custom);
+                Current.Resources.MergedDictionaries.Add(custom);
                 CustomTheme.ApplyTheme();
                 if (CustomTheme.Default.IsDarkMode == true) {
                     Current.RequestedThemeVariant = ThemeVariant.Dark;
@@ -114,13 +116,6 @@ namespace OpenUtau.App {
                 }
             }
             ThemeManager.LoadTheme();
-        }
-
-        private static void OverrideTheme(IResourceDictionary resDict) { 
-            foreach (var item in resDict) {
-                var res = Current?.Resources;
-                res![item.Key] = item.Value;
-            }
         }
     }
 }

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -92,22 +92,19 @@ namespace OpenUtau.App {
             if (Current == null) {
                 return;
             }
-            var light = (IResourceProvider)Current.Resources["themes-light"]!;
-            var dark = (IResourceProvider)Current.Resources["themes-dark"]!;
-            var custom = (IResourceProvider)Current.Resources["themes-custom"]!;
-            Current.Resources.MergedDictionaries.Remove(light);
-            Current.Resources.MergedDictionaries.Remove(dark);
-            Current.Resources.MergedDictionaries.Remove(custom);
+            var light = (IResourceDictionary) Current.Resources["themes-light"]!;
+            var dark = (IResourceDictionary) Current.Resources["themes-dark"]!;
+            var custom = (IResourceDictionary) Current.Resources["themes-custom"]!;
             if (Core.Util.Preferences.Default.Theme == 0) {
-                Current.Resources.MergedDictionaries.Add(light);
+                OverrideTheme(light);
                 Current.RequestedThemeVariant = ThemeVariant.Light;
             } 
             if (Core.Util.Preferences.Default.Theme == 1) {
-                Current.Resources.MergedDictionaries.Add(dark);
+                OverrideTheme(dark);
                 Current.RequestedThemeVariant = ThemeVariant.Dark;
             }
             if (Core.Util.Preferences.Default.Theme == 2) {
-                Current.Resources.MergedDictionaries.Add(custom);
+                OverrideTheme(custom);
                 CustomTheme.ApplyTheme();
                 if (CustomTheme.Default.IsDarkMode == true) {
                     Current.RequestedThemeVariant = ThemeVariant.Dark;
@@ -116,6 +113,13 @@ namespace OpenUtau.App {
                 }
             }
             ThemeManager.LoadTheme();
+        }
+
+        private static void OverrideTheme(IResourceDictionary resDict) { 
+            foreach (var item in resDict) {
+                var res = Current?.Resources;
+                res![item.Key] = item.Value;
+            }
         }
     }
 }

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -92,22 +93,19 @@ namespace OpenUtau.App {
             if (Current == null) {
                 return;
             }
-            var light = (IResourceProvider)Current.Resources["themes-light"]!;
-            var dark = (IResourceProvider)Current.Resources["themes-dark"]!;
-            var custom = (IResourceProvider)Current.Resources["themes-custom"]!;
-            Current.Resources.MergedDictionaries.Remove(light);
-            Current.Resources.MergedDictionaries.Remove(dark);
-            Current.Resources.MergedDictionaries.Remove(custom);
+            var light = (IResourceDictionary) Current.Resources["themes-light"]!;
+            var dark = (IResourceDictionary) Current.Resources["themes-dark"]!;
+            var custom = (IResourceDictionary) Current.Resources["themes-custom"]!;
             if (Core.Util.Preferences.Default.Theme == 0) {
-                Current.Resources.MergedDictionaries.Add(light);
+                OverrideTheme(light);
                 Current.RequestedThemeVariant = ThemeVariant.Light;
             } 
             if (Core.Util.Preferences.Default.Theme == 1) {
-                Current.Resources.MergedDictionaries.Add(dark);
+                OverrideTheme(dark);
                 Current.RequestedThemeVariant = ThemeVariant.Dark;
             }
             if (Core.Util.Preferences.Default.Theme == 2) {
-                Current.Resources.MergedDictionaries.Add(custom);
+                OverrideTheme(custom);
                 CustomTheme.ApplyTheme();
                 if (CustomTheme.Default.IsDarkMode == true) {
                     Current.RequestedThemeVariant = ThemeVariant.Dark;
@@ -116,6 +114,13 @@ namespace OpenUtau.App {
                 }
             }
             ThemeManager.LoadTheme();
+        }
+
+        private static void OverrideTheme(IResourceDictionary resDict) { 
+            foreach (var item in resDict) {
+                var res = Current?.Resources;
+                res![item.Key] = item.Value;
+            }
         }
     }
 }

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -96,15 +96,15 @@ namespace OpenUtau.App {
             var dark = (IResourceDictionary) Current.Resources["themes-dark"]!;
             var custom = (IResourceDictionary) Current.Resources["themes-custom"]!;
             if (Core.Util.Preferences.Default.Theme == 0) {
-                OverrideTheme(light);
+                ApplyTheme(light);
                 Current.RequestedThemeVariant = ThemeVariant.Light;
             } 
             if (Core.Util.Preferences.Default.Theme == 1) {
-                OverrideTheme(dark);
+                ApplyTheme(dark);
                 Current.RequestedThemeVariant = ThemeVariant.Dark;
             }
             if (Core.Util.Preferences.Default.Theme == 2) {
-                OverrideTheme(custom);
+                ApplyTheme(custom);
                 CustomTheme.ApplyTheme();
                 if (CustomTheme.Default.IsDarkMode == true) {
                     Current.RequestedThemeVariant = ThemeVariant.Dark;
@@ -115,7 +115,7 @@ namespace OpenUtau.App {
             ThemeManager.LoadTheme();
         }
 
-        private static void OverrideTheme(IResourceDictionary resDict) { 
+        private static void ApplyTheme(IResourceDictionary resDict) { 
             foreach (var item in resDict) {
                 var res = Current?.Resources;
                 res![item.Key] = item.Value;

--- a/OpenUtau/App.axaml.cs
+++ b/OpenUtau/App.axaml.cs
@@ -116,8 +116,8 @@ namespace OpenUtau.App {
         }
 
         private static void ApplyTheme(IResourceDictionary resDict) { 
+            var res = Current?.Resources;
             foreach (var item in resDict) {
-                var res = Current?.Resources;
                 res![item.Key] = item.Value;
             }
         }

--- a/OpenUtau/Colors/CustomTheme.axaml.cs
+++ b/OpenUtau/Colors/CustomTheme.axaml.cs
@@ -20,26 +20,34 @@ public class CustomTheme {
 
     public static void Load(string themeName) {
         if (!string.IsNullOrEmpty(themeName) && Themes.TryGetValue(themeName, out var themePath) && File.Exists(themePath)) {
-            Default = Yaml.DefaultDeserializer.Deserialize<ThemeYaml>(File.ReadAllText(themePath,
-                Encoding.UTF8));
-        } else {
-            Preferences.Default.ThemeName = "Light";
-            Default = new ThemeYaml();
+            try {
+                Default = Yaml.DefaultDeserializer.Deserialize<ThemeYaml>(File.ReadAllText(themePath, Encoding.UTF8));
+                return;
+            } catch (Exception e) {
+                Log.Error(e, $"Failed to parse yaml in {themePath}");
+            }
         }
+
+        Preferences.Default.ThemeName = "Light";
+        Default = new ThemeYaml();
     }
 
     public static void ListThemes() {
         Themes.Clear();
         Directory.CreateDirectory(PathManager.Inst.ThemesPath);
         foreach (var item in Directory.EnumerateFiles(PathManager.Inst.ThemesPath, "*.yaml")) {
-            string baseName = Yaml.DefaultDeserializer.Deserialize<ThemeYaml>(File.ReadAllText(item, Encoding.UTF8)).Name;
-            string themeName = baseName;
-            int dupIter = 1;
-            while (Themes.ContainsKey(themeName)) {
-                themeName = $"{baseName} ({dupIter})";
-                dupIter++;
+            try {
+                string baseName = Yaml.DefaultDeserializer.Deserialize<ThemeYaml>(File.ReadAllText(item, Encoding.UTF8)).Name;
+                string themeName = baseName;
+                int dupIter = 1;
+                while (Themes.ContainsKey(themeName)) {
+                    themeName = $"{baseName} ({dupIter})";
+                    dupIter++;
+                }
+                Themes.Add(themeName, item);
+            } catch (Exception e) {
+                Log.Error(e, $"Failed to parse yaml in {item}");
             }
-            Themes.Add(themeName, item);
         }
     }
 

--- a/OpenUtau/Colors/CustomTheme.axaml.cs
+++ b/OpenUtau/Colors/CustomTheme.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Media;
 using OpenUtau.Core;
 using OpenUtau.Core.Util;
+using Serilog;
 
 namespace OpenUtau.Colors;
 public class CustomTheme {
@@ -47,45 +48,53 @@ public class CustomTheme {
 
         if (Application.Current != null) {
             Application.Current.Resources["IsDarkMode"] = Default.IsDarkMode; 
-            Application.Current.Resources["BackgroundColor"] = Color.Parse($"{Default.BackgroundColor}");
-            Application.Current.Resources["BackgroundColorPointerOver"] = Color.Parse($"{Default.BackgroundColorPointerOver}");
-            Application.Current.Resources["BackgroundColorPressed"] = Color.Parse($"{Default.BackgroundColorPressed}");
-            Application.Current.Resources["BackgroundColorDisabled"] = Color.Parse($"{Default.BackgroundColorDisabled}");  
-            
-            Application.Current.Resources["ForegroundColor"] = Color.Parse($"{Default.ForegroundColor}");
-            Application.Current.Resources["ForegroundColorPointerOver"] = Color.Parse($"{Default.ForegroundColorPointerOver}");
-            Application.Current.Resources["ForegroundColorPressed"] = Color.Parse($"{Default.ForegroundColorPressed}");
-            Application.Current.Resources["ForegroundColorDisabled"] = Color.Parse($"{Default.ForegroundColorDisabled}");
-            
-            Application.Current.Resources["BorderColor"] = Color.Parse($"{Default.BorderColor}");
-            Application.Current.Resources["BorderColorPointerOver"] = Color.Parse($"{Default.BorderColorPointerOver}");
-            
-            Application.Current.Resources["SystemAccentColor"] = Color.Parse($"{Default.SystemAccentColor}");
-            Application.Current.Resources["SystemAccentColorLight1"] = Color.Parse($"{Default.SystemAccentColorLight1}");
-            Application.Current.Resources["SystemAccentColorDark1"] = Color.Parse($"{Default.SystemAccentColorDark1}");
-            
-            Application.Current.Resources["NeutralAccentColor"] = Color.Parse($"{Default.NeutralAccentColor}");
-            Application.Current.Resources["NeutralAccentColorPointerOver"] = Color.Parse($"{Default.NeutralAccentColorPointerOver}");
-            Application.Current.Resources["AccentColor1"] = Color.Parse($"{Default.AccentColor1}");
-            Application.Current.Resources["AccentColor2"] = Color.Parse($"{Default.AccentColor2}");
-            Application.Current.Resources["AccentColor3"] = Color.Parse($"{Default.AccentColor3}");
-            
-            Application.Current.Resources["TickLineColor"] = Color.Parse($"{Default.TickLineColor}");
-            Application.Current.Resources["BarNumberColor"] = Color.Parse($"{Default.BarNumberColor}");
-            Application.Current.Resources["FinalPitchColor"] = Color.Parse($"{Default.FinalPitchColor}");
-            Application.Current.Resources["TrackBackgroundAltColor"] = Color.Parse($"{Default.TrackBackgroundAltColor}");
-            
-            Application.Current.Resources["WhiteKeyColorLeft"] = Color.Parse($"{Default.WhiteKeyColorLeft}");
-            Application.Current.Resources["WhiteKeyColorRight"] = Color.Parse($"{Default.WhiteKeyColorRight}");
-            Application.Current.Resources["WhiteKeyNameColor"] = Color.Parse($"{Default.WhiteKeyNameColor}");
-            
-            Application.Current.Resources["CenterKeyColorLeft"] = Color.Parse($"{Default.CenterKeyColorLeft}");
-            Application.Current.Resources["CenterKeyColorRight"] = Color.Parse($"{Default.CenterKeyColorRight}");
-            Application.Current.Resources["CenterKeyNameColor"] = Color.Parse($"{Default.CenterKeyNameColor}");
-            
-            Application.Current.Resources["BlackKeyColorLeft"] = Color.Parse($"{Default.BlackKeyColorLeft}");
-            Application.Current.Resources["BlackKeyColorRight"] = Color.Parse($"{Default.BlackKeyColorRight}");
-            Application.Current.Resources["BlackKeyNameColor"] = Color.Parse($"{Default.BlackKeyNameColor}");
+            SetResourceColor("BackgroundColor", Default.BackgroundColor);
+            SetResourceColor("BackgroundColorPointerOver", Default.BackgroundColorPointerOver);
+            SetResourceColor("BackgroundColorPressed", Default.BackgroundColorPressed);
+            SetResourceColor("BackgroundColorDisabled", Default.BackgroundColorDisabled);
+
+            SetResourceColor("ForegroundColor", Default.ForegroundColor);
+            SetResourceColor("ForegroundColorPointerOver", Default.ForegroundColorPointerOver);
+            SetResourceColor("ForegroundColorPressed", Default.ForegroundColorPressed);
+            SetResourceColor("ForegroundColorDisabled", Default.ForegroundColorDisabled);
+
+            SetResourceColor("BorderColor", Default.BorderColor);
+            SetResourceColor("BorderColorPointerOver", Default.BorderColorPointerOver);
+
+            SetResourceColor("SystemAccentColor", Default.SystemAccentColor);
+            SetResourceColor("SystemAccentColorLight1", Default.SystemAccentColorLight1);
+            SetResourceColor("SystemAccentColorDark1", Default.SystemAccentColorDark1);
+
+            SetResourceColor("NeutralAccentColor", Default.NeutralAccentColor);
+            SetResourceColor("NeutralAccentColorPointerOver", Default.NeutralAccentColorPointerOver);
+            SetResourceColor("AccentColor1", Default.AccentColor1);
+            SetResourceColor("AccentColor2", Default.AccentColor2);
+            SetResourceColor("AccentColor3", Default.AccentColor3);
+
+            SetResourceColor("TickLineColor", Default.TickLineColor);
+            SetResourceColor("BarNumberColor", Default.BarNumberColor);
+            SetResourceColor("FinalPitchColor", Default.FinalPitchColor);
+            SetResourceColor("TrackBackgroundAltColor", Default.TrackBackgroundAltColor);
+
+            SetResourceColor("WhiteKeyColorLeft", Default.WhiteKeyColorLeft);
+            SetResourceColor("WhiteKeyColorRight", Default.WhiteKeyColorRight);
+            SetResourceColor("WhiteKeyNameColor", Default.WhiteKeyNameColor);
+
+            SetResourceColor("CenterKeyColorLeft", Default.CenterKeyColorLeft);
+            SetResourceColor("CenterKeyColorRight", Default.CenterKeyColorRight);
+            SetResourceColor("CenterKeyNameColor", Default.CenterKeyNameColor);
+
+            SetResourceColor("BlackKeyColorLeft", Default.BlackKeyColorLeft);
+            SetResourceColor("BlackKeyColorRight", Default.BlackKeyColorRight);
+            SetResourceColor("BlackKeyNameColor", Default.BlackKeyNameColor);
+        }
+    }
+
+    private static void SetResourceColor(string res, string colorStr) {
+        if (Color.TryParse(colorStr, out var color)) {
+            Application.Current!.Resources[res] = color;
+        } else {
+            Log.Error($"Failed to parse color \"{colorStr}\" in {Default.Name} custom theme");
         }
     }
     

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
+using System.Collections.ObjectModel;
 using OpenUtau.Audio;
 using OpenUtau.Classic;
 using OpenUtau.Core;
@@ -92,13 +93,13 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public GpuInfo OnnxGpu { get; set; }
       
         // Appearance
-        [Reactive] public int Theme { get; set; }
-        [Reactive] public string CustomName { get; set; } = Colors.CustomTheme.Default.Name;
+        [Reactive] public string ThemeName { get; set; }
         [Reactive] public int DegreeStyle { get; set; }
         [Reactive] public bool UseTrackColor { get; set; }
         [Reactive] public bool ShowPortrait { get; set; }
         [Reactive] public bool ShowIcon { get; set; }
         [Reactive] public bool ShowGhostNotes { get; set; }
+        public ObservableCollection<string> ThemeItems { get; } = [];
 
         // UTAU
         public List<string> DefaultRendererOptions { get; set; }
@@ -170,7 +171,9 @@ namespace OpenUtau.App.ViewModels {
             DiffSingerTensorCache = Preferences.Default.DiffSingerTensorCache;
             DiffSingerLangCodeHide = Preferences.Default.DiffSingerLangCodeHide;
             SkipRenderingMutedTracks = Preferences.Default.SkipRenderingMutedTracks;
-            Theme = Preferences.Default.Theme;
+            Colors.CustomTheme.ListThemes();
+            ThemeItems = ["Light", "Dark", ..Colors.CustomTheme.Themes.Select(v => v.Key)!];
+            ThemeName = Preferences.Default.ThemeName;
             PenPlusDefault = Preferences.Default.PenPlusDefault;
             DegreeStyle = Preferences.Default.DegreeStyle;
             UseTrackColor = Preferences.Default.UseTrackColor;
@@ -184,7 +187,7 @@ namespace OpenUtau.App.ViewModels {
             RememberMid = Preferences.Default.RememberMid;
             RememberUst = Preferences.Default.RememberUst;
             RememberVsqx = Preferences.Default.RememberVsqx;
-            ClearCacheOnQuit = Preferences.Default.ClearCacheOnQuit;
+            ClearCacheOnQuit = Preferences.Default.ClearCacheOnQuit;        
 
             this.WhenAnyValue(vm => vm.AudioOutputDevice)
                 .WhereNotNull()
@@ -249,9 +252,9 @@ namespace OpenUtau.App.ViewModels {
                     Preferences.Default.SortingOrder = so?.Name ?? null;
                     Preferences.Save();
                 });
-            this.WhenAnyValue(vm => vm.Theme)
-                .Subscribe(theme => {
-                    Preferences.Default.Theme = theme;
+            this.WhenAnyValue(vm => vm.ThemeName)
+                .Subscribe(themeName => {
+                    Preferences.Default.ThemeName = themeName;
                     Preferences.Save();
                     App.SetTheme();
                 });

--- a/OpenUtau/ViewModels/PreferencesViewModel.cs
+++ b/OpenUtau/ViewModels/PreferencesViewModel.cs
@@ -172,7 +172,7 @@ namespace OpenUtau.App.ViewModels {
             DiffSingerLangCodeHide = Preferences.Default.DiffSingerLangCodeHide;
             SkipRenderingMutedTracks = Preferences.Default.SkipRenderingMutedTracks;
             Colors.CustomTheme.ListThemes();
-            ThemeItems = ["Light", "Dark", ..Colors.CustomTheme.Themes.Select(v => v.Key)!];
+            ThemeItems = ["Light", "Dark", ..Colors.CustomTheme.Themes.Select(v => v.Key)];
             ThemeName = Preferences.Default.ThemeName;
             PenPlusDefault = Preferences.Default.PenPlusDefault;
             DegreeStyle = Preferences.Default.DegreeStyle;

--- a/OpenUtau/Views/PreferencesDialog.axaml
+++ b/OpenUtau/Views/PreferencesDialog.axaml
@@ -209,11 +209,7 @@
         <!-- Appearance -->
         <StackPanel>
           <TextBlock Text="{DynamicResource prefs.appearance.theme}" Margin="0,10,0,0"/>
-          <ComboBox SelectedIndex="{Binding Theme}">
-            <ComboBoxItem Content="{DynamicResource prefs.appearance.theme.light}"/>
-            <ComboBoxItem Content="{DynamicResource prefs.appearance.theme.dark}"/>
-            <ComboBoxItem Content="{Binding CustomName}"/>
-          </ComboBox>
+          <ComboBox ItemsSource="{Binding ThemeItems}" SelectedItem="{Binding ThemeName}"/>
           <TextBlock Text="{DynamicResource prefs.appearance.degree}" Margin="0,10,0,0"/>
           <ComboBox SelectedIndex="{Binding DegreeStyle}">
             <ComboBoxItem Content="{DynamicResource prefs.appearance.degree.off}"/>


### PR DESCRIPTION
Add support for multple custom themes by placing yaml files in `OpenUtau/Themes` directory.

![multi-custom-theme](https://github.com/user-attachments/assets/96828bf1-52c0-4149-91e1-817ce6af4268)

Technical Changes:
- Replace `Theme` with `ThemeName` in preferences. Current user theme will reset to Light.
- `Light` and `Dark` strings are no longer translatable (unless other contributors can make it work).

This PR depends on PR #1852, either merge that first or only merge this PR.