### PR TITLE
Fix NullReferenceException when importing UST with unregistered flags

### DIFF
--- a/OpenUtau.Core/Classic/Ust.cs
+++ b/OpenUtau.Core/Classic/Ust.cs
@@ -175,9 +175,14 @@ namespace OpenUtau.Classic {
                         var parser = new UstFlagParser();
                         var track = project.tracks[0];
                         foreach (var flag in parser.Parse(parts[1].Trim())) {
-                            var descriptor = project.expressions.Values.FirstOrDefault(exp => exp.flag == flag.Key).Clone();
-                            descriptor.CustomDefaultValue = flag.Value;
-                            track.TrackExpressions.Add(descriptor);
+                            var item = project.expressions.Values.FirstOrDefault(exp => exp.flag == flag.Key);
+                            if (item != null) {
+                                var descriptor = item.Clone();
+                                descriptor.CustomDefaultValue = flag.Value;
+                                track.TrackExpressions.Add(descriptor);
+                            }
+                            // otherwise expression not found, often when importing UST into a new project
+                            // ignore it.
                         }
                         break;
                 }


### PR DESCRIPTION
## Summary
This PR fixes a `System.NullReferenceException` that occurs when parsing UST flags that are not registered in the project's expressions list.

## The Bug
When importing UST with flag into a new UProject, the parser identifies flags correctly, but the `FirstOrDefault` always returns `null` since no expressions are registered to the project.

## The Fix
Added a null check before cloning the expression descriptor. If an expression/flag is registered, it is now safely ignored.

## Future Improvements / Suggestions
Since I am not very familiar with C#, I only fixed the crash with minimum modification. However, silently ignoring unknown flags is not ideal. A better long-term solution would be to implement a Flag Mapping Popup . When importing a UST with unknown flags, the user could be prompted to manually map them to valid/registered USTX flags.
