### PR TITLE
Replace backslash with slash in archive entry keys when installing singer.

### DIFF
--- a/OpenUtau.Core/Classic/VoicebankInstaller.cs
+++ b/OpenUtau.Core/Classic/VoicebankInstaller.cs
@@ -45,15 +45,16 @@ namespace OpenUtau.Classic {
                 int count = 0;
                 bool hasCharacterYaml = archive.Entries.Any(e => Path.GetFileName(e.Key) == kCharacterYaml);
                 foreach (var entry in archive.Entries) {
-                    progress.Invoke(100.0 * ++count / total, entry.Key);
+                    string fixedKey = entry.Key!.Replace("\\", "/");
+                    progress.Invoke(100.0 * ++count / total, fixedKey);
                     if (entry.Key.Contains("..")) {
                         // Prevent zipSlip attack
                         continue;
                     }
-                    var filePath = Path.Combine(basePath, entry.Key);
+                    var filePath = Path.Combine(basePath, fixedKey);
                     Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-                    if (!entry.IsDirectory && entry.Key != kInstallTxt) {
-                        entry.WriteToFile(Path.Combine(basePath, entry.Key), extractionOptions);
+                    if (!entry.IsDirectory && fixedKey != kInstallTxt) {
+                        entry.WriteToFile(filePath, extractionOptions);
                         if (!hasCharacterYaml && Path.GetFileName(filePath) == kCharacterTxt) {
                             var config = new VoicebankConfig() {
                                 TextFileEncoding = textEncoding.WebName,

--- a/OpenUtau/ViewModels/SingerSetupViewModel.cs
+++ b/OpenUtau/ViewModels/SingerSetupViewModel.cs
@@ -90,7 +90,7 @@ namespace OpenUtau.App.ViewModels {
             using (var archive = ArchiveFactory.Open(ArchiveFilePath, readerOptions)) {
                 textItems.Clear();
                 textItems.AddRange(archive.Entries
-                    .Select(entry => entry.Key!)
+                    .Select(entry => entry.Key!.Replace("\\", "/"))
                     .ToArray());
             }
         }
@@ -130,7 +130,7 @@ namespace OpenUtau.App.ViewModels {
                     foreach (var entry in archive.Entries.Where(entry => entry.Key!.EndsWith("character.txt") || entry.Key.EndsWith("oto.ini"))) {
                         using (var stream = entry.OpenEntryStream()) {
                             using var reader = new StreamReader(stream, TextEncoding);
-                            textItems.Add($"------ {entry.Key} ------");
+                            textItems.Add($"------ {entry.Key!.Replace("\\", "/")} ------");
                             int count = 0;
                             while (count < 256 && !reader.EndOfStream) {
                                 string? line = reader.ReadLine();


### PR DESCRIPTION
This should fix an issue where backslashes in filenames were treated as part of the file instead of directory separators in macOS and Linux.

<img width="761" height="236" alt="jdasjdklsa" src="https://github.com/user-attachments/assets/db0cabf7-ad08-48da-af62-e5b0cf87ae74" />

Referenced Voicebank: [eseph_en.zip](https://eseph-voice.carrd.co/#home-en)
