### PR TITLE
Fix Worldline crashes for some Windows machines

### DIFF
--- a/cpp/build_linux.sh
+++ b/cpp/build_linux.sh
@@ -14,5 +14,5 @@ build()
     cp bazel-bin/worldline/libworldline.so ../runtimes/linux-$1/native
 }
 
-build x64 "--cpu=k8"
+build x64 "--cpu=k8 --copt=-march=x86-64"
 build arm64 "--config=ubuntu-aarch64"

--- a/cpp/build_win.bat
+++ b/cpp/build_win.bat
@@ -4,13 +4,13 @@
 @echo Building %~1
 
 if not exist ..\runtimes\%~1\native mkdir ..\runtimes\%~1\native
-bazel build //worldline:worldline -c opt --cpu=%~2
+call bazel build //worldline:worldline -c opt --cpu=%~2 --copt=%~3
 attrib -r bazel-bin\worldline\worldline.dll
 copy bazel-bin\worldline\worldline.dll ..\runtimes\%~1\native
 
 @EXIT /B
 
 :MAIN
-@call :BUILD win-x64 x64_windows
-@call :BUILD win-x86 x64_x86_windows
-@call :BUILD win-arm64 arm64_windows
+@call :BUILD win-x64 x64_windows "/arch:SSE2"
+@call :BUILD win-x86 x64_x86_windows "/arch:SSE2"
+@call :BUILD win-arm64 arm64_windows "/arch:armv8.0"


### PR DESCRIPTION
Fix Worldline crashes for some Windows machines by telling bazel to use the most portable cpu instruction set available. Binaries not included, need to be recompiled.