### PR TITLE
fix(piano-roll): mark F11 key event as handled to prevent double-triggering

### DIFF
--- a/OpenUtau/Controls/PianoRoll.axaml.cs
+++ b/OpenUtau/Controls/PianoRoll.axaml.cs
@@ -1295,7 +1295,7 @@ namespace OpenUtau.App.Controls {
                     break;
                 case Key.F11:
                     OnMenuFullScreen(RootWindow, new RoutedEventArgs());
-                    break;
+                    return true;
                 case Key.Enter:
                     if (isNone) {
                         if (notesVm.Selection.Count == 1) {


### PR DESCRIPTION
Problem description: When pressing the F11 shortcut key on the piano roll-up window, the window flickers.

Cause Analysis When handling the F11 key in the `OnKeyDown` method, the event is not marked as handled (`e.Handled = true`), causing the key event to continue bubbling up. The system or other event handlers may process the F11 key again, resulting in multiple triggers of full-screen operations, which can cause window flickering.

Solution: Add the statement `e.Handled = true` after the F11 key processing logic to prevent the event from continuing to propagate.


This code has always been using "break", but the old version didn't have the flickering bug. I'm not sure about the specific principle, but I found that changing it to "return true" can fix this bug