### PR TITLE
[IT SYL] Bug fix for consonant transitions + add custom dictionary support

### DIFF
--- a/OpenUtau.Plugin.Builtin/ItalianSyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ItalianSyllableBasedPhonemizer.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using OpenUtau.Api;
 using OpenUtau.Core.G2p;
 using System.Linq;
+using Serilog;
+using System.IO;
 
 namespace OpenUtau.Plugin.Builtin {
     [Phonemizer("Italian Syllable-Based Phonemizer", "IT SYL", "Lotte V", language:"IT")]
@@ -35,7 +38,25 @@ namespace OpenUtau.Plugin.Builtin {
         protected override string GetDictionaryName() => "cmudict_it.txt";
         protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
 
-        protected override IG2p LoadBaseDictionary() => new ItalianG2p();
+        protected override IG2p LoadBaseDictionary() {
+            var g2ps = new List<IG2p>();
+
+            // Load dictionary from singer folder.
+            if (singer != null && singer.Found && singer.Loaded) {
+                string file = Path.Combine(singer.Location, "it-syl.yaml");
+
+                if (File.Exists(file)) {
+                    try {
+                        g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
+                    } catch (Exception e) {
+                        Log.Error(e, $"Failed to load {file}");
+                    }
+                }
+            }
+
+            g2ps.Add(new ItalianG2p());
+            return new G2pFallbacks(g2ps.ToArray());
+        }
 
         protected override List<string> ProcessSyllable(Syllable syllable)
         {


### PR DESCRIPTION
This fixes an issue regarding consonant transitions, most of all `[r]`. Currently, a single `[r]` transition does not work. Previously I had made a rather messy solution that didn't really work; the code has now been improved and should work as intended.

Fixes #1988 

I also added custom dictionary support to compensate for the "flimsiness" of the Italian CMUdict.