### PR TITLE
Fix PianoRoll Issues

### DIFF
--- a/OpenUtau/Controls/LyricBox.axaml.cs
+++ b/OpenUtau/Controls/LyricBox.axaml.cs
@@ -181,7 +181,6 @@ namespace OpenUtau.App.Controls {
             viewModel.NoteOrPhoneme = null;
             viewModel.IsVisible = false;
             viewModel.Text = string.Empty;
-            this.Focus();
         }
     }
 }

--- a/OpenUtau/Controls/PianoRoll.axaml
+++ b/OpenUtau/Controls/PianoRoll.axaml
@@ -7,7 +7,7 @@
         xmlns:c="clr-namespace:OpenUtau.App.Controls"
         mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="650"
         x:Class="OpenUtau.App.Controls.PianoRoll"
-        Focusable="True">
+        Focusable="True" Background="Transparent">
   <UserControl.Styles>
     <StyleInclude Source="/Styles/PianoRollStyles.axaml"/>
   </UserControl.Styles>

--- a/OpenUtau/Controls/PianoRoll.axaml
+++ b/OpenUtau/Controls/PianoRoll.axaml
@@ -751,7 +751,7 @@
       <Grid Grid.Row="3" Grid.Column="1" RowDefinitions="1*,1*">
         <Border Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Top"
                 BoxShadow="0 0 5 1 #3F000000">
-          <c:LyricBox Name="LyricBox" Width="360"/>
+          <c:LyricBox Name="LyricBox" Width="360" LostFocus="LyricBoxLostFocus"/>
         </Border>
       </Grid>
       <Border Grid.Row="5" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"

--- a/OpenUtau/Controls/PianoRoll.axaml.cs
+++ b/OpenUtau/Controls/PianoRoll.axaml.cs
@@ -470,6 +470,10 @@ namespace OpenUtau.App.Controls {
             dialog.ShowDialog(RootWindow);
         }
 
+        private void LyricBoxLostFocus(object sender, RoutedEventArgs e) {
+            this.Focus();
+        }
+
         public void OnExpButtonClick(object sender, RoutedEventArgs args) {
             var notesVM = ViewModel.NotesViewModel;
             if (notesVM.Part == null) {

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -404,9 +404,7 @@
           <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                         Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Focusable="False" Cursor="SizeNorthSouth" IsVisible="{Binding ShowPianoRoll}"/>
           <Canvas Grid.Row="4" Grid.ColumnSpan="3">
-            <ContentControl Name="PianoRollContainer"
-                            Width="{Binding Bounds.Width, RelativeSource={RelativeSource AncestorType=Canvas}}"
-                            Height="{Binding Bounds.Height, RelativeSource={RelativeSource AncestorType=Canvas}}"/>
+            <ContentControl Name="PianoRollContainer" Width="{Binding $parent[Canvas].Bounds.Width}" Height="{Binding $parent[Canvas].Bounds.Height}"/>
           </Canvas>
           <TextBlock Grid.Row="5" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" Height="20" Margin="4,4,4,0" Text="{Binding ProgressText}"/>
           <ProgressBar Grid.Row="6" Grid.ColumnSpan="3" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Value="{Binding Progress}"/>

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -401,7 +401,7 @@
           <Border Grid.Row="1" Grid.Column="2" Background="Transparent" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="0" Height="24" PointerWheelChanged="ViewScalerPointerWheelChanged">
             <c:ViewScaler Name="VScaler" DataContext="{Binding TracksViewModel}" Value="{Binding TrackHeight}" Min="{Binding TrackHeightMin}" Max="{Binding TrackHeightMax}"/>
           </Border>
-          <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" DragIncrement="1"
+          <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                         Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Focusable="False" Cursor="SizeNorthSouth" IsVisible="{Binding ShowPianoRoll}"/>
           <Canvas Grid.Row="4" Grid.ColumnSpan="3">
             <ContentControl Name="PianoRollContainer"

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -213,7 +213,7 @@
           <Grid.RowDefinitions>
             <RowDefinition Height="24"/>
             <RowDefinition Height="24"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="*" MinHeight="0.01"/>
             <RowDefinition Height="auto"/>
             <RowDefinition Height="3*"
                            MinHeight="{Binding PianoRollMinHeight}"
@@ -401,7 +401,7 @@
           <Border Grid.Row="1" Grid.Column="2" Background="Transparent" HorizontalAlignment="Stretch" VerticalAlignment="Top" Margin="0" Height="24" PointerWheelChanged="ViewScalerPointerWheelChanged">
             <c:ViewScaler Name="VScaler" DataContext="{Binding TracksViewModel}" Value="{Binding TrackHeight}" Min="{Binding TrackHeightMin}" Max="{Binding TrackHeightMax}"/>
           </Border>
-          <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+          <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" DragIncrement="1"
                         Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Focusable="False" Cursor="SizeNorthSouth" IsVisible="{Binding ShowPianoRoll}"/>
           <ContentControl Name="PianoRollContainer" Grid.Row="4" Grid.ColumnSpan="3" Margin="0,-5" Padding="0,5"/>
           <TextBlock Grid.Row="5" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" Height="20" Margin="4,4,4,0" Text="{Binding ProgressText}"/>

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -403,7 +403,11 @@
           </Border>
           <GridSplitter Grid.Row="3" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" DragIncrement="1"
                         Background="{DynamicResource SystemControlBackgroundAltHighBrush}" Focusable="False" Cursor="SizeNorthSouth" IsVisible="{Binding ShowPianoRoll}"/>
-          <ContentControl Name="PianoRollContainer" Grid.Row="4" Grid.ColumnSpan="3" Margin="0,-5" Padding="0,5"/>
+          <Canvas Grid.Row="4" Grid.ColumnSpan="3">
+            <ContentControl Name="PianoRollContainer"
+                            Width="{Binding Bounds.Width, RelativeSource={RelativeSource AncestorType=Canvas}}"
+                            Height="{Binding Bounds.Height, RelativeSource={RelativeSource AncestorType=Canvas}}"/>
+          </Canvas>
           <TextBlock Grid.Row="5" Grid.ColumnSpan="3" HorizontalAlignment="Stretch" Height="20" Margin="4,4,4,0" Text="{Binding ProgressText}"/>
           <ProgressBar Grid.Row="6" Grid.ColumnSpan="3" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Value="{Binding Progress}"/>
         </Grid>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -35,7 +35,6 @@ namespace OpenUtau.App.Views {
 
         private PianoRollDetachedWindow? pianoRollWindow;
         private PianoRoll? pianoRoll;
-        private bool openPianoRollWindow;
 
         private PartEditState? partEditState;
         private readonly DispatcherTimer timer;
@@ -1174,26 +1173,19 @@ namespace OpenUtau.App.Views {
         }
 
         public void PartsCanvasPointerReleased(object sender, PointerReleasedEventArgs args) {
-            if (partEditState != null) {
-                if (partEditState.MouseButton != args.InitialPressMouseButton) {
-                    return;
-                }
-                var control = (Control)sender;
-                var point = args.GetCurrentPoint(control);
-                partEditState.Update(point.Pointer, point.Position);
-                partEditState.End(point.Pointer, point.Position);
-                partEditState = null;
-                Cursor = null;
+            if (partEditState?.MouseButton != args.InitialPressMouseButton) {
+                return;
             }
-            if (openPianoRollWindow) {
-                pianoRollWindow?.Show();
-                pianoRollWindow?.Activate();
-                openPianoRollWindow = false;
-            }
+            var control = (Control)sender;
+            var point = args.GetCurrentPoint(control);
+            partEditState.Update(point.Pointer, point.Position);
+            partEditState.End(point.Pointer, point.Position);
+            partEditState = null;
+            Cursor = null;
         }
 
         public async void PartsCanvasDoubleTapped(object sender, TappedEventArgs args) {
-            if (!(sender is Canvas canvas)) {
+            if (sender is not Canvas canvas) {
                 return;
             }
             var control = canvas.InputHitTest(args.GetPosition(canvas));
@@ -1209,11 +1201,9 @@ namespace OpenUtau.App.Views {
                     };
 
                     if (Preferences.Default.DetachPianoRoll) {
-                        viewModel!.ShowPianoRoll = false;
+                        viewModel.ShowPianoRoll = false;
                         pianoRollWindow = new(pianoRoll);
-                        pianoRollWindow.Show();
                     } else {
-                        viewModel!.ShowPianoRoll = true;
                         PianoRollContainer.Content = pianoRoll;
                     }
 
@@ -1224,9 +1214,9 @@ namespace OpenUtau.App.Views {
 
                     pianoRoll.ViewModel.PlaybackViewModel = viewModel.PlaybackViewModel;
                 }
-                // Workaround for new window losing focus.
                 if (pianoRollWindow != null) {
-                    openPianoRollWindow = true;
+                    pianoRollWindow.Show();
+                    pianoRollWindow.Activate();
                 } else {
                     viewModel.ShowPianoRoll = true;
                     pianoRoll.Focus();
@@ -1245,11 +1235,11 @@ namespace OpenUtau.App.Views {
                 pianoRollWindow?.ForceClose();
                 pianoRollWindow = null;
                 PianoRollContainer.Content = pianoRoll;
-                viewModel!.ShowPianoRoll = true;
+                viewModel.ShowPianoRoll = true;
                 Preferences.Default.DetachPianoRoll = false;
             } else {
                 PianoRollContainer.Content = null;
-                viewModel!.ShowPianoRoll = false;
+                viewModel.ShowPianoRoll = false;
                 if (pianoRollWindow == null) {
                     pianoRollWindow = new(pianoRoll);
                     pianoRollWindow.Show();

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -1229,6 +1229,7 @@ namespace OpenUtau.App.Views {
                     openPianoRollWindow = true;
                 } else {
                     viewModel.ShowPianoRoll = true;
+                    pianoRoll.Focus();
                 }
                 int tick = viewModel.TracksViewModel.PointToTick(args.GetPosition(canvas));
                 DocManager.Inst.ExecuteCmd(new LoadPartNotification(partControl.part, DocManager.Inst.Project, tick));

--- a/OpenUtau/Views/PianoRollDetachedWindow.axaml
+++ b/OpenUtau/Views/PianoRollDetachedWindow.axaml
@@ -9,7 +9,7 @@
         x:Class="OpenUtau.App.Views.PianoRollDetachedWindow"
         Icon="/Assets/open-utau.ico"
         Title="{Binding NotesViewModel.WindowTitle}" MinWidth="300" MinHeight="200" Width="{Binding Width}" Height="{Binding Height}"
-        Focusable="True" TransparencyLevelHint="None"
+        Focusable="True" GotFocus="WindowGotFocus" TransparencyLevelHint="None"
         Closing="WindowClosing" Deactivated="WindowDeactivated">
     <ContentControl Name="PianoRollContainer"/>
 </Window>

--- a/OpenUtau/Views/PianoRollDetachedWindow.axaml.cs
+++ b/OpenUtau/Views/PianoRollDetachedWindow.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using OpenUtau.App.Controls;
 using OpenUtau.Core.Util;
 
@@ -20,6 +21,10 @@ namespace OpenUtau.App.Views {
                 Position = new PixelPoint(x, y);
             }
             WindowState = (WindowState)Preferences.Default.PianorollWindowSize.State;
+        }
+
+        public void WindowGotFocus(object sender, GotFocusEventArgs e) {
+            pianoRoll.Focus();
         }
 
         public void WindowClosing(object? sender, WindowClosingEventArgs e) {


### PR DESCRIPTION
Changes:
- Focus to PianoRoll right after opening a track
- Return focus to PianoRoll on LyricBox LostFocus
- Fix PianoRollDetached window not focusing when opening tracks
- Row definition not hiding workaround
- New workaround for PianoRoll snapping back on resize