### PR TITLE
Replacements Update: Introduced word boundary logic

### DIFF
--- a/OpenUtau.Plugin.Builtin/ArpasingPlusPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ArpasingPlusPhonemizer.cs
@@ -18,6 +18,7 @@ namespace OpenUtau.Plugin.Builtin {
     // main focus of this Phonemizer is to bring fallbacks to existing available alias from
     // all ARPAsing banks
     public class ArpasingPlusPhonemizer : SyllableBasedPhonemizer {
+        private const string YamlFile = "arpasing.yaml";
         private string[] vowels = {
         "aa", "ax", "ae", "ah", "ao", "aw", "ay", "eh", "er", "ey", "ih", "iy", "ow", "oy", "uh", "uw", "a", "e", "i", "o", "u", "ai", "ei", "oi", "au", "ou", "ix", "ux",
         "aar", "ar", "axr", "aer", "ahr", "aor", "or", "awr", "aur", "ayr", "air", "ehr", "eyr", "eir", "ihr", "iyr", "ir", "owr", "our", "oyr", "oir", "uhr", "uwr", "ur",
@@ -135,7 +136,7 @@ namespace OpenUtau.Plugin.Builtin {
                 finalPhonemes = new List<string>();
                 while (i < modified.Count) {
                     bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements)) {
+                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
                         if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
                             bool match = true;
                             for (int j = 0; j < fromArray.Length; j++) {
@@ -160,7 +161,7 @@ namespace OpenUtau.Plugin.Builtin {
                     if (!replaced && splittingReplacements.Any()) {
                         string currentPhoneme = modified[i];
                         bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements) {
+                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
                             if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
                                 finalPhonemes.AddRange(toArray);
                                 singleReplaced = true;
@@ -255,14 +256,14 @@ namespace OpenUtau.Plugin.Builtin {
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
             // LOAD DICTIONARY FROM FOLDER
-            string path = Path.Combine(PluginDir, "arpasing.yaml");
+            string path = Path.Combine(PluginDir, YamlFile);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
                 File.WriteAllBytes(path, Data.Resources.arpasing_template);
             }
             // LOAD DICTIONARY FROM SINGER FOLDER
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, "arpasing.yaml");
+                string file = Path.Combine(singer.Location, YamlFile);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -279,24 +280,24 @@ namespace OpenUtau.Plugin.Builtin {
             if (this.singer != singer) {
                 string file;
                 if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, "arpasing.yaml");
+                    file = Path.Combine(singer.Location, YamlFile);
                     if (!File.Exists(file)) {
                         try {
                             File.WriteAllBytes(file, Data.Resources.arpasing_template);
                         } catch (Exception e) {
-                            Log.Error(e, $"Failed to write 'arpasing.yaml' to singer folder at {file}");
+                            Log.Error(e, $"Failed to write '{YamlFile}' to singer folder at {file}");
                         }
                     }
                 } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, "arpasing.yaml");
+                    file = Path.Combine(PluginDir, YamlFile);
                 } else {
-                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'arpasing.yaml'.");
+                    Log.Error($"Singer location and PluginDir are both null or empty. Cannot locate '{YamlFile}'.");
                     return; // Exit early to avoid null file issues
                 }
 
                 if (File.Exists(file)) {
                     try {
-                        var data = Core.Yaml.DefaultDeserializer.Deserialize<ArpabetYAMLData>(File.ReadAllText(file));
+                        var data = Core.Yaml.DefaultDeserializer.Deserialize<YAMLData>(File.ReadAllText(file));
                         // Load vowels
                         try {
                             var loadVowels = data.symbols
@@ -306,7 +307,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             vowels = vowels.Concat(loadVowels).Distinct().ToArray();
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from arpasing.yaml: {ex.Message}");
+                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
                         }
                         // Load tails
                         try {
@@ -317,7 +318,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             tails = tails.Concat(loadTails).Distinct().ToArray();
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load tails from arpasing.yaml: {ex.Message}");
+                            Log.Error($"Failed to load tails from {YamlFile}: {ex.Message}");
                         }
                         // Load stop and tap consonants
                         try {
@@ -328,7 +329,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             consExceptions.AddRange(loadConsonants);
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load stop and tap consonants from filipino.yaml: {ex.Message}");
+                            Log.Error($"Failed to load stop and tap consonants from {YamlFile}: {ex.Message}");
                         }
                         // Load the various consonant types 
                         var fricatives = data.symbols
@@ -385,7 +386,7 @@ namespace OpenUtau.Plugin.Builtin {
                         stop = stops.Distinct().ToArray();
                         tap = taps.Distinct().ToArray();
                         affricate = affricates.Distinct().ToArray();
-                        /*consonants = fricatives
+                        consonants = fricatives
                             .Concat(aspirates)
                             .Concat(semivowels)
                             .Concat(liquids)
@@ -394,7 +395,7 @@ namespace OpenUtau.Plugin.Builtin {
                             .Concat(tap)
                             .Concat(affricate)
                             .Distinct()
-                            .ToArray();*/
+                            .ToArray();
 
                         // Load replacements
                         try {
@@ -405,14 +406,15 @@ namespace OpenUtau.Plugin.Builtin {
 
                                 foreach (var replacement in data.replacements) {
                                     try {
+                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
                                         if (replacement.from != null && replacement.to != null) {
                                             if (replacement.from is IEnumerable<object> fromList) {
                                                 // 'from' is a list (e.g., [ae, n])
                                                 string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
                                                 if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString });
+                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope  });
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope  });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -421,7 +423,7 @@ namespace OpenUtau.Plugin.Builtin {
                                                 if (replacement.to is string toString) {
                                                     dictionaryReplacements[fromString] = toString;
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope  });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -441,7 +443,7 @@ namespace OpenUtau.Plugin.Builtin {
                                 splittingReplacements = new List<Replacement>();
                             }
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from arpasing.yaml: {ex.Message}");
+                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
                         }
                         // load fallbacks
                         try {
@@ -453,10 +455,10 @@ namespace OpenUtau.Plugin.Builtin {
                                 }
                             }
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load fallbacks from arpasing.yaml: {ex.Message}");
+                            Log.Error($"Failed to load fallbacks from {YamlFile}: {ex.Message}");
                         }
                     } catch (Exception ex) {
-                       Log.Error($"Failed to parse arpasing.yaml: {ex.Message}, Exception Type: {ex.GetType()}");
+                       Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
                     }
                 }
                 
@@ -464,7 +466,7 @@ namespace OpenUtau.Plugin.Builtin {
                 this.singer = singer;
             }
         }
-        public class ArpabetYAMLData {
+        public class YAMLData {
             public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
             public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
             public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
@@ -487,6 +489,7 @@ namespace OpenUtau.Plugin.Builtin {
         public class Replacement {
             public object from { get; set; }
             public object to { get; set; }
+            public string where { get; set; } = "inside";
 
             public List<string> FromList {
                 get {
@@ -518,17 +521,87 @@ namespace OpenUtau.Plugin.Builtin {
             return phoneme;
         }
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
-            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
-            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
-            List<string> vowels = new List<string> { ReplacePhoneme(syllable.v, syllable.vowelTone) };
-            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
+            // Replacement for note boundaries
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
+            bool hasV = !string.IsNullOrEmpty(syllable.v);
+
+            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
+            currentPhonemes.AddRange(syllable.cc);
+            if (hasV) currentPhonemes.Add(syllable.v);
+
+            List<string> finalPhonemes = new List<string>();
+            int idx = 0;
+            while (idx < currentPhonemes.Count) {
+                bool replaced = false;
+                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
+                        bool match = true;
+                        for (int j = 0; j < fromArray.Length; j++) {
+                            if (currentPhonemes[idx + j] != fromArray[j]) {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match) {
+                            if (rule.to is string toString) {
+                                finalPhonemes.Add(toString);
+                            } else if (rule.to is string[] toArray) {
+                                finalPhonemes.AddRange(toArray);
+                            }
+                            idx += fromArray.Length;
+                            replaced = true;
+                            break;
+                        }
+                    }
+                }
+                
+                if (!replaced && splittingReplacements.Any()) {
+                    string currentPhoneme = currentPhonemes[idx];
+                    bool singleReplaced = false;
+                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
+                            finalPhonemes.AddRange(toArray);
+                            singleReplaced = true;
+                            break;
+                        }
+                    }
+                    if (!singleReplaced) {
+                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    }
+                    idx++;
+                } else if (!replaced) {
+                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    idx++;
+                }
+            }
+
+            string newPrevV = "";
+            string newV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                if (hasV && finalPhonemes.Count > 0) {
+                    newV = finalPhonemes.Last();
+                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
+                }
+                newCc.AddRange(finalPhonemes);
+            }
+            
+            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
+            string[] cc = newCc.ToArray();
+            string v = newV;
+            List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
-            string[] CurrentWordCc = syllable.CurrentWordCc.Select(ReplacePhoneme).ToArray();
-            string[] PreviousWordCc = syllable.PreviousWordCc.Select(ReplacePhoneme).ToArray();
+            string[] CurrentWordCc = syllable.CurrentWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
             int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
 
             bool isAtomicCluster = cc.Length == 2 && ccvException.Contains(cc[0]);

--- a/OpenUtau.Plugin.Builtin/ArpasingPlusPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ArpasingPlusPhonemizer.cs
@@ -96,14 +96,9 @@ namespace OpenUtau.Plugin.Builtin {
 
         private readonly string[] ccvException = { "ng", "dh" };
         private readonly string[] RomajiException = { "a", "e", "i", "o", "u" };
-        private bool isTails = false;
 
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
-            if (tails.Contains(note.lyric)) {
-                isTails = true;
-                return new string[] { note.lyric };
-            }
             phoneticHint = !string.IsNullOrEmpty(note.phoneticHint);
             if (original == null) {
                 return null;
@@ -398,47 +393,6 @@ namespace OpenUtau.Plugin.Builtin {
                         }
                     }
                 }
-                
-                // CC Endings (trailing)
-                if (isTails && basePhoneme.Contains("-")) {
-                    for (int clusterLength = 3; clusterLength >= 2; clusterLength--) {
-                        if (clusterLength > cc.Length) {
-                            continue;
-                        }
-
-                        var cluster = new string[clusterLength];
-                        Array.Copy(cc, 0, cluster, 0, clusterLength);
-
-                        // All possible spacing patterns for the consonants.
-                        var consonantPatterns = new List<string>();
-
-                        if (!phoneticHint && clusterLength >= 3) {
-                            consonantPatterns.Add($"{cluster[0]} {cluster[1]}{cluster[2]}");
-                            consonantPatterns.Add($"{cluster[0]}{cluster[1]} {cluster[2]}");
-                            consonantPatterns.Add($"{cluster[0]} {cluster[1]} {cluster[2]}");
-                        } else if (clusterLength == 2) {
-                            consonantPatterns.Add($"{cluster[0]} {cluster[1]}");
-                            consonantPatterns.Add($"{cluster[0]}{cluster[1]}");
-                        }
-
-                        // Check for all possible patterns with the ending hyphen.
-                        foreach (var consPattern in consonantPatterns) {
-                            string[] endPatterns = { "-", $" -" };
-                            foreach (var end in endPatterns) {
-                                string endingcc = $"{consPattern}{end}";
-
-                                if (HasOto(endingcc, syllable.tone)) {
-                                    basePhoneme = endingcc;
-                                    lastC = 0;
-                                    goto FoundMatch;
-                                } else {
-                                    continue;
-                                }
-                            }
-                        }
-                    }
-                }
-                FoundMatch:;
 
                 // try [V C], [V CC], [VC C], [V -][- C]
                 for (var i = lastC + 1; i >= 0; i--) {
@@ -658,25 +612,24 @@ namespace OpenUtau.Plugin.Builtin {
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
-            if (tails.Contains(ending.prevV)) {
-                return new List<string>();
-            }
+            string t = ending.HasTail ? ReplacePhoneme(ending.tail, ending.tone) : "-";
+
+            
             if (ending.IsEndingV) {
-                var vR = $"{prevV} -";
-                var vR1 = $"{prevV} R";
-                var vR2 = $"{prevV}-";
-                if (HasOto(vR, ending.tone) || HasOto(ValidateAlias(vR), ending.tone) || HasOto(vR1, ending.tone) || HasOto(ValidateAlias(vR1), ending.tone) || HasOto(vR2, ending.tone) || HasOto(ValidateAlias(vR2), ending.tone)) {
-                    phonemes.Add(AliasFormat($"{prevV}", "ending", ending.tone, ""));
+                var vR = $"{prevV} {t}";
+                var vR2 = $"{prevV}{t}";
+                if (HasOto(vR, ending.tone) || HasOto(ValidateAlias(vR), ending.tone) || HasOto(vR2, ending.tone) || HasOto(ValidateAlias(vR2), ending.tone)) {
+                    phonemes.Add(AliasFormat($"{prevV}", "ending", ending.tone, "", t));
                 }
             } else if (ending.IsEndingVCWithOneConsonant) {
                 var vc = $"{prevV} {cc[0]}";
-                var vcr = $"{prevV} {cc[0]}-";
-                var vcr2 = $"{prevV}{cc[0]} -";
-                var vcr3 = $"{prevV} {cc[0]} -";
-                var vcr4 = $"{prevV}{cc[0]}-";
+                var vcr = $"{prevV} {cc[0]}{t}";
+                var vcr2 = $"{prevV}{cc[0]} {t}";
+                var vcr3 = $"{prevV} {cc[0]} {t}";
+                var vcr4 = $"{prevV}{cc[0]}{t}";
                 if (!RomajiException.Contains(cc[0])) {
                     if (HasOto(vcr, ending.tone) && HasOto(ValidateAlias(vcr), ending.tone) || (HasOto(vcr2, ending.tone) && HasOto(ValidateAlias(vcr2), ending.tone))) {
-                        phonemes.Add(AliasFormat($"{v} {cc[0]}", "dynEnd", ending.tone, ""));
+                        phonemes.Add(AliasFormat($"{v} {cc[0]}", "dynEnd", ending.tone, "", t));
                     } else if (HasOto(vcr3, ending.tone) && HasOto(ValidateAlias(vcr3), ending.tone)) {
                         phonemes.Add(vcr3);
                     } else if (HasOto(vcr4, ending.tone) && HasOto(ValidateAlias(vcr4), ending.tone)) {
@@ -684,7 +637,7 @@ namespace OpenUtau.Plugin.Builtin {
                     } else if (HasOto(vc, ending.tone) && HasOto(ValidateAlias(vc), ending.tone)) {
                         phonemes.Add(vc);
                         if (vc.Contains(cc[0])) {
-                            phonemes.Add(AliasFormat($"{cc[0]}", "ending", ending.tone, ""));
+                            phonemes.Add(AliasFormat($"{cc[0]}", "ending", ending.tone, "", t));
                         }
                     } else {
                         for (int len = cc[0].Length; len > 0; len--) {
@@ -696,24 +649,24 @@ namespace OpenUtau.Plugin.Builtin {
                             }
                         }
                         if (vc.Contains(cc[0])) {
-                            phonemes.Add(AliasFormat($"{cc[0]}", "ending", ending.tone, ""));
+                            phonemes.Add(AliasFormat($"{cc[0]}", "ending", ending.tone, "", t));
                         }
                     }
                 }
             } else {
                 for (var i = lastC; i >= 0; i--) {
-                    var vr = $"{v} -";
+                    var vr = $"{v} {t}";
                     var vr1 = $"{v} R";
-                    var vr2 = $"{v}-";
-                    var vcc = $"{v} {string.Join("", cc.Take(2))}-";
-                    var vcc2 = $"{v}{string.Join(" ", cc.Take(2))} -";
+                    var vr2 = $"{v}{t}";
+                    var vcc = $"{v} {string.Join("", cc.Take(2))}{t}";
+                    var vcc2 = $"{v}{string.Join(" ", cc.Take(2))} {t}";
                     var vcc3 = $"{v}{string.Join(" ", cc.Take(2))}";
                     var vcc4 = $"{v} {string.Join("", cc.Take(2))}";
                     var vc = $"{v} {cc[0]}";
                     if (!RomajiException.Contains(cc[0])) {
                         if (i == 0) {
                             if (HasOto(vr, ending.tone) || HasOto(ValidateAlias(vr), ending.tone) || HasOto(vr2, ending.tone) || HasOto(ValidateAlias(vr2), ending.tone) || HasOto(vr1, ending.tone) || HasOto(ValidateAlias(vr1), ending.tone) && !HasOto(vc, ending.tone)) {
-                                phonemes.Add(AliasFormat($"{v}", "ending", ending.tone, ""));
+                                phonemes.Add(AliasFormat($"{v}", "ending", ending.tone, "", t));
                             }
                             break;
                         } else if (HasOto(vcc, ending.tone) && HasOto(ValidateAlias(vcc), ending.tone) && lastC == 1 && !ccvException.Contains(cc[0])) {
@@ -728,7 +681,7 @@ namespace OpenUtau.Plugin.Builtin {
                             phonemes.Add(vcc3);
                             if (vcc3.EndsWith(cc.Last()) && lastC == 1) {
                                 if (consonants.Contains(cc.Last())) {
-                                    phonemes.Add(AliasFormat($"{cc.Last()}", "ending", ending.tone, ""));
+                                    phonemes.Add(AliasFormat($"{cc.Last()}", "ending", ending.tone, "", t));
                                 }
                             }
                             firstC = 1;
@@ -737,7 +690,7 @@ namespace OpenUtau.Plugin.Builtin {
                             phonemes.Add(vcc4);
                             if (vcc4.EndsWith(cc.Last()) && lastC == 1) {
                                 if (consonants.Contains(cc.Last())) {
-                                    phonemes.Add(AliasFormat($"{cc.Last()}", "ending", ending.tone, ""));
+                                    phonemes.Add(AliasFormat($"{cc.Last()}", "ending", ending.tone, "", t));
                                 }
                             }
                             firstC = 1;
@@ -791,13 +744,13 @@ namespace OpenUtau.Plugin.Builtin {
                             cc1 = ValidateAlias(cc1);
                         }
 
-                        if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone))) {
+                        if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}{t}", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"), ending.tone))) {
                             // like [C1 C2][C2 ...]
                             phonemes.Add(cc1);
-                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone)))) {
+                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}{t}", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"), ending.tone)))) {
                             // like [C1 C2-][C3 ...]
                             phonemes.Add(cc[i]);
-                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}-", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"))) {
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}{t}", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"))) {
                             // like [C1 C2-][C3 ...]
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]}{cc[i + 2]}", ValidateAlias($"{cc[i + 1]}{cc[i + 2]}"))) {
@@ -812,8 +765,8 @@ namespace OpenUtau.Plugin.Builtin {
                             i++;
                         } else {
                             // like [C1][C2 ...]
-                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} -", ValidateAlias($"{cc[i]} -"));
-                            TryAddPhoneme(phonemes, ending.tone, cc[i + 1], ValidateAlias(cc[i + 1]), $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"));
+                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} {t}", ValidateAlias($"{cc[i]} {t}"));
+                            TryAddPhoneme(phonemes, ending.tone, cc[i + 1], ValidateAlias(cc[i + 1]), $"{cc[i + 1]} {t}", ValidateAlias($"{cc[i + 1]} {t}"));
                             i++;
                         }
                         // CC that ends with 3 clusters
@@ -842,7 +795,7 @@ namespace OpenUtau.Plugin.Builtin {
                             }
 
                             foreach (var consPattern in consonantPatterns) {
-                                string[] hyphenPatterns = { "-", " -" };
+                                string[] hyphenPatterns = { $"{t}", $" {t}" };
                                 foreach (var hyphenPattern in hyphenPatterns) {
                                     string endingcc = $"{consPattern}{hyphenPattern}";
 
@@ -880,21 +833,21 @@ namespace OpenUtau.Plugin.Builtin {
                             cc1 = ValidateAlias(cc1);
                         }
                         // CC that ends with 2 clusters
-                        if (!phoneticHint && (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}-", ValidateAlias($"{cc[i]} {cc[i + 1]}-")))) {
+                        if (!phoneticHint && (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}{t}", ValidateAlias($"{cc[i]} {cc[i + 1]}{t}")))) {
                             // like [C1 C2-]
                             i++;
-                        } else if (!phoneticHint && (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]} -", ValidateAlias($"{cc[i]} {cc[i + 1]} -")))) {
+                        } else if (!phoneticHint && (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]} {t}", ValidateAlias($"{cc[i]} {cc[i + 1]} {t}")))) {
                             // like [C1 C2 -]
                             i++;
-                        } else if (!phoneticHint && (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}-", ValidateAlias($"{cc[i]}{cc[i + 1]}-")))) {
+                        } else if (!phoneticHint && (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}{t}", ValidateAlias($"{cc[i]}{cc[i + 1]}{t}")))) {
                             // like [C1C2-]
                             i++;
-                        } else if (!phoneticHint && (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]} -", ValidateAlias($"{cc[i]}{cc[i + 1]} -")))) {
+                        } else if (!phoneticHint && (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]} {t}", ValidateAlias($"{cc[i]}{cc[i + 1]} {t}")))) {
                             // like [C1C2 -]
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1))) {
                             // like [C1 C2][C2 -]
-                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"), cc[i + 1], ValidateAlias(cc[i + 1]));
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {t}", ValidateAlias($"{cc[i + 1]} {t}"), cc[i + 1], ValidateAlias(cc[i + 1]));
                             i++;
                         } else if (!HasOto(cc1, ending.tone) && !HasOto($"{cc[i]} {cc[i + 1]}", ending.tone)) {
                             // [C1 -] [- C2]
@@ -907,7 +860,7 @@ namespace OpenUtau.Plugin.Builtin {
             }
             return phonemes;
         }
-        private string AliasFormat(string alias, string type, int tone, string prevV) {
+        private string AliasFormat(string alias, string type, int tone, string prevV, string t = "-") {
             var aliasFormats = new Dictionary<string, string[]> {
             // Define alias formats for different types
                 { "dynStart", new string[] { "" } },
@@ -919,14 +872,14 @@ namespace OpenUtau.Plugin.Builtin {
                 { "vvExtend", new string[] { "", "_", "-", "- " } },
                 { "cv", new string[] { "-", "", "- ", "_" } },
                 { "cvStart", new string[] { "-", "- ", "_" } },
-                { "ending", new string[] { " -", "-", " R" } },
-                { "ending_mix", new string[] { "-", " -", "R", " R", "_", "--" } },
+                { "ending", new string[] { $" {t}", $"{t}"} },
+                { "ending_mix", new string[] { $"{t}", $" {t}", "--" } },
                 { "cc", new string[] { "", "-", "- ", "_" } },
                 { "cc_start", new string[] { "- ", "-", "_" } },
-                { "cc_end", new string[] { " -", "-", "" } },
+                { "cc_end", new string[] { $" {t}", $"{t}", "" } },
                 { "cc_inB", new string[] { "_", "-", "- " } },
-                { "cc_endB", new string[] { "_", "-", " -" } },
-                { "cc_mix", new string[] { " -", " R", "-", "", "_", "- ", "-" } },
+                { "cc_endB", new string[] { "_", $"{t}", $" {t}" } },
+                { "cc_mix", new string[] { $" {t}", " R", $"{t}", "", "_", $"{t} ", $"{t}" } },
                 { "cc1_mix", new string[] { "", " -", "-", " R", "_", "- ", "-" } },
             };
 

--- a/OpenUtau.Plugin.Builtin/ArpasingPlusPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ArpasingPlusPhonemizer.cs
@@ -18,36 +18,24 @@ namespace OpenUtau.Plugin.Builtin {
     // main focus of this Phonemizer is to bring fallbacks to existing available alias from
     // all ARPAsing banks
     public class ArpasingPlusPhonemizer : SyllableBasedPhonemizer {
-        private const string YamlFile = "arpasing.yaml";
-        private string[] vowels = {
-        "aa", "ax", "ae", "ah", "ao", "aw", "ay", "eh", "er", "ey", "ih", "iy", "ow", "oy", "uh", "uw", "a", "e", "i", "o", "u", "ai", "ei", "oi", "au", "ou", "ix", "ux",
-        "aar", "ar", "axr", "aer", "ahr", "aor", "or", "awr", "aur", "ayr", "air", "ehr", "eyr", "eir", "ihr", "iyr", "ir", "owr", "our", "oyr", "oir", "uhr", "uwr", "ur",
-        "aal", "al", "axl", "ael", "ahl", "aol", "ol", "awl", "aul", "ayl", "ail", "ehl", "el", "eyl", "eil", "ihl", "iyl", "il", "owl", "oul", "oyl", "oil", "uhl", "uwl", "ul",
-        "aan", "an", "axn", "aen", "ahn", "aon", "on", "awn", "aun", "ayn", "ain", "ehn", "en", "eyn", "ein", "ihn", "iyn", "in", "own", "oun", "oyn", "oin", "uhn", "uwn", "un",
-        "aang", "ang", "axng", "aeng", "ahng", "aong", "ong", "awng", "aung", "ayng", "aing", "ehng", "eng", "eyng", "eing", "ihng", "iyng", "ing", "owng", "oung", "oyng", "oing", "uhng", "uwng", "ung",
-        "aam", "am", "axm", "aem", "ahm", "aom", "om", "awm", "aum", "aym", "aim", "ehm", "em", "eym", "eim", "ihm", "iym", "im", "owm", "oum", "oym", "oim", "uhm", "uwm", "um", "oh",
-        "eu", "oe", "yw", "yx", "wx", "ox", "ex", "ea", "ia", "oa", "ua", "ean", "eam", "eang"
-        };
-        private string[] consonants = "b,ch,d,dh,dr,dx,f,g,hh,jh,k,l,m,n,ng,p,q,r,s,sh,t,th,tr,v,w,y,z".Split(',');
-        private static string[] affricate = "".Split(',');
-        private static string[] fricative = "".Split(',');
-        private static string[] aspirate = "".Split(',');
-        private static string[] semivowel = "".Split(',');
-        private static string[] liquid = "".Split(',');
-        private static string[] nasal = "".Split(',');
-        private static string[] stop = "".Split(',');
-        private static string[] tap = "".Split(',');
-        private Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
-
+        protected override string YamlFileName => "arpasing.yaml";
+        protected override byte[] YamlTemplate => Data.Resources.arpasing_template;
+        public ArpasingPlusPhonemizer() {
+            this.vowels = new string[] {
+                "aa", "ax", "ae", "ah", "ao", "aw", "ay", "eh", "er", "ey", "ih", "iy", "ow", "oy", "uh", "uw", "a", "e", "i", "o", "u", "ai", "ei", "oi", "au", "ou", "ix", "ux",
+                "aar", "ar", "axr", "aer", "ahr", "aor", "or", "awr", "aur", "ayr", "air", "ehr", "eyr", "eir", "ihr", "iyr", "ir", "owr", "our", "oyr", "oir", "uhr", "uwr", "ur",
+                "aal", "al", "axl", "ael", "ahl", "aol", "ol", "awl", "aul", "ayl", "ail", "ehl", "el", "eyl", "eil", "ihl", "iyl", "il", "owl", "oul", "oyl", "oil", "uhl", "uwl", "ul",
+                "aan", "an", "axn", "aen", "ahn", "aon", "on", "awn", "aun", "ayn", "ain", "ehn", "en", "eyn", "ein", "ihn", "iyn", "in", "own", "oun", "oyn", "oin", "uhn", "uwn", "un",
+                "aang", "ang", "axng", "aeng", "ahng", "aong", "ong", "awng", "aung", "ayng", "aing", "ehng", "eng", "eyng", "eing", "ihng", "iyng", "ing", "owng", "oung", "oyng", "oing", "uhng", "uwng", "ung",
+                "aam", "am", "axm", "aem", "ahm", "aom", "om", "awm", "aum", "aym", "aim", "ehm", "em", "eym", "eim", "ihm", "iym", "im", "owm", "oum", "oym", "oim", "uhm", "uwm", "um", "oh",
+                "eu", "oe", "yw", "yx", "wx", "ox", "ex", "ea", "ia", "oa", "ua", "ean", "eam", "eang"
+            };
+            this.consonants = "b,ch,d,dh,dr,dx,f,g,hh,jh,k,l,m,n,ng,p,q,r,s,sh,t,th,tr,v,w,y,z".Split(',');
+        }
+        
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "";
-        private Dictionary<string, string> dictionaryReplacements;
-        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
-        // Store the splitting replacements
-        private List<Replacement> splittingReplacements = new List<Replacement>();
-        // Store the merging replacements
-        private List<Replacement> mergingReplacements = new List<Replacement>();
         List<string> consExceptions = new List<string>();
 
         // For banks with missing vowels
@@ -65,13 +53,6 @@ namespace OpenUtau.Plugin.Builtin {
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
         private bool isMissingCPhonemes = false;
-
-        // TIMIT symbols
-        private readonly Dictionary<string, string> yamlFallbacks = "".Split(',')
-                .Select(entry => entry.Split('='))
-                .Where(parts => parts.Length == 2)
-                .Where(parts => parts[0] != parts[1])
-                .ToDictionary(parts => parts[0], parts => parts[1]);
         private bool isYamlFallbacks = false;
         private bool vc_FallBack = false;
         private bool phoneticHint = false;
@@ -115,7 +96,6 @@ namespace OpenUtau.Plugin.Builtin {
 
         private readonly string[] ccvException = { "ng", "dh" };
         private readonly string[] RomajiException = { "a", "e", "i", "o", "u" };
-        private string[] tails = "-,R".Split(',');
         private bool isTails = false;
 
         protected override string[] GetSymbols(Note note) {
@@ -129,57 +109,7 @@ namespace OpenUtau.Plugin.Builtin {
                 return null;
             }
             List<string> modified = new List<string>(original);
-            List<string> finalPhonemes = new List<string>();
-            int i = 0;
-            bool hasReplacements = mergingReplacements.Any() == true || splittingReplacements.Any() == true; // Check for any replacements
-            if (hasReplacements) {
-                finalPhonemes = new List<string>();
-                while (i < modified.Count) {
-                    bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
-                        if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
-                            bool match = true;
-                            for (int j = 0; j < fromArray.Length; j++) {
-                                if (modified[i + j] != fromArray[j]) {
-                                    match = false;
-                                    break;
-                                }
-                            }
-                            if (match) {
-                                if (rule.to is string toString) {
-                                    finalPhonemes.Add(toString);
-                                } else if (rule.to is string[] toArray) {
-                                    finalPhonemes.AddRange(toArray);
-                                }
-                                i += fromArray.Length;
-                                replaced = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!replaced && splittingReplacements.Any()) {
-                        string currentPhoneme = modified[i];
-                        bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
-                            if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                                singleReplaced = true;
-                                break;
-                            }
-                        }
-                        if (!singleReplaced) {
-                            finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        }
-                        i++;
-                    } else if (!replaced) {
-                        finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        i++;
-                    }
-                }
-            } else {
-                finalPhonemes = new List<string>(modified);
-            }
+            List<string> finalPhonemes = ApplyReplacements(modified, false);
             List<string> finalProcessedPhonemes = new List<string>();
 
             // SPLITS UP DR AND TR
@@ -208,18 +138,15 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             }
             IEnumerable<string> phonemes;
-            if (hasReplacements) {
-                phonemes = finalPhonemes;
-            } else {
-                phonemes = original;
-            }
+            phonemes = finalPhonemes;
+            
             foreach (string s in phonemes) {
                 switch (s) {
                     case var str when dr.Contains(str) && !HasOto($"{str} {vowels}", note.tone) && !HasOto($"ay {str}", note.tone):
-                        finalProcessedPhonemes.AddRange(new string[] { "jh", s[1].ToString() });
+                        finalProcessedPhonemes.AddRange(new string[] { "d", s[1].ToString() });
                         break;
                     case var str when tr.Contains(str) && !HasOto($"{str} {vowels}", note.tone) && !HasOto($"ay {str}", note.tone):
-                        finalProcessedPhonemes.AddRange(new string[] { "ch", s[1].ToString() });
+                        finalProcessedPhonemes.AddRange(new string[] { "t", s[1].ToString() });
                         break;
                     case var str when wh.Contains(str) && !HasOto($"{str} {vowels}", note.tone) && !HasOto($"ay {str}", note.tone):
                         finalProcessedPhonemes.AddRange(new string[] { "hh", s[1].ToString() });
@@ -256,14 +183,14 @@ namespace OpenUtau.Plugin.Builtin {
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
             // LOAD DICTIONARY FROM FOLDER
-            string path = Path.Combine(PluginDir, YamlFile);
+            string path = Path.Combine(PluginDir, YamlFileName);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
-                File.WriteAllBytes(path, Data.Resources.arpasing_template);
+                File.WriteAllBytes(path, YamlTemplate);
             }
             // LOAD DICTIONARY FROM SINGER FOLDER
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, YamlFile);
+                string file = Path.Combine(singer.Location, YamlFileName);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -276,235 +203,17 @@ namespace OpenUtau.Plugin.Builtin {
             g2ps.Add(new ArpabetPlusG2p());
             return new G2pFallbacks(g2ps.ToArray());
         }
+
         public override void SetSinger(USinger singer) {
-            if (this.singer != singer) {
-                string file;
-                if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, YamlFile);
-                    if (!File.Exists(file)) {
-                        try {
-                            File.WriteAllBytes(file, Data.Resources.arpasing_template);
-                        } catch (Exception e) {
-                            Log.Error(e, $"Failed to write '{YamlFile}' to singer folder at {file}");
-                        }
-                    }
-                } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, YamlFile);
-                } else {
-                    Log.Error($"Singer location and PluginDir are both null or empty. Cannot locate '{YamlFile}'.");
-                    return; // Exit early to avoid null file issues
-                }
+            base.SetSinger(singer);
 
-                if (File.Exists(file)) {
-                    try {
-                        var data = Core.Yaml.DefaultDeserializer.Deserialize<YAMLData>(File.ReadAllText(file));
-                        // Load vowels
-                        try {
-                            var loadVowels = data.symbols
-                                ?.Where(s => s.type == "vowel")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            vowels = vowels.Concat(loadVowels).Distinct().ToArray();
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
-                        }
-                        // Load tails
-                        try {
-                            var loadTails = data.symbols
-                                ?.Where(s => s.type == "tail")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            tails = tails.Concat(loadTails).Distinct().ToArray();
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load tails from {YamlFile}: {ex.Message}");
-                        }
-                        // Load stop and tap consonants
-                        try {
-                            var loadConsonants = data.symbols
-                                ?.Where(s => s.type == "stop" || s.type == "tap")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            consExceptions.AddRange(loadConsonants);
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load stop and tap consonants from {YamlFile}: {ex.Message}");
-                        }
-                        // Load the various consonant types 
-                        var fricatives = data.symbols
-                            ?.Where(s => s.type == "fricative")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var aspirates = data.symbols
-                            ?.Where(s => s.type == "aspirate")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var semivowels = data.symbols
-                            ?.Where(s => s.type == "semivowel")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var liquids = data.symbols
-                            ?.Where(s => s.type == "liquid")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var nasals = data.symbols
-                            ?.Where(s => s.type == "nasal")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var stops = data.symbols
-                            ?.Where(s => s.type == "stop")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var taps = data.symbols
-                            ?.Where(s => s.type == "tap")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var affricates = data.symbols
-                            ?.Where(s => s.type == "affricate")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        PhonemeOverrides = data.timings
-                            ?.ToDictionary(t => t.symbol, t => t.value)
-                            ?? new Dictionary<string, double>();
-
-                       
-                        // Load consonant types into their respective lists
-                        fricative = fricatives.Distinct().ToArray();
-                        aspirate = aspirates.Distinct().ToArray();
-                        semivowel = semivowels.Distinct().ToArray();
-                        liquid = liquids.Distinct().ToArray();
-                        nasal = nasals.Distinct().ToArray();
-                        stop = stops.Distinct().ToArray();
-                        tap = taps.Distinct().ToArray();
-                        affricate = affricates.Distinct().ToArray();
-                        consonants = fricatives
-                            .Concat(aspirates)
-                            .Concat(semivowels)
-                            .Concat(liquids)
-                            .Concat(nasals)
-                            .Concat(stop)
-                            .Concat(tap)
-                            .Concat(affricate)
-                            .Distinct()
-                            .ToArray();
-
-                        // Load replacements
-                        try {
-                            if (data?.replacements != null && data.replacements.Any() == true) {
-                                dictionaryReplacements = new Dictionary<string, string>();
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-
-                                foreach (var replacement in data.replacements) {
-                                    try {
-                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
-                                        if (replacement.from != null && replacement.to != null) {
-                                            if (replacement.from is IEnumerable<object> fromList) {
-                                                // 'from' is a list (e.g., [ae, n])
-                                                string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
-                                                if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope  });
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope  });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else if (replacement.from is string fromString) {
-                                                // 'from' is a single string (e.g., tr, aw, ae, m, ng)
-                                                if (replacement.to is string toString) {
-                                                    dictionaryReplacements[fromString] = toString;
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope  });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else {
-                                                Log.Error($"Error: Invalid 'from' type in replacement: {replacement}");
-                                            }
-                                        } else {
-                                            Log.Error($"Error: 'from' or 'to' is null in replacement: {replacement}");
-                                        }
-                                    } catch (Exception ex) {
-                                        Log.Error($"Failed to process replacement entry: {replacement}. Error: {ex.Message}");
-                                    }
-                                }
-                            } else {
-                                dictionaryReplacements = new Dictionary<string, string>();
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
-                        }
-                        // load fallbacks
-                        try {
-                            if (data?.fallbacks?.Any() == true) {
-                                foreach (var df in data.fallbacks) {
-                                    if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
-                                        yamlFallbacks[df.from] = df.to;
-                                    }
-                                }
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load fallbacks from {YamlFile}: {ex.Message}");
-                        }
-                    } catch (Exception ex) {
-                       Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
-                    }
-                }
+            if (this.singer != null && this.singer.Loaded) {
                 
-                ReadDictionaryAndInit();
-                this.singer = singer;
-            }
-        }
-        public class YAMLData {
-            public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
-            public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
-            public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
-            public Timings[] timings { get; set; } = Array.Empty<Timings>();
-
-            public struct SymbolData {
-                public string symbol { get; set; }
-                public string type { get; set; }
-            }
-            public struct Fallbacks {
-                public string from { get; set; }
-                public string to { get; set; }
-            }
-            public struct Timings {
-                public string symbol { get; set; }
-                public double value { get; set; }
-            }
-        }
-        // can split or merge
-        public class Replacement {
-            public object from { get; set; }
-            public object to { get; set; }
-            public string where { get; set; } = "inside";
-
-            public List<string> FromList {
-                get {
-                    if (from is string s) return new List<string> { s };
-                    if (from is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
-
-            public List<string> ToList {
-                get {
-                    if (to is string s) return new List<string> { s };
-                    if (to is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
+                consExceptions.Clear();
+                if (stop != null) consExceptions.AddRange(stop);
+                if (tap != null) consExceptions.AddRange(tap);
+                
+                consExceptions = consExceptions.Distinct().ToList();
             }
         }
 
@@ -521,80 +230,11 @@ namespace OpenUtau.Plugin.Builtin {
             return phoneme;
         }
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            // Replacement for note boundaries
-            List<string> currentPhonemes = new List<string>();
-            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
-            bool hasV = !string.IsNullOrEmpty(syllable.v);
-
-            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
-            currentPhonemes.AddRange(syllable.cc);
-            if (hasV) currentPhonemes.Add(syllable.v);
-
-            List<string> finalPhonemes = new List<string>();
-            int idx = 0;
-            while (idx < currentPhonemes.Count) {
-                bool replaced = false;
-                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
-                        bool match = true;
-                        for (int j = 0; j < fromArray.Length; j++) {
-                            if (currentPhonemes[idx + j] != fromArray[j]) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (match) {
-                            if (rule.to is string toString) {
-                                finalPhonemes.Add(toString);
-                            } else if (rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                            }
-                            idx += fromArray.Length;
-                            replaced = true;
-                            break;
-                        }
-                    }
-                }
-                
-                if (!replaced && splittingReplacements.Any()) {
-                    string currentPhoneme = currentPhonemes[idx];
-                    bool singleReplaced = false;
-                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                            finalPhonemes.AddRange(toArray);
-                            singleReplaced = true;
-                            break;
-                        }
-                    }
-                    if (!singleReplaced) {
-                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    }
-                    idx++;
-                } else if (!replaced) {
-                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    idx++;
-                }
-            }
-
-            string newPrevV = "";
-            string newV = "";
-            List<string> newCc = new List<string>();
-
-            if (finalPhonemes.Count > 0) {
-                if (hasPrevV) {
-                    newPrevV = finalPhonemes[0];
-                    finalPhonemes.RemoveAt(0);
-                }
-                if (hasV && finalPhonemes.Count > 0) {
-                    newV = finalPhonemes.Last();
-                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
-                }
-                newCc.AddRange(finalPhonemes);
-            }
-            
-            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
-            string[] cc = newCc.ToArray();
-            string v = newV;
+            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
+            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
+            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
+            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
             List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();

--- a/OpenUtau.Plugin.Builtin/Data/njokis.template.yaml
+++ b/OpenUtau.Plugin.Builtin/Data/njokis.template.yaml
@@ -1,5 +1,6 @@
 %YAML 1.2
 ---
+version: 1.0
 symbols:
 #Con Pez
   - {symbol: z, type: fricative}
@@ -38,41 +39,23 @@ symbols:
   - {symbol: ks, type: stop}
 
 replacements:
-  - {from: [n, p], to: [m, p]}
-  - {from: [n, B], to: [m, b]}
-  - {from: [m, B], to: [m, b]}
-  - {from: [n, b], to: [m, b]}
-  - {from: [n, m], to: [m, m]}
-  - {from: [n, D], to: [n, d]}
-  - {from: [l, D], to: [l, d]}
-  - {from: [n, G], to: [n, g]}
-  - {from: [s, r], to: [s, rr]}
-  - {from: [x, r], to: [x, rr]}
-  - {from: [n, r], to: [n, rr]}
-  - {from: [m, r], to: [m, rr]}
-  - {from: [l, r], to: [l, rr]}
+  - {from: [n, p], to: [m, p], where: all}
+  - {from: [n, B], to: [m, b], where: all}
+  - {from: [m, B], to: [m, b], where: all}
+  - {from: [n, b], to: [m, b], where: all}
+  - {from: [n, m], to: [m, m], where: all}
+  - {from: [n, D], to: [n, d], where: all}
+  - {from: [l, D], to: [l, d], where: all}
+  - {from: [n, G], to: [n, g], where: all}
+  - {from: [s, r], to: [s, rr], where: all}
+  - {from: [x, r], to: [x, rr], where: all}
+  - {from: [n, r], to: [n, rr], where: all}
+  - {from: [m, r], to: [m, rr], where: all}
+  - {from: [l, r], to: [l, rr], where: all}
   - {from: [r, r], to: [rr]}
-  - {from: [a, b], to: [a, B]}
-  - {from: [e, b], to: [e, B]}
-  - {from: [i, b], to: [i, B]}
-  - {from: [o, b], to: [o, B]}
-  - {from: [u, b], to: [u, B]}
-  - {from: [I, b], to: [I, B]}
-  - {from: [U, b], to: [U, B]}
-  - {from: [a, g], to: [a, G]}
-  - {from: [e, g], to: [e, G]}
-  - {from: [i, g], to: [i, G]}
-  - {from: [o, g], to: [o, G]}
-  - {from: [u, g], to: [u, G]}
-  - {from: [I, g], to: [I, G]}
-  - {from: [U, g], to: [U, G]}
-  - {from: [a, d], to: [a, D]}
-  - {from: [e, d], to: [e, D]}
-  - {from: [i, d], to: [i, D]}
-  - {from: [o, d], to: [o, D]}
-  - {from: [u, d], to: [u, D]}
-  - {from: [I, d], to: [I, D]}
-  - {from: [U, d], to: [U, D]}
+  - {from: [vowel, b, vowel], to: [vowel, B, vowel], where: all}
+  - {from: [vowel, g, vowel], to: [vowel, G, vowel], where: all}
+  - {from: [vowel, d, vowel], to: [vowel, D, vowel], where: all}
 
 entries:
   - grapheme: openutau

--- a/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
@@ -353,15 +353,16 @@ namespace OpenUtau.Plugin.Builtin {
                             splittingReplacements = new List<Replacement>();
 
                             foreach (var replacement in data.replacements) {
+                                string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
                                 try {
                                     if (replacement.from != null && replacement.to != null) {
                                         if (replacement.from is IEnumerable<object> fromList) {
                                             // 'from' is a list (e.g., [ae, n])
                                             string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
                                             if (replacement.to is string toString) {
-                                                mergingReplacements.Add(new Replacement { from = fromArray, to = toString });
+                                                mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
                                             } else if (replacement.to is IEnumerable<object> toList) {
-                                                splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray() });
+                                                splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                             } else {
                                                 Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                             }
@@ -370,7 +371,7 @@ namespace OpenUtau.Plugin.Builtin {
                                             if (replacement.to is string toString) {
                                                 dictionaryReplacements[fromString] = toString;
                                             } else if (replacement.to is IEnumerable<object> toList) {
-                                                splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray() });
+                                                splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                             } else {
                                                 Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                             }
@@ -437,6 +438,7 @@ namespace OpenUtau.Plugin.Builtin {
         public class Replacement {
             public object from { get; set; }
             public object to { get; set; }
+            public string where { get; set; } = "inside";
 
             public List<string> FromList {
                 get {
@@ -472,7 +474,7 @@ namespace OpenUtau.Plugin.Builtin {
                 finalPhonemes = new List<string>();
                 while (i < modified.Count) {
                     bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements)) {
+                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
                         if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
                             bool match = true;
                             for (int j = 0; j < fromArray.Length; j++) {
@@ -497,7 +499,7 @@ namespace OpenUtau.Plugin.Builtin {
                     if (!replaced && splittingReplacements.Any()) {
                         string currentPhoneme = modified[i];
                         bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements) {
+                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
                             if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
                                 finalPhonemes.AddRange(toArray);
                                 singleReplaced = true;
@@ -552,20 +554,89 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
-            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
-            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
-            string[] cc = syllable.cc.Select(ReplacePhoneme).ToArray();
-            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
+            // Replacement for note boundaries
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
+            bool hasV = !string.IsNullOrEmpty(syllable.v);
 
-            string[] CurrentWordCc = syllable.CurrentWordCc.Select(ReplacePhoneme).ToArray();
-            string[] PreviousWordCc = syllable.PreviousWordCc.Select(ReplacePhoneme).ToArray();
-            int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
+            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
+            currentPhonemes.AddRange(syllable.cc);
+            if (hasV) currentPhonemes.Add(syllable.v);
 
+            List<string> finalPhonemes = new List<string>();
+            int idx = 0;
+            while (idx < currentPhonemes.Count) {
+                bool replaced = false;
+                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
+                        bool match = true;
+                        for (int j = 0; j < fromArray.Length; j++) {
+                            if (currentPhonemes[idx + j] != fromArray[j]) {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match) {
+                            if (rule.to is string toString) {
+                                finalPhonemes.Add(toString);
+                            } else if (rule.to is string[] toArray) {
+                                finalPhonemes.AddRange(toArray);
+                            }
+                            idx += fromArray.Length;
+                            replaced = true;
+                            break;
+                        }
+                    }
+                }
+                
+                if (!replaced && splittingReplacements.Any()) {
+                    string currentPhoneme = currentPhonemes[idx];
+                    bool singleReplaced = false;
+                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
+                            finalPhonemes.AddRange(toArray);
+                            singleReplaced = true;
+                            break;
+                        }
+                    }
+                    if (!singleReplaced) {
+                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    }
+                    idx++;
+                } else if (!replaced) {
+                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    idx++;
+                }
+            }
+
+            string newPrevV = "";
+            string newV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                if (hasV && finalPhonemes.Count > 0) {
+                    newV = finalPhonemes.Last();
+                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
+                }
+                newCc.AddRange(finalPhonemes);
+            }
+            
+            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
+            string[] cc = newCc.ToArray();
+            string v = newV;
+            List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
+            string[] CurrentWordCc = syllable.CurrentWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
+
             var rv = $"- {v}";
             
             // Switch between phonetic systems, depending on certain aliases in the bank

--- a/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
@@ -173,7 +173,6 @@ namespace OpenUtau.Plugin.Builtin {
                 {"@u","u"},
                 {"3", "r"}
             };
-        private bool isTails = false;
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
 
@@ -202,30 +201,16 @@ namespace OpenUtau.Plugin.Builtin {
 
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
-            if (tails.Contains(note.lyric)) {
-                isTails = true;
-                return new string[] { note.lyric };
-            }
             if (original == null) {
                 return null;
-            }
-            var mappedOriginal = new List<string>();
-            foreach (var p in original) {
-                if (dictionaryReplacements.ContainsKey(p)) {
-                    mappedOriginal.Add(dictionaryReplacements[p]);
-                } else {
-                    mappedOriginal.Add(p);
-                }
             }
             List<string> finalProcessedPhonemes = new List<string>();
             
             // Splits diphthongs and affricates if not present in the bank
             string[] diphthongs = new[] { "aI", "eI", "OI", "aU", "oU", "VI", "VU", "@U", "ai", "ei", "Oi", "au", "ou", "Ou", "@u", };
             string[] affricates = new[] { "dZ", "tS" };
-            IEnumerable<string> phonemes;
-            phonemes = mappedOriginal;
             
-            foreach (string s in phonemes) {
+            foreach (string s in original) {
                 if (diphthongs.Contains(s) && !HasOto($"- {s}", note.tone) && !HasOto(s, note.tone) && !HasOto(ValidateAlias($"- {s}"), note.tone) && !HasOto(ValidateAlias(s), note.tone)) {
                     finalProcessedPhonemes.AddRange(new string[] { s[0].ToString(), s[1] + '^'.ToString() });
                 } else if (affricates.Contains(s) && !HasOto($"{s}A", note.tone) && !HasOto($"{s} A", note.tone) && !HasOto($"{s}Q", note.tone) && !HasOto($"{s} Q", note.tone)) {
@@ -462,45 +447,6 @@ namespace OpenUtau.Plugin.Builtin {
                             }
                         }
                     }
-                    // CC Endings (trailing)
-                    if (isTails && basePhoneme.Contains("-")) {
-                        for (int clusterLength = 3; clusterLength >= 2; clusterLength--) {
-                            if (clusterLength > cc.Length) {
-                                continue;
-                            }
-
-                            var cluster = new string[clusterLength];
-                            Array.Copy(cc, 0, cluster, 0, clusterLength);
-
-                            // All possible spacing patterns for the consonants.
-                            var consonantPatterns = new List<string>();
-
-                            if (clusterLength >= 3) {
-                                consonantPatterns.Add($"{cluster[0]} {cluster[1]}{cluster[2]}");
-                                consonantPatterns.Add($"{cluster[0]}{cluster[1]} {cluster[2]}");
-                                consonantPatterns.Add($"{cluster[0]} {cluster[1]} {cluster[2]}");
-                            } else if (clusterLength == 2) {
-                                consonantPatterns.Add($"{cluster[0]} {cluster[1]}");
-                                consonantPatterns.Add($"{cluster[0]}{cluster[1]}");
-                            }
-
-                            // Check for all possible patterns with the ending hyphen.
-                            foreach (var consPattern in consonantPatterns) {
-                                string[] endPatterns = { "-", $" -" };
-                                foreach (var end in endPatterns) {
-                                    string endingcc = $"{consPattern}{end}";
-
-                                    if (HasOto(endingcc, syllable.tone)) {
-                                        basePhoneme = endingcc;
-                                        lastC = 0;
-                                        goto FoundMatch;
-                                    } else {
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                    }
                     FoundMatch:;
                     // try vcc
                     for (var i = lastC + 1; i >= 0; i--) {
@@ -640,9 +586,9 @@ namespace OpenUtau.Plugin.Builtin {
         protected override List<string> ProcessEnding(Ending ending) {
             string[] cc = ending.cc.Select(c => ReplacePhoneme(c, ending.tone)).ToArray();
             string v = ReplacePhoneme(ending.prevV, ending.tone);
-
+            string t = ending.HasTail ? ReplacePhoneme(ending.tail, ending.tone) : "-";
             var phonemes = new List<string>();
-            var vr = $"{v} -";
+            var vr = $"{v} {t}";
 
             var lastC = cc.Length - 1;
             var firstC = 0;
@@ -651,8 +597,8 @@ namespace OpenUtau.Plugin.Builtin {
                 TryAddPhoneme(phonemes, ending.tone, vr, ValidateAlias(vr));
             } else if (ending.IsEndingVCWithOneConsonant) {
                 var vc = $"{v} {cc[0]}";
-                var vcr = $"{v} {cc[0]}-";
-                var vcr2 = $"{v}{cc[0]} -";
+                var vcr = $"{v} {cc[0]}{t}";
+                var vcr2 = $"{v}{cc[0]} {t}";
                 if (HasOto(vcr, ending.tone) || HasOto(ValidateAlias(vcr), ending.tone)) {
                     phonemes.Add(vcr);
                 } else if ((!HasOto(vcr, ending.tone) && !HasOto(ValidateAlias(vcr), ending.tone)) && (HasOto(vcr2, ending.tone) || HasOto(ValidateAlias(vcr2), ending.tone))) {
@@ -660,15 +606,15 @@ namespace OpenUtau.Plugin.Builtin {
                 } else {
                     phonemes.Add(vc);
                     if (affricate.Contains(cc[0])) {
-                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", cc[0]);
+                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} {t}", cc[0]);
                     } else {
-                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", ValidateAlias($"{cc[0]} -"));
+                        TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} {t}", ValidateAlias($"{cc[0]} {t}"));
                     }
                 }
             } else {
                 for (var i = lastC; i >= 0; i--) {
-                    var vcc = $"{v} {string.Join("", cc.Take(2))}-";
-                    var vcc2 = $"{v}{string.Join(" ", cc.Take(2))}-";
+                    var vcc = $"{v} {string.Join("", cc.Take(2))}{t}";
+                    var vcc2 = $"{v}{string.Join(" ", cc.Take(2))}{t}";
                     var vcc3 = $"{v}{string.Join(" ", cc.Take(2))}";
                     var vcc4 = $"{v} {string.Join("", cc.Take(2))}";
                     var vc = $"{v} {cc[0]}";
@@ -688,9 +634,9 @@ namespace OpenUtau.Plugin.Builtin {
                         phonemes.Add(vcc3);
                         if (vcc3.EndsWith(cc.Last()) && lastC == 1) {
                             if (affricate.Contains(cc.Last())) {
-                                TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()} -", ValidateAlias($"{cc.Last()} -"), cc.Last(), ValidateAlias(cc.Last()));
+                                TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()} {t}", ValidateAlias($"{cc.Last()} {t}"), cc.Last(), ValidateAlias(cc.Last()));
                             } else {
-                                TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()} -", ValidateAlias($"{cc.Last()} -"));
+                                TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()} {t}", ValidateAlias($"{cc.Last()} {t}"));
                             }
                         }
                         firstC = 1;
@@ -699,9 +645,9 @@ namespace OpenUtau.Plugin.Builtin {
                         phonemes.Add(vcc4);
                         if (vcc4.EndsWith(cc.Last()) && lastC == 1) {
                             if (affricate.Contains(cc.Last())) {
-                                TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()} -", ValidateAlias($"{cc.Last()} -"), cc.Last(), ValidateAlias(cc.Last()));
+                                TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()} {t}", ValidateAlias($"{cc.Last()} {t}"), cc.Last(), ValidateAlias(cc.Last()));
                             } else {
-                                TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()} -", ValidateAlias($"{cc.Last()} -"));
+                                TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()} {t}", ValidateAlias($"{cc.Last()} {t}"));
                             }
                         }
                         firstC = 1;
@@ -737,16 +683,16 @@ namespace OpenUtau.Plugin.Builtin {
                         if (!HasOto(cc2, ending.tone)) {
                             cc2 = ValidateAlias(cc2);
                         }
-                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}{cc[i + 2]}-", ValidateAlias($"{cc[i]} {cc[i + 1]}{cc[i + 2]}-"))) {
+                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}{cc[i + 2]}{t}", ValidateAlias($"{cc[i]} {cc[i + 1]}{cc[i + 2]}{t}"))) {
                             // like [C1 C2-][C3 ...]
                             i++;
-                        } else if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone))) {
+                        } else if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}{t}", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"), ending.tone))) {
                             // like [C1 C2][C2 ...]
                             phonemes.Add(cc1);
-                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone)))) {
+                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}{t}", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"), ending.tone)))) {
                             // like [C1 C2-][C3 ...]
                             phonemes.Add(cc[i]);
-                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}-", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"))) {
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}{t}", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"))) {
                             // like [C1 C2-][C3 ...]
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]}{cc[i + 2]}", ValidateAlias($"{cc[i + 1]}{cc[i + 2]}"))) {
@@ -756,8 +702,8 @@ namespace OpenUtau.Plugin.Builtin {
                             i++;
                         } else {
                             // like [C1][C2 ...]
-                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} -", ValidateAlias($"{cc[i]} -"));
-                            TryAddPhoneme(phonemes, ending.tone, cc[i + 1], ValidateAlias(cc[i + 1]), $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"));
+                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} {t}", ValidateAlias($"{cc[i]} {t}"));
+                            TryAddPhoneme(phonemes, ending.tone, cc[i + 1], ValidateAlias(cc[i + 1]), $"{cc[i + 1]} {t}", ValidateAlias($"{cc[i + 1]} {t}"));
                             i++;
                         }
                     } else {
@@ -770,21 +716,21 @@ namespace OpenUtau.Plugin.Builtin {
                         if (!HasOto(cc1, ending.tone)) {
                             cc1 = ValidateAlias(cc1);
                         }
-                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}-", ValidateAlias($"{cc[i]} {cc[i + 1]}-"))) {
+                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}{t}", ValidateAlias($"{cc[i]} {cc[i + 1]}{t}"))) {
                             // like [C1 C2-]
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1))) {
                             // like [C1 C2][C2 -]
-                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"), cc[i + 1], ValidateAlias(cc[i + 1]));
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {t}", ValidateAlias($"{cc[i + 1]} {t}"), cc[i + 1], ValidateAlias(cc[i + 1]));
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}", ValidateAlias($"{cc[i]}{cc[i + 1]}"))) {
                             // like [C1C2][C2 -]
-                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"), cc[i + 1], ValidateAlias(cc[i + 1]));
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {t}", ValidateAlias($"{cc[i + 1]} {t}"), cc[i + 1], ValidateAlias(cc[i + 1]));
                             i++;
                         } else {
                             // like [C1][C2 -]
-                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} -", ValidateAlias($"{cc[i]} -"));
-                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"), cc[i + 1], ValidateAlias(cc[i + 1]));
+                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} {t}", ValidateAlias($"{cc[i]} {t}"));
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {t}", ValidateAlias($"{cc[i + 1]} {t}"), cc[i + 1], ValidateAlias(cc[i + 1]));
                             i++;
                         }
                     }

--- a/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnXSampaPhonemizer.cs
@@ -28,35 +28,24 @@ namespace OpenUtau.Plugin.Builtin {
     /// </summary>
     [Phonemizer("English X-SAMPA phonemizer", "EN X-SAMPA", "Lotte V", language: "EN")]
     public class EnXSampaPhonemizer : SyllableBasedPhonemizer {
-        private string[] vowels = "a,A,@,{,V,O,aU,aI,E,3,eI,I,i,oU,OI,U,u,Q,Ol,Ql,aUn,e@,eN,IN,e,o,Ar,Qr,Er,Ir,Or,Ur,ir,ur,aIr,aUr,A@,Q@,E@,I@,O@,U@,i@,u@,aI@,aU@,@r,@l,@m,@n,@N,1,e@m,e@n,y,I\\,M,U\\,Y,@\\,@`,3`,A`,Q`,E`,I`,O`,U`,i`,u`,aI`,aU`,},2,3\\,6,7,8,9,&,{~,I~,aU~,VI,VU,@U,ai,ei,Oi,au,ou,Ou,@u,i:,u:,O:,e@0,E~,e~,3r,ar,or,{l,Al,al,El,Il,il,ol,ul,Ul,oUl,@5,u5,O5,A5,E5,I5,i5,mm,nn,ll,NN".Split(',');
-        private readonly string[] consonants = "b,tS,d,D,4,f,g,h,dZ,k,l,m,n,N,p,r,s,S,t,T,v,w,W,j,z,Z,t_},・,_".Split(',');
-        private static string[] affricate = "".Split(',');
-        private static string[] fricative = "".Split(',');
-        private static string[] aspirate = "".Split(',');
-        private static string[] semivowel = "".Split(',');
-        private static string[] liquid = "".Split(',');
-        private static string[] nasal = "".Split(',');
-        private static string[] stop = "".Split(',');
-        private static string[] tap = "".Split(',');
-        private Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
-
-        private Dictionary<string, string> dictionaryReplacements = ("aa=A;ae={;ah=V;ao=O;aw=aU;ax=@;ay=aI;" +
+        protected override string YamlFileName => "en-xsampa.yaml";
+        protected override byte[] YamlTemplate => Data.Resources.en_xsampa_template;
+        public EnXSampaPhonemizer() {
+            this.vowels = "a,A,@,{,V,O,aU,aI,E,3,eI,I,i,oU,OI,U,u,Q,Ol,Ql,aUn,e@,eN,IN,e,o,Ar,Qr,Er,Ir,Or,Ur,ir,ur,aIr,aUr,A@,Q@,E@,I@,O@,U@,i@,u@,aI@,aU@,@r,@l,@m,@n,@N,1,e@m,e@n,y,I\\,M,U\\,Y,@\\,@`,3`,A`,Q`,E`,I`,O`,U`,i`,u`,aI`,aU`,},2,3\\,6,7,8,9,&,{~,I~,aU~,VI,VU,@U,ai,ei,Oi,au,ou,Ou,@u,i:,u:,O:,e@0,E~,e~,3r,ar,or,{l,Al,al,El,Il,il,ol,ul,Ul,oUl,@5,u5,O5,A5,E5,I5,i5,mm,nn,ll,NN".Split(',');
+            this.consonants = "b,tS,d,D,4,f,g,h,dZ,k,l,m,n,N,p,r,s,S,t,T,v,w,W,j,z,Z,t_},・,_".Split(',');
+            this.dictionaryReplacements = ("aa=A;ae={;ah=V;ao=O;aw=aU;ax=@;ay=aI;" +
             "b=b;ch=tS;d=d;dh=D;" + "dx=4;eh=E;el=@l;em=@m;en=@n;eng=@N;er=3;ey=eI;f=f;g=g;hh=h;ih=I;iy=i;jh=dZ;k=k;l=l;m=m;n=n;ng=N;ow=oU;oy=OI;" +
             "p=p;q=・;r=r;s=s;sh=S;t=t;th=T;" + "uh=U;uw=u;v=v;w=w;" + "y=j;z=z;zh=Z").Split(';')
                 .Select(entry => entry.Split('='))
                 .Where(parts => parts.Length == 2)
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
+        }
 
+        private bool isYamlFallbacks = false;
         protected override string[] GetVowels() => vowels;
-        protected override string[] GetConsonants() => consonants; 
+        protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "";
-        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
-        // Store the splitting replacements
-        private List<Replacement> splittingReplacements = new List<Replacement>();
-        // Store the merging replacements
-        private List<Replacement> mergingReplacements = new List<Replacement>();
-
 
         // For banks aliased with VOCALOID-style phonemes
         private readonly Dictionary<string, string> vocaSampa = "A=Q;E=e;i=i:;u=u:;O=O:;3=@r;oU=@U;Ar=Q@;Qr=Q@;Er=e@;er=e@;Ir=I@;ir=I@;i:r=I@;Or=O@;O:r=O@;Ur=U@;ur=U@;u:r=U@".Split(';')
@@ -65,20 +54,6 @@ namespace OpenUtau.Plugin.Builtin {
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
         private bool isVocaSampa = false;
-
-        private readonly Dictionary<string, string> replacements = "".Split(';')
-                .Select(entry => entry.Split('='))
-                .Where(parts => parts.Length == 2)
-                .Where(parts => parts[0] != parts[1])
-                .ToDictionary(parts => parts[0], parts => parts[1]);
-        private bool isReplacements = false;
-
-        private readonly Dictionary<string, string> fallbacks = "".Split(';')
-                .Select(entry => entry.Split('='))
-                .Where(parts => parts.Length == 2)
-                .Where(parts => parts[0] != parts[1])
-                .ToDictionary(parts => parts[0], parts => parts[1]);
-        private bool isfallbacks = false;
 
         // For banks with slightly fewer vowels
         private readonly Dictionary<string, string> simpleDelta = "E=e;V=@;o=O".Split(';')
@@ -198,263 +173,31 @@ namespace OpenUtau.Plugin.Builtin {
                 {"@u","u"},
                 {"3", "r"}
             };
-        private string[] tails = "-,R".Split(',');
         private bool isTails = false;
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
 
             // Load dictionary from plugin folder.
-            string path = Path.Combine(PluginDir, "en-xsampa.yaml");
+            string path = Path.Combine(PluginDir, YamlFileName);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
-                File.WriteAllBytes(path, Data.Resources.en_xsampa_template);
+                File.WriteAllBytes(path, YamlTemplate);
             }
             g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(path)).Build());
 
             // Load dictionary from singer folder.
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, "en-xsampa.yaml");
-                string file2 = Path.Combine(singer.Location, "xsampa.yaml");
+                string file = Path.Combine(singer.Location, YamlFileName);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
                     } catch (Exception e) {
                         Log.Error(e, $"Failed to load {file}");
                     }
-                } else if (File.Exists(file2)) {
-                    try {
-                        g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file2)).Build());
-                    } catch (Exception e) {
-                        Log.Error(e, $"Failed to load {file2}");
-                    }
                 }
             }
             g2ps.Add(new ArpabetG2p());
             return new G2pFallbacks(g2ps.ToArray());
-        }
-        public override void SetSinger(USinger singer) {
-            if (this.singer == singer) return;
-
-            this.singer = singer;
-            string file = null;
-
-            // Resolve path priority: en-xsampa.yaml > xsampa.yaml > write en-xsampa.yaml
-            string baseDir = (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location))
-                ? singer.Location
-                : PluginDir;
-
-            if (!string.IsNullOrEmpty(baseDir)) {
-                string enXsampaPath = Path.Combine(baseDir, "en-xsampa.yaml");
-                string fallbackXsampaPath = Path.Combine(baseDir, "xsampa.yaml");
-
-                if (File.Exists(enXsampaPath)) {
-                    file = enXsampaPath;
-                } else if (File.Exists(fallbackXsampaPath)) {
-                    file = fallbackXsampaPath;
-                } else {
-                    try {
-                        File.WriteAllBytes(enXsampaPath, Data.Resources.en_xsampa_template);
-                        file = enXsampaPath;
-                        Log.Error($"Wrote default 'en-xsampa.yaml' to {enXsampaPath}");
-                    } catch (Exception e) {
-                        Log.Error(e, $"Failed to write 'en-xsampa.yaml' to {enXsampaPath}");
-                        return;
-                    }
-                }
-            } else {
-                Log.Error("Singer location and PluginDir are both null or empty. Cannot locate or write xsampa YAML.");
-                return;
-            }
-
-            if (!string.IsNullOrEmpty(file) && File.Exists(file)) {
-                try {
-                    var data = Core.Yaml.DefaultDeserializer.Deserialize<XsampaYAMLData>(File.ReadAllText(file));
-                    // Load vowels
-                    try {
-                        var loadVowels = data.symbols?
-                            .Where(s => s.type == "vowel")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        vowels = vowels.Concat(loadVowels).Distinct().ToArray();
-                    } catch (Exception ex) {
-                        Log.Error($"Failed to load vowels from YAML: {ex.Message}");
-                    }
-                    // Load tails
-                    try {
-                        var loadTails = data.symbols
-                            ?.Where(s => s.type == "tail")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        tails = tails.Concat(loadTails).Distinct().ToArray();
-                    } catch (Exception ex) {
-                        Log.Error($"Failed to load tails from xsampa.yaml: {ex.Message}");
-                    }
-                    // Load the various consonant types 
-                    var fricatives = data.symbols
-                        ?.Where(s => s.type == "fricative")
-                        .Select(s => s.symbol)
-                        .ToList() ?? new List<string>();
-
-                    var aspirates = data.symbols
-                        ?.Where(s => s.type == "aspirate")
-                        .Select(s => s.symbol)
-                        .ToList() ?? new List<string>();
-
-                    var semivowels = data.symbols
-                        ?.Where(s => s.type == "semivowel")
-                        .Select(s => s.symbol)
-                        .ToList() ?? new List<string>();
-
-                    var liquids = data.symbols
-                        ?.Where(s => s.type == "liquid")
-                        .Select(s => s.symbol)
-                        .ToList() ?? new List<string>();
-
-                    var nasals = data.symbols
-                        ?.Where(s => s.type == "nasal")
-                        .Select(s => s.symbol)
-                        .ToList() ?? new List<string>();
-
-                    var stops = data.symbols
-                        ?.Where(s => s.type == "stop")
-                        .Select(s => s.symbol)
-                        .ToList() ?? new List<string>();
-
-                    var taps = data.symbols
-                        ?.Where(s => s.type == "tap")
-                        .Select(s => s.symbol)
-                        .ToList() ?? new List<string>();
-
-                    var affricates = data.symbols
-                        ?.Where(s => s.type == "affricate")
-                        .Select(s => s.symbol)
-                        .ToList() ?? new List<string>();
-
-                    PhonemeOverrides = data.timings
-                        ?.ToDictionary(t => t.symbol, t => t.value)
-                        ?? new Dictionary<string, double>();
-                    
-                    // Load consonant types into their respective lists
-                    fricative = fricatives.Distinct().ToArray();
-                    aspirate = aspirates.Distinct().ToArray();
-                    semivowel = semivowels.Distinct().ToArray();
-                    liquid = liquids.Distinct().ToArray();
-                    nasal = nasals.Distinct().ToArray();
-                    stop = stops.Distinct().ToArray();
-                    tap = taps.Distinct().ToArray();
-                    affricate = affricates.Distinct().ToArray();
-
-                    // Load replacements
-                    try {
-                        if (data?.replacements != null && data.replacements.Any() == true) {
-                            mergingReplacements = new List<Replacement>();
-                            splittingReplacements = new List<Replacement>();
-
-                            foreach (var replacement in data.replacements) {
-                                string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
-                                try {
-                                    if (replacement.from != null && replacement.to != null) {
-                                        if (replacement.from is IEnumerable<object> fromList) {
-                                            // 'from' is a list (e.g., [ae, n])
-                                            string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
-                                            if (replacement.to is string toString) {
-                                                mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
-                                            } else if (replacement.to is IEnumerable<object> toList) {
-                                                splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                            } else {
-                                                Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                            }
-                                        } else if (replacement.from is string fromString) {
-                                            // 'from' is a single string (e.g., tr, aw, ae, m, ng)
-                                            if (replacement.to is string toString) {
-                                                dictionaryReplacements[fromString] = toString;
-                                            } else if (replacement.to is IEnumerable<object> toList) {
-                                                splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                            } else {
-                                                Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                            }
-                                        } else {
-                                            Log.Error($"Error: Invalid 'from' type in replacement: {replacement}");
-                                        }
-                                    } else {
-                                        Log.Error($"Error: 'from' or 'to' is null in replacement: {replacement}");
-                                    }
-                                } catch (Exception ex) {
-                                    Log.Error($"Failed to process replacement entry: {replacement}. Error: {ex.Message}");
-                                }
-                            }
-                        } else {
-                            mergingReplacements = new List<Replacement>();
-                            splittingReplacements = new List<Replacement>();
-                        }
-                    } catch (Exception ex) {
-                        Log.Error($"Failed to load replacements from en-xsampa.yaml: {ex.Message}");
-                    }
-                    // Load fallbacks
-                    try {
-                        if (data?.fallbacks?.Any() == true) {
-                            foreach (var df in data.fallbacks) {
-                                if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
-                                    // Overwrite or add
-                                    fallbacks[df.from] = df.to;
-                                } else {
-                                    Log.Warning("Ignored YAML fallback with missing 'from' or 'to' value.");
-                                }
-                            }
-                        }
-                    } catch (Exception ex) {
-                        Log.Error($"Failed to load fallbacks from YAML: {ex.Message}");
-                    }
-                } catch (Exception ex) {
-                    Log.Error($"Failed to parse YAML file '{file}': {ex.Message}");
-                }
-            }
-            ReadDictionaryAndInit();
-        }
-
-        public class XsampaYAMLData {
-            public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
-            public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
-            public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
-            public Timings[] timings { get; set; } = Array.Empty<Timings>();
-
-
-            public struct SymbolData {
-                public string symbol { get; set; }
-                public string type { get; set; }
-            }
-            public struct Fallbacks {
-                public string from { get; set; }
-                public string to { get; set; }
-            }
-            public struct Timings {
-                public string symbol { get; set; }
-                public double value { get; set; }
-            }
-        }
-        // can split or merge
-        public class Replacement {
-            public object from { get; set; }
-            public object to { get; set; }
-            public string where { get; set; } = "inside";
-
-            public List<string> FromList {
-                get {
-                    if (from is string s) return new List<string> { s };
-                    if (from is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
-
-            public List<string> ToList {
-                get {
-                    if (to is string s) return new List<string> { s };
-                    if (to is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
         }
 
         protected override string[] GetSymbols(Note note) {
@@ -466,57 +209,13 @@ namespace OpenUtau.Plugin.Builtin {
             if (original == null) {
                 return null;
             }
-            List<string> modified = new List<string>(original);
-            List<string> finalPhonemes = new List<string>();
-            int i = 0;
-            bool hasReplacements = mergingReplacements.Any() == true || splittingReplacements.Any() == true; // Check for any replacements
-            if (hasReplacements) {
-                finalPhonemes = new List<string>();
-                while (i < modified.Count) {
-                    bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
-                        if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
-                            bool match = true;
-                            for (int j = 0; j < fromArray.Length; j++) {
-                                if (modified[i + j] != fromArray[j]) {
-                                    match = false;
-                                    break;
-                                }
-                            }
-                            if (match) {
-                                if (rule.to is string toString) {
-                                    finalPhonemes.Add(toString);
-                                } else if (rule.to is string[] toArray) {
-                                    finalPhonemes.AddRange(toArray);
-                                }
-                                i += fromArray.Length;
-                                replaced = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!replaced && splittingReplacements.Any()) {
-                        string currentPhoneme = modified[i];
-                        bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
-                            if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                                singleReplaced = true;
-                                break;
-                            }
-                        }
-                        if (!singleReplaced) {
-                            finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        }
-                        i++;
-                    } else if (!replaced) {
-                        finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        i++;
-                    }
+            var mappedOriginal = new List<string>();
+            foreach (var p in original) {
+                if (dictionaryReplacements.ContainsKey(p)) {
+                    mappedOriginal.Add(dictionaryReplacements[p]);
+                } else {
+                    mappedOriginal.Add(p);
                 }
-            } else {
-                finalPhonemes = new List<string>(modified);
             }
             List<string> finalProcessedPhonemes = new List<string>();
             
@@ -524,15 +223,12 @@ namespace OpenUtau.Plugin.Builtin {
             string[] diphthongs = new[] { "aI", "eI", "OI", "aU", "oU", "VI", "VU", "@U", "ai", "ei", "Oi", "au", "ou", "Ou", "@u", };
             string[] affricates = new[] { "dZ", "tS" };
             IEnumerable<string> phonemes;
-            if (hasReplacements) {
-                phonemes = finalPhonemes;
-            } else {
-                phonemes = original;
-            }
+            phonemes = mappedOriginal;
+            
             foreach (string s in phonemes) {
                 if (diphthongs.Contains(s) && !HasOto($"- {s}", note.tone) && !HasOto(s, note.tone) && !HasOto(ValidateAlias($"- {s}"), note.tone) && !HasOto(ValidateAlias(s), note.tone)) {
                     finalProcessedPhonemes.AddRange(new string[] { s[0].ToString(), s[1] + '^'.ToString() });
-                } else if (affricate.Contains(s) && !HasOto($"{s}A", note.tone) && !HasOto($"{s} A", note.tone) && !HasOto($"{s}Q", note.tone) && !HasOto($"{s} Q", note.tone)) {
+                } else if (affricates.Contains(s) && !HasOto($"{s}A", note.tone) && !HasOto($"{s} A", note.tone) && !HasOto($"{s}Q", note.tone) && !HasOto($"{s} Q", note.tone)) {
                     finalProcessedPhonemes.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
                 } else {
                     finalProcessedPhonemes.Add(s);
@@ -554,80 +250,11 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            // Replacement for note boundaries
-            List<string> currentPhonemes = new List<string>();
-            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
-            bool hasV = !string.IsNullOrEmpty(syllable.v);
-
-            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
-            currentPhonemes.AddRange(syllable.cc);
-            if (hasV) currentPhonemes.Add(syllable.v);
-
-            List<string> finalPhonemes = new List<string>();
-            int idx = 0;
-            while (idx < currentPhonemes.Count) {
-                bool replaced = false;
-                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
-                        bool match = true;
-                        for (int j = 0; j < fromArray.Length; j++) {
-                            if (currentPhonemes[idx + j] != fromArray[j]) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (match) {
-                            if (rule.to is string toString) {
-                                finalPhonemes.Add(toString);
-                            } else if (rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                            }
-                            idx += fromArray.Length;
-                            replaced = true;
-                            break;
-                        }
-                    }
-                }
-                
-                if (!replaced && splittingReplacements.Any()) {
-                    string currentPhoneme = currentPhonemes[idx];
-                    bool singleReplaced = false;
-                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                            finalPhonemes.AddRange(toArray);
-                            singleReplaced = true;
-                            break;
-                        }
-                    }
-                    if (!singleReplaced) {
-                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    }
-                    idx++;
-                } else if (!replaced) {
-                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    idx++;
-                }
-            }
-
-            string newPrevV = "";
-            string newV = "";
-            List<string> newCc = new List<string>();
-
-            if (finalPhonemes.Count > 0) {
-                if (hasPrevV) {
-                    newPrevV = finalPhonemes[0];
-                    finalPhonemes.RemoveAt(0);
-                }
-                if (hasV && finalPhonemes.Count > 0) {
-                    newV = finalPhonemes.Last();
-                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
-                }
-                newCc.AddRange(finalPhonemes);
-            }
-            
-            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
-            string[] cc = newCc.ToArray();
-            string v = newV;
+            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
+            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
+            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
+            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
             List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
@@ -637,58 +264,54 @@ namespace OpenUtau.Plugin.Builtin {
             string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
             int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
 
+
             var rv = $"- {v}";
             
             // Switch between phonetic systems, depending on certain aliases in the bank
-            if (replacements.ContainsKey(syllable.v) || replacements.ContainsKey(syllable.prevV)) {
-                isReplacements = true;
-            } else {
-                if (HasOto($"- i:", syllable.tone) || HasOto($"i:", syllable.tone) || (!HasOto($"- 3", syllable.tone) && !HasOto($"3", syllable.tone))) {
-                    isVocaSampa = true;
+            foreach (var entry in yamlFallbacks) {
+                if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Key, syllable.tone)) {
+                    isYamlFallbacks = true;
+                    break;
                 }
+            }
+            if (HasOto($"- i:", syllable.tone) || HasOto($"i:", syllable.tone) || (!HasOto($"- 3", syllable.tone) && !HasOto($"3", syllable.tone))) {
+                isVocaSampa = true;
+            }
 
-                if (!HasOto($"- VI", syllable.tone) || HasOto($"VI", syllable.tone) || (!HasOto($"- VU", syllable.tone) && !HasOto($"VU", syllable.tone))) {
-                    isMissingCanadianRaising = true;
-                }
+            if (!HasOto($"- VI", syllable.tone) || HasOto($"VI", syllable.tone) || (!HasOto($"- VU", syllable.tone) && !HasOto($"VU", syllable.tone))) {
+                isMissingCanadianRaising = true;
+            }
 
-                if (!HasOto($"- V", syllable.vowelTone) && !HasOto($"V", syllable.vowelTone)) {
-                    isSimpleDelta = true;
-                }
+            if (!HasOto($"- V", syllable.vowelTone) && !HasOto($"V", syllable.vowelTone)) {
+                isSimpleDelta = true;
+            }
 
-                if (!HasOto($"- bV", syllable.vowelTone) && !HasOto($"bV", syllable.vowelTone)) {
-                    isTetoException = true;
-                }
+            if (!HasOto($"- bV", syllable.vowelTone) && !HasOto($"bV", syllable.vowelTone)) {
+                isTetoException = true;
+            }
 
-                if ((!HasOto($"- I", syllable.vowelTone) && !HasOto($"I", syllable.vowelTone)) || (!HasOto($"- U", syllable.vowelTone) && !HasOto($"U", syllable.vowelTone))) {
-                    isMiniDelta = true;
-                }
+            if ((!HasOto($"- I", syllable.vowelTone) && !HasOto($"I", syllable.vowelTone)) || (!HasOto($"- U", syllable.vowelTone) && !HasOto($"U", syllable.vowelTone))) {
+                isMiniDelta = true;
+            }
 
-                if (HasOto("あ", syllable.vowelTone) || HasOto("- あ", syllable.vowelTone)) {
-                    isEnPlusJa = true;
-                }
+            if (HasOto("あ", syllable.vowelTone) || HasOto("- あ", syllable.vowelTone)) {
+                isEnPlusJa = true;
+            }
 
-                if (HasOto($"{prevV} r\\", syllable.tone)) {
-                    isTrueXSampa = true;
-                }
+            if (HasOto($"{prevV} r\\", syllable.tone)) {
+                isTrueXSampa = true;
+            }
 
-                if (!HasOto($"- 3", syllable.tone) && !HasOto($"3", syllable.tone) && !HasOto($"- @`", syllable.tone) && !HasOto($"@`", syllable.tone)) {
-                    isSalemList = true;
-                }
+            if (!HasOto($"- 3", syllable.tone) && !HasOto($"3", syllable.tone) && !HasOto($"- @`", syllable.tone) && !HasOto($"@`", syllable.tone)) {
+                isSalemList = true;
+            }
 
-                if ((!HasOto($"N g", syllable.tone) || !HasOto($"N g-", syllable.tone)) && (!HasOto($"N k", syllable.tone) || !HasOto($"N k-", syllable.tone))) {
-                    isVelarNasalFallback = true;
-                }
+            if ((!HasOto($"N g", syllable.tone) || !HasOto($"N g-", syllable.tone)) && (!HasOto($"N k", syllable.tone) || !HasOto($"N k-", syllable.tone))) {
+                isVelarNasalFallback = true;
+            }
 
-                if (HasOto("@5", syllable.vowelTone) || HasOto("u5", syllable.vowelTone) || HasOto("O5", syllable.vowelTone) || HasOto("A5", syllable.vowelTone) || HasOto("E5", syllable.vowelTone) || HasOto("I5", syllable.vowelTone) || HasOto("i5", syllable.vowelTone) || HasOto("- @5", syllable.vowelTone) || HasOto("- u5", syllable.vowelTone) || HasOto("- O5", syllable.vowelTone) || HasOto("- A5", syllable.vowelTone) || HasOto("- E5", syllable.vowelTone) || HasOto("- I5", syllable.vowelTone) || HasOto("- i5", syllable.vowelTone)) {
-                    isDarkLVowel = true;
-                }
-
-                foreach (var entry in fallbacks) {
-                    if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Key, syllable.tone)) {
-                        isfallbacks = true;
-                        break;
-                    }
-                }
+            if (HasOto("@5", syllable.vowelTone) || HasOto("u5", syllable.vowelTone) || HasOto("O5", syllable.vowelTone) || HasOto("A5", syllable.vowelTone) || HasOto("E5", syllable.vowelTone) || HasOto("I5", syllable.vowelTone) || HasOto("i5", syllable.vowelTone) || HasOto("- @5", syllable.vowelTone) || HasOto("- u5", syllable.vowelTone) || HasOto("- O5", syllable.vowelTone) || HasOto("- A5", syllable.vowelTone) || HasOto("- E5", syllable.vowelTone) || HasOto("- I5", syllable.vowelTone) || HasOto("- i5", syllable.vowelTone)) {
+                isDarkLVowel = true;
             }
 
             if (syllable.IsStartingV) {
@@ -1232,14 +855,8 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             }
 
-            if (isReplacements) {
-                foreach (var syllable in replacements.OrderByDescending(f => f.Key.Length)) {
-                    alias = alias.Replace(syllable.Key, syllable.Value);
-                }
-            }
-
-            if (isfallbacks) {
-                foreach (var syllable in fallbacks.OrderByDescending(f => f.Key.Length)) {
+            if (isYamlFallbacks) {
+                foreach (var syllable in yamlFallbacks.OrderByDescending(f => f.Key.Length)) {
                     alias = alias.Replace(syllable.Key, syllable.Value);
                 }
             }

--- a/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
@@ -18,6 +18,7 @@ namespace OpenUtau.Plugin.Builtin {
     // Arpabet only but in the future update, it can be customize the phoneme set
     public class EnglishCpVPhonemizer : SyllableBasedPhonemizer {
         private const string LatestVersion = "1.1";
+        private const string YamlFile = "en-cPv.yaml";
         private string[] vowels = {
         "aa", "ax", "ae", "ah", "ao", "aw", "ay", "eh", "er", "ey", "ih", "iy", "ow", "oy", "uh", "uw", "a", "e", "i", "o", "u", "ai", "ei", "oi", "au", "ou", "ix", "ux",
         "aar", "ar", "axr", "aer", "ahr", "aor", "or", "awr", "aur", "ayr", "air", "ehr", "eyr", "eir", "ihr", "iyr", "ir", "owr", "our", "oyr", "oir", "uhr", "uwr", "ur",
@@ -101,7 +102,7 @@ namespace OpenUtau.Plugin.Builtin {
                 finalPhonemes = new List<string>();
                 while (i < modified.Count) {
                     bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements)) {
+                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
                         if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
                             bool match = true;
                             for (int j = 0; j < fromArray.Length; j++) {
@@ -126,7 +127,7 @@ namespace OpenUtau.Plugin.Builtin {
                     if (!replaced && splittingReplacements.Any()) {
                         string currentPhoneme = modified[i];
                         bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements) {
+                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
                             if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
                                 finalPhonemes.AddRange(toArray);
                                 singleReplaced = true;
@@ -227,14 +228,14 @@ namespace OpenUtau.Plugin.Builtin {
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
             // LOAD DICTIONARY FROM FOLDER
-            string path = Path.Combine(PluginDir, "en-cPv.yaml");
+            string path = Path.Combine(PluginDir, YamlFile);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
                 File.WriteAllBytes(path, Data.Resources.en_cPv_template);
             }
             // LOAD DICTIONARY FROM SINGER FOLDER
             if (singer != null || singer.Found || singer.Loaded) {
-                string file = Path.Combine(singer.Location, "en-cPv.yaml");
+                string file = Path.Combine(singer.Location, YamlFile);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -252,9 +253,9 @@ namespace OpenUtau.Plugin.Builtin {
             if (this.singer != singer) {
                 string file;
                 if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, "en-cPv.yaml");
+                    file = Path.Combine(singer.Location, YamlFile);
                 } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, "en-cPv.yaml");
+                    file = Path.Combine(PluginDir, YamlFile);
                 } else {
                     Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'en-cPv.yaml'.");
                     return;
@@ -302,9 +303,9 @@ namespace OpenUtau.Plugin.Builtin {
                                 $"en-cPv_backup.yaml"
                             );
                             File.Move(file, backupFile);
-                            Log.Warning($"Old en-cPv.yaml has been backed up as: {backupFile}");
+                            Log.Warning($"Old {YamlFile} has been backed up as: {backupFile}");
                         } catch (Exception e) {
-                            Log.Error(e, "Failed to back up old en-cPv.yaml. Proceeding with new template anyway.");
+                            Log.Error(e, $"Failed to back up old {YamlFile}. Proceeding with new template anyway.");
                         }
                     }
 
@@ -314,11 +315,11 @@ namespace OpenUtau.Plugin.Builtin {
                             File.WriteAllBytes(file, Data.Resources.en_cPv_template);
                             Log.Information($"'{file}' created or updated to latest version {LatestVersion}");
                         } catch (Exception e) {
-                            Log.Error(e, $"Failed to write 'en-cPv.yaml' to {file}");
+                            Log.Error(e, $"Failed to write '{YamlFile}' to {file}");
                         }
                     }
                 } catch (Exception ex) {
-                    Log.Error(ex, $"Unexpected error while ensuring en-cPv.yaml at {file}");
+                    Log.Error(ex, $"Unexpected error while ensuring {YamlFile} at {file}");
                 }
 
                 if (File.Exists(file)) {
@@ -465,14 +466,15 @@ namespace OpenUtau.Plugin.Builtin {
 
                                 foreach (var replacement in data.replacements) {
                                     try {
+                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
                                         if (replacement.from != null && replacement.to != null) {
                                             if (replacement.from is IEnumerable<object> fromList) {
                                                 // 'from' is a list (e.g., [ae, n])
                                                 string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
                                                 if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString });
+                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -481,7 +483,7 @@ namespace OpenUtau.Plugin.Builtin {
                                                 if (replacement.to is string toString) {
                                                     dictionaryReplacements[fromString] = toString;
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope  });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -501,7 +503,7 @@ namespace OpenUtau.Plugin.Builtin {
                                 splittingReplacements = new List<Replacement>();
                             }
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from en-cPv.yaml: {ex.Message}");
+                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
                         }
                         // Load fallbacks
                         try {
@@ -520,7 +522,7 @@ namespace OpenUtau.Plugin.Builtin {
                         }
 
                     } catch (Exception ex) {
-                        Log.Error($"Failed to parse en-cPv.yaml: {ex.Message}, Exception Type: {ex.GetType()}");
+                        Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
                     }
                 }
                 ReadDictionaryAndInit();
@@ -552,6 +554,8 @@ namespace OpenUtau.Plugin.Builtin {
         public class Replacement {
             public object from { get; set; }
             public object to { get; set; }
+            public string where { get; set; } = "inside";
+
 
             public List<string> FromList {
                 get {
@@ -582,18 +586,87 @@ namespace OpenUtau.Plugin.Builtin {
             return phoneme;
         }
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
-            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
-            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
-            //string prevV = syllable.prevV;
-            string[] cc = syllable.cc;
-            string v = syllable.v;
+            // Replacement for note boundaries
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
+            bool hasV = !string.IsNullOrEmpty(syllable.v);
+
+            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
+            currentPhonemes.AddRange(syllable.cc);
+            if (hasV) currentPhonemes.Add(syllable.v);
+
+            List<string> finalPhonemes = new List<string>();
+            int idx = 0;
+            while (idx < currentPhonemes.Count) {
+                bool replaced = false;
+                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
+                        bool match = true;
+                        for (int j = 0; j < fromArray.Length; j++) {
+                            if (currentPhonemes[idx + j] != fromArray[j]) {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match) {
+                            if (rule.to is string toString) {
+                                finalPhonemes.Add(toString);
+                            } else if (rule.to is string[] toArray) {
+                                finalPhonemes.AddRange(toArray);
+                            }
+                            idx += fromArray.Length;
+                            replaced = true;
+                            break;
+                        }
+                    }
+                }
+                
+                if (!replaced && splittingReplacements.Any()) {
+                    string currentPhoneme = currentPhonemes[idx];
+                    bool singleReplaced = false;
+                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
+                            finalPhonemes.AddRange(toArray);
+                            singleReplaced = true;
+                            break;
+                        }
+                    }
+                    if (!singleReplaced) {
+                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    }
+                    idx++;
+                } else if (!replaced) {
+                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    idx++;
+                }
+            }
+
+            string newPrevV = "";
+            string newV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                if (hasV && finalPhonemes.Count > 0) {
+                    newV = finalPhonemes.Last();
+                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
+                }
+                newCc.AddRange(finalPhonemes);
+            }
+            
+            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
+            string[] cc = newCc.ToArray();
+            string v = newV;
+            List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
-            string[] CurrentWordCc = syllable.CurrentWordCc.Select(ReplacePhoneme).ToArray();
-            string[] PreviousWordCc = syllable.PreviousWordCc.Select(ReplacePhoneme).ToArray();
+            string[] CurrentWordCc = syllable.CurrentWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
             int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
 
             // Check for missing vowel phonemes

--- a/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
@@ -17,37 +17,58 @@ namespace OpenUtau.Plugin.Builtin {
     // Custom C+V Phonemizer for OU
     // Arpabet only but in the future update, it can be customize the phoneme set
     public class EnglishCpVPhonemizer : SyllableBasedPhonemizer {
-        private const string LatestVersion = "1.1";
-        private const string YamlFile = "en-cPv.yaml";
-        private string[] vowels = {
-        "aa", "ax", "ae", "ah", "ao", "aw", "ay", "eh", "er", "ey", "ih", "iy", "ow", "oy", "uh", "uw", "a", "e", "i", "o", "u", "ai", "ei", "oi", "au", "ou", "ix", "ux",
-        "aar", "ar", "axr", "aer", "ahr", "aor", "or", "awr", "aur", "ayr", "air", "ehr", "eyr", "eir", "ihr", "iyr", "ir", "owr", "our", "oyr", "oir", "uhr", "uwr", "ur",
-        "aal", "al", "axl", "ael", "ahl", "aol", "ol", "awl", "aul", "ayl", "ail", "ehl", "el", "eyl", "eil", "ihl", "iyl", "il", "owl", "oul", "oyl", "oil", "uhl", "uwl", "ul",
-        "aan", "an", "axn", "aen", "ahn", "aon", "on", "awn", "aun", "ayn", "ain", "ehn", "en", "eyn", "ein", "ihn", "iyn", "in", "own", "oun", "oyn", "oin", "uhn", "uwn", "un",
-        "aang", "ang", "axng", "aeng", "ahng", "aong", "ong", "awng", "aung", "ayng", "aing", "ehng", "eng", "eyng", "eing", "ihng", "iyng", "ing", "owng", "oung", "oyng", "oing", "uhng", "uwng", "ung",
-        "aam", "am", "axm", "aem", "ahm", "aom", "om", "awm", "aum", "aym", "aim", "ehm", "em", "eym", "eim", "ihm", "iym", "im", "owm", "oum", "oym", "oim", "uhm", "uwm", "um", "oh",
-        "eu", "oe", "yw", "yx", "wx", "ox", "ex", "ea", "ia", "oa", "ua", "ean", "eam", "eang", "N", "nn", "mm", "ll"
-        };
-        private static string[] diphthongs = { "ay", "ey", "oy", "aw", "ow" };
+        protected override string YamlFileName => "en-cPv.yaml";
+        protected override byte[] YamlTemplate => Data.Resources.en_cPv_template;
+        protected override string YamlVersion => "1.1";
+        public EnglishCpVPhonemizer() {
+            this.vowels = new string[] {"aa", "ax", "ae", "ah", "ao", "aw", "ay", "eh", "er", "ey", "ih", "iy", "ow", "oy", "uh", "uw", "a", "e", "i", "o", "u", "ai", "ei", "oi", "au", "ou", "ix", "ux",
+            "aar", "ar", "axr", "aer", "ahr", "aor", "or", "awr", "aur", "ayr", "air", "ehr", "eyr", "eir", "ihr", "iyr", "ir", "owr", "our", "oyr", "oir", "uhr", "uwr", "ur",
+            "aal", "al", "axl", "ael", "ahl", "aol", "ol", "awl", "aul", "ayl", "ail", "ehl", "el", "eyl", "eil", "ihl", "iyl", "il", "owl", "oul", "oyl", "oil", "uhl", "uwl", "ul",
+            "aan", "an", "axn", "aen", "ahn", "aon", "on", "awn", "aun", "ayn", "ain", "ehn", "en", "eyn", "ein", "ihn", "iyn", "in", "own", "oun", "oyn", "oin", "uhn", "uwn", "un",
+            "aang", "ang", "axng", "aeng", "ahng", "aong", "ong", "awng", "aung", "ayng", "aing", "ehng", "eng", "eyng", "eing", "ihng", "iyng", "ing", "owng", "oung", "oyng", "oing", "uhng", "uwng", "ung",
+            "aam", "am", "axm", "aem", "ahm", "aom", "om", "awm", "aum", "aym", "aim", "ehm", "em", "eym", "eim", "ihm", "iym", "im", "owm", "oum", "oym", "oim", "uhm", "uwm", "um", "oh",
+            "eu", "oe", "yw", "yx", "wx", "ox", "ex", "ea", "ia", "oa", "ua", "ean", "eam", "eang", "N", "nn", "mm", "ll"
+            };
+            this.consonants = "b,ch,d,dh,dr,dx,f,g,hh,jh,k,l,m,n,ng,p,q,r,s,sh,t,th,tr,v,w,y,z".Split(',');
+            this.diphthongs = Array.Empty<string>();
+            
+        }
+        private string[] diphthongs = Array.Empty<string>();
         private static string[] c_cR = { "n" };
-        private static string[] consonants = "b,ch,d,dh,dr,dx,f,g,hh,jh,k,l,m,n,ng,p,q,r,s,sh,t,th,tr,v,w,y,z".Split(',');
-        private static string[] affricate = "".Split(',');
-        private static string[] fricative = "".Split(',');
-        private static string[] aspirate = "".Split(',');
-        private static string[] semivowel = "".Split(',');
-        private static string[] liquid = "".Split(',');
-        private static string[] nasal = "".Split(',');
-        private static string[] stop = "".Split(',');
-        private static string[] tap = "".Split(',');
+
+        protected override bool IsGroupKeyword(string rulePhoneme) {
+            string baseGroup = rulePhoneme.Split(new[] { '!', '+' })[0];
+            return base.IsGroupKeyword(rulePhoneme) || new[] { "affricate", "fricative", "aspirate", "semivowel", "liquid", "nasal", "stop", "tap", "diphthong" }.Contains(baseGroup);
+        }
+        protected override bool IsGroupMatch(string rulePhoneme, string actualPhoneme) {
+            if (base.IsGroupMatch(rulePhoneme, actualPhoneme)) return true;
+            string baseGroup = rulePhoneme.Split(new[] { '!', '+' })[0];
+            
+            if (rulePhoneme.Contains("!")) {
+                string[] exceptions = rulePhoneme.Split('!')[1].Split(',');
+                if (exceptions.Contains(actualPhoneme)) return false;
+            }
+            if (rulePhoneme.Contains("+")) {
+                string[] inclusions = rulePhoneme.Split('+')[1].Split(',');
+                if (!inclusions.Contains(actualPhoneme)) return false;
+            }
+            switch (baseGroup) {
+                case "affricate": return affricate.Contains(actualPhoneme);
+                case "fricative": return fricative.Contains(actualPhoneme);
+                case "aspirate": return aspirate.Contains(actualPhoneme);
+                case "semivowel": return semivowel.Contains(actualPhoneme);
+                case "liquid": return liquid.Contains(actualPhoneme);
+                case "nasal": return nasal.Contains(actualPhoneme);
+                case "stop": return stop.Contains(actualPhoneme);
+                case "tap": return tap.Contains(actualPhoneme);
+                case "diphthong": return diphthongs.Contains(actualPhoneme);
+                default: return false;
+            }
+        }
+
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "";
-        private Dictionary<string, string> dictionaryReplacements;
-        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
-        // Store the splitting replacements
-        private List<Replacement> splittingReplacements = new List<Replacement>();
-        // Store the merging replacements
-        private List<Replacement> mergingReplacements = new List<Replacement>();
 
         // For banks with missing vowels
         private readonly Dictionary<string, string> missingVphonemes = "ax=ah,aa=ah,ae=ah,iy=ih,uh=uw,ix=ih,ux=uh,oh=ao,eu=uh,oe=ax,uy=uw,yw=uw,yx=iy,wx=uw,ea=eh,ia=iy,oa=ao,ua=uw,R=-,N=n,mm=m,ll=l".Split(',')
@@ -73,18 +94,15 @@ namespace OpenUtau.Plugin.Builtin {
                 .ToDictionary(parts => parts[0], parts => parts[1]);
         private bool isTimitPhonemes = false;
 
-        private static Dictionary<string, string> DiphthongExceptions = diphthongs.ToDictionary(
-            key => key,
-            value => value.Last().ToString()
-        );
+        private Dictionary<string, string> DiphthongExceptions = new Dictionary<string, string>() {
+            { "ay", "ay-" }, { "ey", "ey-" }, { "oy", "oy-" }, { "aw", "aw-" }, { "ow", "ow-" }
+        };
 
-        private Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
+        private bool isYamlFallbacks = false;
 
         private readonly string[] ccvException = { "ch", "dh", "dx", "fh", "gh", "hh", "jh", "kh", "ph", "ng", "sh", "th", "vh", "wh", "zh" };
         private readonly string[] RomajiException = { "a", "e", "i", "o", "u" };
-        private string[] tails = "-,R".Split(',');
         private bool isTails = false;
-
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
             if (tails.Contains(note.lyric)) {
@@ -95,57 +113,7 @@ namespace OpenUtau.Plugin.Builtin {
                 return null;
             }
             List<string> modified = new List<string>(original);
-            List<string> finalPhonemes = new List<string>();
-            int i = 0;
-            bool hasReplacements = mergingReplacements.Any() == true || splittingReplacements.Any() == true; // Check for any replacements
-            if (hasReplacements) {
-                finalPhonemes = new List<string>();
-                while (i < modified.Count) {
-                    bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
-                        if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
-                            bool match = true;
-                            for (int j = 0; j < fromArray.Length; j++) {
-                                if (modified[i + j] != fromArray[j]) {
-                                    match = false;
-                                    break;
-                                }
-                            }
-                            if (match) {
-                                if (rule.to is string toString) {
-                                    finalPhonemes.Add(toString);
-                                } else if (rule.to is string[] toArray) {
-                                    finalPhonemes.AddRange(toArray);
-                                }
-                                i += fromArray.Length;
-                                replaced = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!replaced && splittingReplacements.Any()) {
-                        string currentPhoneme = modified[i];
-                        bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
-                            if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                                singleReplaced = true;
-                                break;
-                            }
-                        }
-                        if (!singleReplaced) {
-                            finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        }
-                        i++;
-                    } else if (!replaced) {
-                        finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        i++;
-                    }
-                }
-            } else {
-                finalPhonemes = new List<string>(modified);
-            }
+            List<string> finalPhonemes = ApplyReplacements(modified, false);
             List<string> finalProcessedPhonemes = new List<string>();
 
             // SPLITS UP DR AND TR
@@ -177,11 +145,8 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             }
             IEnumerable<string> phonemes;
-            if (hasReplacements) {
-                phonemes = finalPhonemes;
-            } else {
-                phonemes = original;
-            }
+            phonemes = finalPhonemes;
+           
             foreach (string s in phonemes) {
                 switch (s) {
                     case var str when dr.Contains(str) && !HasOto($"{str}", note.tone) && !HasOto(ValidateAlias(str), note.tone):
@@ -228,14 +193,14 @@ namespace OpenUtau.Plugin.Builtin {
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
             // LOAD DICTIONARY FROM FOLDER
-            string path = Path.Combine(PluginDir, YamlFile);
+            string path = Path.Combine(PluginDir, YamlFileName);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
-                File.WriteAllBytes(path, Data.Resources.en_cPv_template);
+                File.WriteAllBytes(path, YamlTemplate);
             }
             // LOAD DICTIONARY FROM SINGER FOLDER
             if (singer != null || singer.Found || singer.Loaded) {
-                string file = Path.Combine(singer.Location, YamlFile);
+                string file = Path.Combine(singer.Location, YamlFileName);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -250,330 +215,53 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         public override void SetSinger(USinger singer) {
-            if (this.singer != singer) {
-                string file;
-                if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, YamlFile);
-                } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, YamlFile);
-                } else {
-                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'en-cPv.yaml'.");
-                    return;
-                }
-                try {
-                    bool shouldWriteTemplate = false;
-                    bool shouldBackupOldFile = false;
+            base.SetSinger(singer);
 
-                    if (File.Exists(file)) {
-                        try {
-                            // Build YAML deserializer
-                            var deserializer = new DeserializerBuilder()
-                                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                                .Build();
-
-                            using var reader = new StreamReader(file);
-                            var config = deserializer.Deserialize<Dictionary<string, object>>(reader);
-
-                            if (config == null || !config.ContainsKey("version")) {
-                                shouldWriteTemplate = true;
-                                shouldBackupOldFile = true; // No version → backup old
-                            } else {
-                                string currentVersion = config["version"]?.ToString()?.Trim() ?? "";
-
-                                // If version is missing OR outdated → backup old + write new
-                                if (string.IsNullOrWhiteSpace(currentVersion) || currentVersion != LatestVersion) {
-                                    shouldWriteTemplate = true;
-                                    shouldBackupOldFile = true;
-                                }
-                            }
-                        } catch (Exception ex) {
-                            Log.Error(ex, $"Failed to read '{file}', backing up old file and writing a fresh one...");
-                            shouldWriteTemplate = true;
-                            shouldBackupOldFile = true;
-                        }
-                    } else {
-                        shouldWriteTemplate = true;
-                    }
-
-                    // If needed, back up the old file
-                    if (shouldBackupOldFile && File.Exists(file)) {
-                        try {
-                            string backupFile = Path.Combine(
-                                Path.GetDirectoryName(file)!,
-                                $"en-cPv_backup.yaml"
-                            );
-                            File.Move(file, backupFile);
-                            Log.Warning($"Old {YamlFile} has been backed up as: {backupFile}");
-                        } catch (Exception e) {
-                            Log.Error(e, $"Failed to back up old {YamlFile}. Proceeding with new template anyway.");
-                        }
-                    }
-
-                    // Write a fresh template if necessary
-                    if (shouldWriteTemplate) {
-                        try {
-                            File.WriteAllBytes(file, Data.Resources.en_cPv_template);
-                            Log.Information($"'{file}' created or updated to latest version {LatestVersion}");
-                        } catch (Exception e) {
-                            Log.Error(e, $"Failed to write '{YamlFile}' to {file}");
-                        }
-                    }
-                } catch (Exception ex) {
-                    Log.Error(ex, $"Unexpected error while ensuring {YamlFile} at {file}");
+            if (this.singer != null && this.singer.Loaded) {
+                
+                string file = Path.Combine(this.singer.Location, YamlFileName);
+                if (!File.Exists(file)) {
+                    file = Path.Combine(PluginDir, YamlFileName);
                 }
 
                 if (File.Exists(file)) {
                     try {
                         var data = Core.Yaml.DefaultDeserializer.Deserialize<ArpabetYAMLData>(File.ReadAllText(file));
-
-                        // Load vowels and diphthongs
-                        try {
-                            var loadedVowels = data.symbols
-                                ?.Where(s => s.type == "vowel")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            var loadedDiphthongs = data.symbols
-                                ?.Where(s => s.type == "diphthong")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            // Combine vowels and diphthongs, then remove duplicates
-                            vowels = vowels.Concat(loadedVowels)
-                                        .Concat(loadedDiphthongs)
-                                        .Distinct()
-                                        .ToArray();
-
-                            // Load diphthongs specifically to their own list
-                            diphthongs = loadedDiphthongs.ToArray();
-
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels and diphthongs from en-cPv.yaml: {ex.Message}");
-                        }
-                        // Load tails
-                        try {
-                            var loadTails = data.symbols
-                                ?.Where(s => s.type == "tail")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            tails = tails.Concat(loadTails).Distinct().ToArray();
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load tails from en-cPv.yaml: {ex.Message}");
-                        }
-                        // Load the various consonant types for double consonant endings
-                        var fricatives = data.symbols
-                            ?.Where(s => s.type == "fricative")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var aspirates = data.symbols
-                            ?.Where(s => s.type == "aspirate")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var semivowels = data.symbols
-                            ?.Where(s => s.type == "semivowel")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var liquids = data.symbols
-                            ?.Where(s => s.type == "liquid")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var nasals = data.symbols
-                            ?.Where(s => s.type == "nasal")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-                        /// others
-                        var stops = data.symbols
-                            ?.Where(s => s.type == "stop")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var taps = data.symbols
-                            ?.Where(s => s.type == "tap")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var affricates = data.symbols
-                            ?.Where(s => s.type == "affricate")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        PhonemeOverrides = data.timings
-                            ?.ToDictionary(t => t.symbol, t => t.value)
-                            ?? new Dictionary<string, double>();
-
-                        // Combine all the consonant types into one list
-                        c_cR = fricatives
-                            .Concat(aspirates)
-                            .Concat(semivowels)
-                            .Concat(liquids)
-                            .Concat(nasals)
-                            .Distinct()
-                            .ToArray();
-
-                        // Load consonant types into their respective lists
-                        fricative = fricatives.Distinct().ToArray();
-                        aspirate = aspirates.Distinct().ToArray();
-                        semivowel = semivowels.Distinct().ToArray();
-                        liquid = liquids.Distinct().ToArray();
-                        nasal = nasals.Distinct().ToArray();
-                        stop = stops.Distinct().ToArray();
-                        tap = taps.Distinct().ToArray();
-                        affricate = affricates.Distinct().ToArray();
-                        /*consonants = fricatives
-                            .Concat(aspirates)
-                            .Concat(semivowels)
-                            .Concat(liquids)
-                            .Concat(nasals)
-                            .Concat(stop)
-                            .Concat(tap)
-                            .Concat(affricate)
-                            .Distinct()
-                            .ToArray();*/
-                        // Load diphthong exceptions
-                        try {
-                            var allDiphthongs = data.symbols
-                                ?.Where(s => s.type == "diphthong")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            // Load explicit exceptions from the new YAML section
-                            var loadedDiphthongExceptions = data.diphthongs
-                                ?.ToDictionary(d => d.from, d => d.to) ?? new Dictionary<string, string>();
-
-                            // Initialize the DiphthongExceptions dictionary with explicit exceptions
-                            DiphthongExceptions = new Dictionary<string, string>(loadedDiphthongExceptions);
-
-                            // Create default mappings for diphthongs without an explicit exception [aw=aw], [ay=ay] etc
-                            foreach (var diphthong in allDiphthongs) {
-                                if (!DiphthongExceptions.ContainsKey(diphthong)) {
-                                    DiphthongExceptions.Add(diphthong, diphthong);
+                        
+                        if (data?.diphthongs != null && data.diphthongs.Any()) {
+                            DiphthongExceptions.Clear();
+                            foreach (var df in data.diphthongs) {
+                                if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
+                                    DiphthongExceptions[df.from] = df.to;
                                 }
                             }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load diphthongs and exceptions: {ex.Message}");
                         }
-                        // Load replacements (errors out if there's no replacements)
-                        try {
-                            if (data?.replacements != null && data.replacements.Any() == true) {
-                                dictionaryReplacements = new Dictionary<string, string>();
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-
-                                foreach (var replacement in data.replacements) {
-                                    try {
-                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
-                                        if (replacement.from != null && replacement.to != null) {
-                                            if (replacement.from is IEnumerable<object> fromList) {
-                                                // 'from' is a list (e.g., [ae, n])
-                                                string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
-                                                if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else if (replacement.from is string fromString) {
-                                                // 'from' is a single string (e.g., tr, aw, ae, m, ng)
-                                                if (replacement.to is string toString) {
-                                                    dictionaryReplacements[fromString] = toString;
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope  });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else {
-                                                Log.Error($"Error: Invalid 'from' type in replacement: {replacement}");
-                                            }
-                                        } else {
-                                            Log.Error($"Error: 'from' or 'to' is null in replacement: {replacement}");
-                                        }
-                                    } catch (Exception ex) {
-                                        Log.Error($"Failed to process replacement entry: {replacement}. Error: {ex.Message}");
-                                    }
-                                }
-                            } else {
-                                dictionaryReplacements = new Dictionary<string, string>();
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
+                        
+                        this.diphthongs = data.symbols?.Where(s => s.type == "diphthong").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+                        DiphthongExceptions.Clear();
+                        foreach (var d in this.diphthongs) {
+                            DiphthongExceptions[d] = d + "-"; 
                         }
-                        // Load fallbacks
-                        try {
-                            if (data?.fallbacks?.Any() == true) {
-                                foreach (var df in data.fallbacks) {
-                                    if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
-                                        // Overwrite or add
-                                        missingVphonemes[df.from] = df.to;
-                                    } else {
-                                        Log.Warning("Ignored YAML fallback with missing 'from' or 'to' value.");
-                                    }
+                        
+                        if (data?.diphthongs != null && data.diphthongs.Any()) {
+                            foreach (var df in data.diphthongs) {
+                                if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
+                                    DiphthongExceptions[df.from] = df.to;
                                 }
                             }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load fallbacks from YAML: {ex.Message}");
                         }
-
+                        
                     } catch (Exception ex) {
-                        Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
+                        Log.Error($"Failed to parse custom diphthongs from {YamlFileName}: {ex.Message}");
                     }
                 }
-                ReadDictionaryAndInit();
-                this.singer = singer;
             }
         }
 
-        public class ArpabetYAMLData {
-            public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
-            public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
-            public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
+        public class ArpabetYAMLData: YAMLData {
             public Fallbacks[] diphthongs { get; set; } = Array.Empty<Fallbacks>();
-            public Timings[] timings { get; set; } = Array.Empty<Timings>();
-
-            public struct SymbolData {
-                public string symbol { get; set; }
-                public string type { get; set; }
-            }
-            public struct Fallbacks {
-                public string from { get; set; }
-                public string to { get; set; }
-            }
-            public struct Timings {
-                public string symbol { get; set; }
-                public double value { get; set; }
-            }
         }
-        // can split or merge
-        public class Replacement {
-            public object from { get; set; }
-            public object to { get; set; }
-            public string where { get; set; } = "inside";
 
-
-            public List<string> FromList {
-                get {
-                    if (from is string s) return new List<string> { s };
-                    if (from is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
-
-            public List<string> ToList {
-                get {
-                    if (to is string s) return new List<string> { s };
-                    if (to is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
-        }
-        // prioritize yaml replacements over dictionary replacements
         private string ReplacePhoneme(string phoneme, int tone) {
             // If the original phoneme has an OTO, use it directly.
             if (HasOto(phoneme, tone) || HasOto(ValidateAlias(phoneme), tone)) {
@@ -586,80 +274,11 @@ namespace OpenUtau.Plugin.Builtin {
             return phoneme;
         }
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            // Replacement for note boundaries
-            List<string> currentPhonemes = new List<string>();
-            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
-            bool hasV = !string.IsNullOrEmpty(syllable.v);
-
-            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
-            currentPhonemes.AddRange(syllable.cc);
-            if (hasV) currentPhonemes.Add(syllable.v);
-
-            List<string> finalPhonemes = new List<string>();
-            int idx = 0;
-            while (idx < currentPhonemes.Count) {
-                bool replaced = false;
-                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
-                        bool match = true;
-                        for (int j = 0; j < fromArray.Length; j++) {
-                            if (currentPhonemes[idx + j] != fromArray[j]) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (match) {
-                            if (rule.to is string toString) {
-                                finalPhonemes.Add(toString);
-                            } else if (rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                            }
-                            idx += fromArray.Length;
-                            replaced = true;
-                            break;
-                        }
-                    }
-                }
-                
-                if (!replaced && splittingReplacements.Any()) {
-                    string currentPhoneme = currentPhonemes[idx];
-                    bool singleReplaced = false;
-                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                            finalPhonemes.AddRange(toArray);
-                            singleReplaced = true;
-                            break;
-                        }
-                    }
-                    if (!singleReplaced) {
-                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    }
-                    idx++;
-                } else if (!replaced) {
-                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    idx++;
-                }
-            }
-
-            string newPrevV = "";
-            string newV = "";
-            List<string> newCc = new List<string>();
-
-            if (finalPhonemes.Count > 0) {
-                if (hasPrevV) {
-                    newPrevV = finalPhonemes[0];
-                    finalPhonemes.RemoveAt(0);
-                }
-                if (hasV && finalPhonemes.Count > 0) {
-                    newV = finalPhonemes.Last();
-                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
-                }
-                newCc.AddRange(finalPhonemes);
-            }
-            
-            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
-            string[] cc = newCc.ToArray();
-            string v = newV;
+            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
+            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
+            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
+            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
             List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
@@ -692,6 +311,14 @@ namespace OpenUtau.Plugin.Builtin {
                     break;
                 }
             }
+
+            foreach (var entry in yamlFallbacks) {
+                if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Value, syllable.tone)) {
+                    isYamlFallbacks = true;
+                    break;
+                }
+            }
+
 
             // STARTING V
             if (syllable.IsStartingV) {
@@ -1173,6 +800,12 @@ namespace OpenUtau.Plugin.Builtin {
                     alias = alias.Replace(fb.Key, fb.Value);
                 }
             }
+            if (isYamlFallbacks) {
+                foreach (var fb in yamlFallbacks.OrderByDescending(f => f.Key.Length)) {
+                    alias = alias.Replace(fb.Key, fb.Value);
+                }
+            }
+
             return alias;
 
         }

--- a/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
@@ -102,13 +102,8 @@ namespace OpenUtau.Plugin.Builtin {
 
         private readonly string[] ccvException = { "ch", "dh", "dx", "fh", "gh", "hh", "jh", "kh", "ph", "ng", "sh", "th", "vh", "wh", "zh" };
         private readonly string[] RomajiException = { "a", "e", "i", "o", "u" };
-        private bool isTails = false;
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
-            if (tails.Contains(note.lyric)) {
-                isTails = true;
-                return new string[] { note.lyric };
-            }
             if (original == null) {
                 return null;
             }
@@ -346,13 +341,7 @@ namespace OpenUtau.Plugin.Builtin {
                             }
                         }
                     }
-                    // EXTEND AS [V]
-                } else if (!HasOto($"{prevV} {v}", syllable.vowelTone) || !HasOto(ValidateAlias($"{prevV} {v}"), syllable.vowelTone) || missingVphonemes.ContainsKey(prevV)) {
-                    basePhoneme = AliasFormat(v, "vv", syllable.vowelTone, "");
-                } else if (HasOto($"{prevV} {v}", syllable.vowelTone) || HasOto(ValidateAlias($"{prevV} {v}"), syllable.vowelTone) || missingVphonemes.ContainsKey(prevV)) {
-                    basePhoneme = AliasFormat(v, "vv", syllable.vowelTone, "");
                 } else {
-                    // PREVIOUS ALIAS WILL EXTEND as [V V]
                     basePhoneme = null;
                 }
 
@@ -379,15 +368,6 @@ namespace OpenUtau.Plugin.Builtin {
             } else {
                 // [V] to [-V] to [- V]
                 basePhoneme = AliasFormat(v, "cv", syllable.vowelTone, "");
-                if (isTails && basePhoneme.Contains("-")) {
-                    if (HasOto($"{cc.Last()} -", syllable.tone) || HasOto($"{cc.Last()}-", syllable.tone)
-                    || HasOto($"{cc.Last()}_", syllable.tone)) {
-                        // like [C1 -]
-                        basePhoneme = AliasFormat($"{cc.Last()}", "cc_end", syllable.tone, "");
-                    } else {
-                        basePhoneme = null;
-                    }
-                }
                 // try [V C], [V CC], [VC C], [V -][- C]
                 for (var i = lastC + 1; i >= 0; i--) {
                     var vr = $"_{prevV}";
@@ -519,59 +499,57 @@ namespace OpenUtau.Plugin.Builtin {
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
-            if (tails.Contains(ending.prevV)) {
-                return new List<string>();
-            }
+            string t = ending.HasTail ? ReplacePhoneme(ending.tail, ending.tone) : "-";
+
             if (ending.IsEndingV) {
-                var vR = $"{v} -";
-                var vR1 = $"{v} R";
-                var vR2 = $"{v}-";
-                var endV = AliasFormat(v, "ending", ending.tone, "");
-                if (HasOto(vR, ending.tone) || HasOto(ValidateAlias(vR), ending.tone) || (HasOto(vR1, ending.tone) || HasOto(ValidateAlias(vR1), ending.tone) || (HasOto(vR2, ending.tone) || HasOto(ValidateAlias(vR2), ending.tone)))) {
-                    TryAddPhoneme(phonemes, ending.tone, AliasFormat(v, "ending", ending.tone, ""));
+                var vR = $"{v} {t}";
+                var vR2 = $"{v}{t}";
+                var endV = AliasFormat(v, "ending", ending.tone, "", t);
+                if (HasOto(vR, ending.tone) || HasOto(ValidateAlias(vR), ending.tone) || (HasOto(vR2, ending.tone) || HasOto(ValidateAlias(vR2), ending.tone))) {
+                    TryAddPhoneme(phonemes, ending.tone, AliasFormat(v, "ending", ending.tone, "", t));
                     /// split diphthong vowels
                 } else if (DiphthongExceptions.ContainsKey(prevV) && !(HasOto(vR, ending.tone) && HasOto(ValidateAlias(vR), ending.tone) && (HasOto(vR2, ending.tone) || HasOto(ValidateAlias(vR2), ending.tone)))) {
-                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "cv", ending.tone, ""));
+                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "cv", ending.tone, "", t));
                 }
             } else if (ending.IsEndingVCWithOneConsonant) {
                 var vc = $"{v} {cc[0]}";
-                var vcr = $"{v} {cc[0]}-";
-                var vcr2 = $"{v}{cc[0]} -";
+                var vcr = $"{v} {cc[0]}{t}";
+                var vcr2 = $"{v}{cc[0]} {t}";
                 var vr = $"_{v}";
-                var vr1 = $"{v}-";
+                var vr1 = $"{v}{t}";
                 if (!RomajiException.Contains(cc[0])) {
                     if (HasOto(vcr, ending.tone) || HasOto(ValidateAlias(vcr), ending.tone)) {
                         TryAddPhoneme(phonemes, ending.tone, vcr);
                     } else if (!HasOto(vcr, ending.tone) && !HasOto(ValidateAlias(vcr), ending.tone) && (HasOto(vcr2, ending.tone) || HasOto(ValidateAlias(vcr2), ending.tone))) {
                         TryAddPhoneme(phonemes, ending.tone, vcr2);
                         // double the consonants if has [C -]/[C-]
-                    } else if (DiphthongExceptions.ContainsKey(prevV) && (c_cR.Contains(cc.Last())) && ((HasOto(AliasFormat(v, "ending_mix", ending.tone, ""), ending.tone) && (HasOto($"{c_cR[0]} -", ending.tone) || (HasOto($"{c_cR[0]}-", ending.tone)))))) {
+                    } else if (DiphthongExceptions.ContainsKey(prevV) && (c_cR.Contains(cc.Last())) && ((HasOto(AliasFormat(v, "ending_mix", ending.tone, ""), ending.tone) && (HasOto($"{c_cR[0]} {t}", ending.tone) || (HasOto($"{c_cR[0]}{t}", ending.tone)))))) {
                         // ex: [ow][ow-][z][z -]
-                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "diph_mix", ending.tone, ""));
-                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, ""));
-                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
+                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "diph_mix", ending.tone, "", t));
+                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, "", t));
+                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
                     } else if (DiphthongExceptions.ContainsKey(prevV) && ((HasOto(AliasFormat(v, "ending_mix", ending.tone, ""), ending.tone)) && !HasOto(vc, ending.tone))) {
-                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "diph_mix", ending.tone, ""));
-                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
+                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "diph_mix", ending.tone, "", t));
+                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
                         /// use consonants for diphthongs if the vb doesn't have vowel endings
-                    } else if (DiphthongExceptions.ContainsKey(prevV) && (!(HasOto(AliasFormat(v, "ending_mix", ending.tone, ""), ending.tone) && !HasOto(vc, ending.tone)))) {
-                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "diph_mix", ending.tone, ""));
+                    } else if (DiphthongExceptions.ContainsKey(prevV) && (!(HasOto(AliasFormat(v, "ending_mix", ending.tone, "", t), ending.tone) && !HasOto(vc, ending.tone)))) {
+                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "diph_mix", ending.tone, "", t));
                         if (c_cR.Contains(cc.Last())) {
                             if (HasOto(AliasFormat($"{c_cR[0]}", "cc_mix", ending.tone, ""), ending.tone)) {
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, ""));
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, "", t));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
                             } else if (!(HasOto(AliasFormat($"{c_cR[0]}", "cc_mix", ending.tone, ""), ending.tone))) {
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, ""));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, "", t));
                             } else {
-                                TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", $"{cc[0]}-");
+                                TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} {t}", $"{cc[0]}{t}");
                             }
                         } else if (!c_cR.Contains(cc.Last())) {
                             if (HasOto(AliasFormat($"{c_cR[0]}", "cc_mix", ending.tone, ""), ending.tone)) {
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
                             } else if (!(HasOto(AliasFormat($"{c_cR[0]}", "cc_mix", ending.tone, ""), ending.tone))) {
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, ""));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, "", t));
                             } else {
-                                TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", $"{cc[0]}-");
+                                TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} {t}", $"{cc[0]}{t}");
                             }
                         }
                         /// add additional c to those consonants on the top
@@ -579,30 +557,30 @@ namespace OpenUtau.Plugin.Builtin {
                         if (HasOto(vc, ending.tone) || HasOto(ValidateAlias(vc), ending.tone)) {
                             TryAddPhoneme(phonemes, ending.tone, vc);
                             //TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, ""));
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
-                        } else if (HasOto($"{c_cR[0]} -", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]} -"), ending.tone) || (HasOto($"{c_cR[0]}-", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]}-"), ending.tone))) {
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, ""));
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
-                        } else if (!(HasOto($"{c_cR[0]} -", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]} -"), ending.tone) || (HasOto($"{c_cR[0]}-", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]}-"), ending.tone)))) {
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
+                        } else if (HasOto($"{c_cR[0]} {t}", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]} {t}"), ending.tone) || (HasOto($"{c_cR[0]}{t}", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]}{t}"), ending.tone))) {
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc1_mix", ending.tone, "", t));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
+                        } else if (!(HasOto($"{c_cR[0]} {t}", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]} {t}"), ending.tone) || (HasOto($"{c_cR[0]}{t}", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]}{t}"), ending.tone)))) {
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
                         } else {
-                            TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", $"{cc[0]}-");
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} {t}", $"{cc[0]}{t}");
                         }
                     } else {
                         TryAddPhoneme(phonemes, ending.tone, vc);
                         if (vc.Contains(cc[0])) {
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
                         } else {
-                            TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} -", $"{cc[0]}-");
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[0]} {t}", $"{cc[0]}{t}");
                         }
                     }
                 }
             } else {
                 for (var i = lastC; i >= 0; i--) {
                     var vr = $"_{v}";
-                    var vr1 = $"{v}-";
-                    var vcc = $"{v} {string.Join("", cc.Take(2))}-";
-                    var vcc2 = $"{v}{string.Join(" ", cc.Take(2))} -";
+                    var vr1 = $"{v}{t}";
+                    var vcc = $"{v} {string.Join("", cc.Take(2))}{t}";
+                    var vcc2 = $"{v}{string.Join(" ", cc.Take(2))} {t}";
                     var vcc3 = $"{v}{string.Join(" ", cc.Take(2))}";
                     var vcc4 = $"{v} {string.Join("", cc.Take(2))}";
                     var vc = $"{v} {cc[0]}";
@@ -624,7 +602,7 @@ namespace OpenUtau.Plugin.Builtin {
                             TryAddPhoneme(phonemes, ending.tone, vcc3);
                             if (vcc3.EndsWith(cc.Last()) && lastC == 1) {
                                 if (consonants.Contains(cc.Last())) {
-                                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
+                                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
                                 }
                             }
                             firstC = 1;
@@ -633,7 +611,7 @@ namespace OpenUtau.Plugin.Builtin {
                             TryAddPhoneme(phonemes, ending.tone, vcc4);
                             if (vcc4.EndsWith(cc.Last()) && lastC == 1) {
                                 if (consonants.Contains(cc.Last())) {
-                                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, ""));
+                                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "cc_mix", ending.tone, "", t));
                                 }
                             }
                             firstC = 1;
@@ -643,7 +621,7 @@ namespace OpenUtau.Plugin.Builtin {
                             break;
                             /// use consonants for diphthongs if the vb doesn't have vowel endings
                         } else if (DiphthongExceptions.ContainsKey(prevV) && (!(HasOto(vr, ending.tone) || HasOto(ValidateAlias(vr), ending.tone) || (HasOto(vr1, ending.tone) || HasOto(ValidateAlias(vr1), ending.tone)) && !HasOto(vc, ending.tone)))) {
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "diph_mix", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{DiphthongExceptions[prevV]}", "diph_mix", ending.tone, "", t));
                             break;
                         } else {
                             TryAddPhoneme(phonemes, ending.tone, vc);
@@ -669,21 +647,21 @@ namespace OpenUtau.Plugin.Builtin {
                         if (!HasOto(cc1, ending.tone)) {
                             cc1 = ValidateAlias(cc1);
                         }
-                        if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone))) {
+                        if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}{t}", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"), ending.tone))) {
                             // like [C1 C2][C2 ...]
                             phonemes.Add(cc1);
-                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone)))) {
+                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}{t}", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"), ending.tone)))) {
                             // like [C1 C2-][C3 ...]
                             phonemes.Add(cc[i]);
-                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}-", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"))) {
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}{t}", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"))) {
                             // like [C1 C2-][C3 ...]
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1))) {
                             i++;
                         } else {
                             // like [C1][C2 ...]
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i]}", "cc1_mix", ending.tone, ""));
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc1_mix", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i]}", "cc1_mix", ending.tone, "", t));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc1_mix", ending.tone, "", t));
                             i++;
                         }
                     } else {
@@ -693,7 +671,7 @@ namespace OpenUtau.Plugin.Builtin {
                         // CC FALLBACKS
                         if (!HasOto(cc1, ending.tone) || !HasOto(ValidateAlias(cc1), ending.tone)) {
                             // [C1] [C2]
-                            cc1 = AliasFormat($"{cc[i + 1]}", "cc_end", ending.tone, "");
+                            cc1 = AliasFormat($"{cc[i + 1]}", "cc_end", ending.tone, "", t);
                         }
                         if (!HasOto(cc1, ending.tone)) {
                             cc1 = ValidateAlias(cc1);
@@ -701,34 +679,34 @@ namespace OpenUtau.Plugin.Builtin {
                         // CC FALLBACKS
                         if (!HasOto(cc1, ending.tone) || !HasOto(ValidateAlias(cc1), ending.tone) && !HasOto($"{cc[i]} {cc[i + 1]}", ending.tone)) {
                             // [C1] [C2]
-                            cc1 = AliasFormat($"{cc[i + 1]}", "cc1_mix", ending.tone, ""); ;
+                            cc1 = AliasFormat($"{cc[i + 1]}", "cc1_mix", ending.tone, "", t); ;
                         }
                         if (!HasOto(cc1, ending.tone)) {
                             cc1 = ValidateAlias(cc1);
                         }
-                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}-", ValidateAlias($"{cc[i]} {cc[i + 1]}-"))) {
+                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}{t}", ValidateAlias($"{cc[i]} {cc[i + 1]}{t}"))) {
                             // like [C1 C2-]
                             i++;
                         } else if (c_cR.Contains(cc.Last())) {
-                            if (HasOto($"{c_cR[0]} -", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]} -"), ending.tone) || (HasOto($"{c_cR[0]}-", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]}-"), ending.tone))) {
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i]}", "cc1_mix", ending.tone, ""));
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc1_mix", ending.tone, ""));
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_mix", ending.tone, ""));
+                            if (HasOto($"{c_cR[0]} {t}", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]} {t}"), ending.tone) || (HasOto($"{c_cR[0]}{t}", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]}{t}"), ending.tone))) {
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i]}", "cc1_mix", ending.tone, "", t));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc1_mix", ending.tone, "", t));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_mix", ending.tone, "", t));
                                 i++;
-                            } else if (!(HasOto($"{c_cR[0]} -", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]} -"), ending.tone) || (HasOto($"{c_cR[0]}-", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]}-"), ending.tone)))) {
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i]}", "cc1_mix", ending.tone, ""));
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_mix", ending.tone, ""));
+                            } else if (!(HasOto($"{c_cR[0]} {t}", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]} {t}"), ending.tone) || (HasOto($"{c_cR[0]}{t}", ending.tone) || HasOto(ValidateAlias($"{c_cR[0]}{t}"), ending.tone)))) {
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i]}", "cc1_mix", ending.tone, "", t));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_mix", ending.tone, "", t));
                                 i++;
                             }
                         } else if (TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1))) {
                             // like [C1 C2][C2 -]
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_mix", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_mix", ending.tone, "", t));
                             i++;
 
                         } else if (!HasOto(cc1, ending.tone) && !HasOto($"{cc[i]} {cc[i + 1]}", ending.tone)) {
                             // [C1 -] [- C2]
                             TryAddPhoneme(phonemes, ending.tone, $"- {cc[i + 1]}", ValidateAlias($"- {cc[i + 1]}"), cc[i + 1], ValidateAlias(cc[i + 1]));
-                            phonemes.Add($"{cc[i]} -");
+                            phonemes.Add($"{cc[i]} {t}");
                             i++;
                         }
 
@@ -737,21 +715,21 @@ namespace OpenUtau.Plugin.Builtin {
             }
             return phonemes;
         }
-        private string AliasFormat(string alias, string type, int tone, string prevV) {
+        private string AliasFormat(string alias, string type, int tone, string prevV, string t = "-") {
             var aliasFormats = new Dictionary<string, string[]> {
                 // Define alias formats for different types
                 { "startingV", new string[] { "-", "- ", "_", "" } },
                 { "vv", new string[] { "-", "", "_", "- " } },
                 { "vvExtend", new string[] { "", "_", "-", "- " } },
                 { "cv", new string[] { "-", "", "- ", "_" } },
-                { "ending", new string[] { " -", "-", " R" } },
-                { "ending_mix", new string[] { "-", " -", "R", " R", "_", "--" } },
+                { "ending", new string[] { $" {t}", $"{t}" } },
+                { "ending_mix", new string[] { $"{t}", $" {t}", "_", "--" } },
                 { "cc", new string[] { "", "-", "- ", "_" } },
                 { "cc_start", new string[] { "- ", "-", "", "_" } },
-                { "cc_end", new string[] { " -", "-", "" } },
-                { "cc_mix", new string[] { " -", " R", "-", "", "_", "- ", "-" } },
+                { "cc_end", new string[] { $" {t}", $"{t}", "" } },
+                { "cc_mix", new string[] { $" {t}", $" {t}", $"{t}", "", "_", "- ", "-" } },
                 { "cc1_mix", new string[] { "", " -", "-", " R", "_", "- ", "-" } },
-                { "diph_mix", new string[] { "-", "_", "", " -", "", "_", "- ", "-" } },
+                { "diph_mix", new string[] { $"{t}", "_", "", $" {t}", "", "_", "- ", "-" } },
 
             };
 

--- a/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
@@ -23,6 +23,7 @@ namespace OpenUtau.Plugin.Builtin {
     // cadlaxa here ^_^
     public class EnglishVCCVPhonemizer : SyllableBasedPhonemizer {
         private const string LatestVersion = "1.1";
+        private const string YamlFile = "envccv.yaml";
         private string[] vowels = "a,@,u,0,8,I,e,3,A,i,E,O,Q,6,o,1ng,9,&,x,1,Y,L,W".Split(",");
         private readonly string[] consonants = "b,ch,d,dh,f,g,h,j,k,l,m,n,ng,p,r,s,sh,t,th,v,w,y,z,zh,dd,hh,sp,st".Split(",");
         private Dictionary<string, string> dictionaryReplacements = ("aa=a;ae=@;ah=u;ao=9;aw=8;ay=I;" +
@@ -132,7 +133,7 @@ namespace OpenUtau.Plugin.Builtin {
             var g2ps = new List<IG2p>();
 
             // Load dictionary from plugin folder.
-            string path = Path.Combine(PluginDir, "envccv.yaml");
+            string path = Path.Combine(PluginDir, YamlFile);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
                 File.WriteAllBytes(path, Data.Resources.envccv_template);
@@ -141,7 +142,7 @@ namespace OpenUtau.Plugin.Builtin {
 
             // Load dictionary from singer folder.
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, "envccv.yaml");
+                string file = Path.Combine(singer.Location, YamlFile);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -170,7 +171,7 @@ namespace OpenUtau.Plugin.Builtin {
                 finalPhonemes = new List<string>();
                 while (i < modified.Count) {
                     bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements)) {
+                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
                         if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
                             bool match = true;
                             for (int j = 0; j < fromArray.Length; j++) {
@@ -195,7 +196,7 @@ namespace OpenUtau.Plugin.Builtin {
                     if (!replaced && splittingReplacements.Any()) {
                         string currentPhoneme = modified[i];
                         bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements) {
+                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
                             if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
                                 finalPhonemes.AddRange(toArray);
                                 singleReplaced = true;
@@ -239,10 +240,10 @@ namespace OpenUtau.Plugin.Builtin {
             if (this.singer != singer) {
                 string file;
                 if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, "envccv.yaml");
+                    file = Path.Combine(singer.Location, YamlFile);
                 }
                 else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, "envccv.yaml");
+                    file = Path.Combine(PluginDir, YamlFile);
                 }
                 else {
                     Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'envccv.yaml'.");
@@ -294,10 +295,10 @@ namespace OpenUtau.Plugin.Builtin {
                                 $"envccv_backup.yaml"
                             );
                             File.Move(file, backupFile);
-                            Log.Warning($"Old envccv.yaml has been backed up as: {backupFile}");
+                            Log.Warning($"Old {YamlFile} has been backed up as: {backupFile}");
                         }
                         catch (Exception e) {
-                            Log.Error(e, "Failed to back up old envccv.yaml. Proceeding with new template anyway.");
+                            Log.Error(e, $"Failed to back up old {YamlFile}. Proceeding with new template anyway.");
                         }
                     }
 
@@ -308,12 +309,12 @@ namespace OpenUtau.Plugin.Builtin {
                             Log.Information($"'{file}' created or updated to latest version {LatestVersion}");
                         }
                         catch (Exception e) {
-                            Log.Error(e, $"Failed to write 'envccv.yaml' to {file}");
+                            Log.Error(e, $"Failed to write '{YamlFile}' to {file}");
                         }
                     }
                 }
                 catch (Exception ex) {
-                    Log.Error(ex, $"Unexpected error while ensuring envccv.yaml at {file}");
+                    Log.Error(ex, $"Unexpected error while ensuring {YamlFile} at {file}");
                 }
 
                 if (File.Exists(file)) {
@@ -329,7 +330,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             vowels = vowels.Concat(loadVowels).Distinct().ToArray();
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from envccv.yaml: {ex.Message}");
+                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
                         }
                         // Load replacements
                         try {
@@ -339,14 +340,15 @@ namespace OpenUtau.Plugin.Builtin {
 
                                 foreach (var replacement in data.replacements) {
                                     try {
+                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
                                         if (replacement.from != null && replacement.to != null) {
                                             if (replacement.from is IEnumerable<object> fromList) {
                                                 // 'from' is a list (e.g., [ae, n])
                                                 string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
                                                 if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString });
+                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -355,7 +357,7 @@ namespace OpenUtau.Plugin.Builtin {
                                                 if (replacement.to is string toString) {
                                                     dictionaryReplacements[fromString] = toString;
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -374,7 +376,7 @@ namespace OpenUtau.Plugin.Builtin {
                                 splittingReplacements = new List<Replacement>();
                             }
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from en-vccv.yaml: {ex.Message}");
+                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
                         }
                         // Load fallbacks
                         try {
@@ -393,7 +395,7 @@ namespace OpenUtau.Plugin.Builtin {
                         }
 
                     } catch (Exception ex) {
-                       Log.Error($"Failed to parse envccv.yaml: {ex.Message}, Exception Type: {ex.GetType()}");
+                       Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
                     }
                 }
                 ReadDictionaryAndInit();
@@ -418,6 +420,7 @@ namespace OpenUtau.Plugin.Builtin {
         public class Replacement {
             public object from { get; set; }
             public object to { get; set; }
+            public string where { get; set; } = "inside";
 
             public List<string> FromList {
                 get {
@@ -450,14 +453,86 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
-            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
-            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
-            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
-            string[] cc = syllable.cc.Select(ReplacePhoneme).ToArray();
-            string[] PreviousWordCc = syllable.PreviousWordCc.Select(ReplacePhoneme).ToArray();
-            string[] CurrentWordCc = syllable.CurrentWordCc.Select(ReplacePhoneme).ToArray();
-            int lastC = cc.Length - 1;
+            // Replacement for note boundaries
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
+            bool hasV = !string.IsNullOrEmpty(syllable.v);
+
+            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
+            currentPhonemes.AddRange(syllable.cc);
+            if (hasV) currentPhonemes.Add(syllable.v);
+
+            List<string> finalPhonemes = new List<string>();
+            int idx = 0;
+            while (idx < currentPhonemes.Count) {
+                bool replaced = false;
+                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
+                        bool match = true;
+                        for (int j = 0; j < fromArray.Length; j++) {
+                            if (currentPhonemes[idx + j] != fromArray[j]) {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match) {
+                            if (rule.to is string toString) {
+                                finalPhonemes.Add(toString);
+                            } else if (rule.to is string[] toArray) {
+                                finalPhonemes.AddRange(toArray);
+                            }
+                            idx += fromArray.Length;
+                            replaced = true;
+                            break;
+                        }
+                    }
+                }
+                
+                if (!replaced && splittingReplacements.Any()) {
+                    string currentPhoneme = currentPhonemes[idx];
+                    bool singleReplaced = false;
+                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
+                            finalPhonemes.AddRange(toArray);
+                            singleReplaced = true;
+                            break;
+                        }
+                    }
+                    if (!singleReplaced) {
+                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    }
+                    idx++;
+                } else if (!replaced) {
+                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    idx++;
+                }
+            }
+
+            string newPrevV = "";
+            string newV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                if (hasV && finalPhonemes.Count > 0) {
+                    newV = finalPhonemes.Last();
+                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
+                }
+                newCc.AddRange(finalPhonemes);
+            }
+            
+            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
+            string[] cc = newCc.ToArray();
+            string v = newV;
+            List<string> vowels = new List<string> { v };
+            var lastC = cc.Length - 1;
+            var firstC = 0;
+            string[] CurrentWordCc = syllable.CurrentWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
             int lastCPrevWord = syllable.prevWordConsonantsCount;
 
             foreach (var entry in replacements) {

--- a/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
@@ -143,7 +143,7 @@ namespace OpenUtau.Plugin.Builtin {
                     }
                 }
             }
-            g2ps.Add(new ArpabetPlusG2p());
+            g2ps.Add(new ArpabetG2p());
             return new G2pFallbacks(g2ps.ToArray());
         }
 
@@ -155,21 +155,9 @@ namespace OpenUtau.Plugin.Builtin {
             if (original == null) {
                 return null;
             }
-            var mappedOriginal = new List<string>();
-            foreach (var p in original) {
-                if (dictionaryReplacements.ContainsKey(p)) {
-                    mappedOriginal.Add(dictionaryReplacements[p]);
-                } else {
-                    mappedOriginal.Add(p);
-                }
-            }
             List<string> finalProcessedPhonemes = new List<string>();
-            
-            IEnumerable<string> phonemes;
-            phonemes = mappedOriginal;
-           
             string[] tr_dr = new[] { "tr", "dr"};
-            foreach (string s in phonemes) {
+            foreach (string s in original) {
                 switch (s) {
                     case var str when tr_dr.Contains(str) && !HasOto(str, note.tone) && !HasOto($"A {str}", note.tone):
                         finalProcessedPhonemes.AddRange(new string[] { s[0].ToString(), s[1].ToString() });

--- a/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
@@ -22,24 +22,22 @@ namespace OpenUtau.Plugin.Builtin {
     // Thanks to cubialpha, Cz, Halo/BagelHero, nago, and Anjo for their help.
     // cadlaxa here ^_^
     public class EnglishVCCVPhonemizer : SyllableBasedPhonemizer {
-        private const string LatestVersion = "1.1";
-        private const string YamlFile = "envccv.yaml";
-        private string[] vowels = "a,@,u,0,8,I,e,3,A,i,E,O,Q,6,o,1ng,9,&,x,1,Y,L,W".Split(",");
-        private readonly string[] consonants = "b,ch,d,dh,f,g,h,j,k,l,m,n,ng,p,r,s,sh,t,th,v,w,y,z,zh,dd,hh,sp,st".Split(",");
-        private Dictionary<string, string> dictionaryReplacements = ("aa=a;ae=@;ah=u;ao=9;aw=8;ay=I;" +
+        protected override string YamlFileName => "envccv.yaml";
+        protected override byte[] YamlTemplate => Data.Resources.envccv_template;
+        protected override string YamlVersion => "1.1";
+        public EnglishVCCVPhonemizer() {
+            this.vowels = "a,@,u,0,8,I,e,3,A,i,E,O,Q,6,o,1ng,9,&,x,1,Y,L,W".Split(',');
+            this.consonants = "b,ch,d,dh,f,g,h,j,k,l,m,n,ng,p,r,s,sh,t,th,v,w,y,z,zh,dd,hh,sp,st".Split(',');
+            this.dictionaryReplacements = ("ax=x;aa=a;ae=@;ah=u;ao=9;aw=8;ay=I;" +
             "b=b;ch=ch;d=d;dh=dh;eh=e;er=3;ey=A;f=f;g=g;hh=h;hhy=hh;ih=i;iy=E;jh=j;k=k;l=l;m=m;n=n;ng=ng;ow=O;oy=Q;" +
             "p=p;r=r;s=s;sh=sh;t=t;th=th;uh=6;uw=o;v=v;w=w;y=y;z=z;zh=zh;dx=dd;").Split(';')
                 .Select(entry => entry.Split('='))
                 .Where(parts => parts.Length == 2)
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
-        // for fallbacks
-        private readonly Dictionary<string, string> replacements = "ax=x".Split(';')
-                .Select(entry => entry.Split('='))
-                .Where(parts => parts.Length == 2)
-                .Where(parts => parts[0] != parts[1])
-                .ToDictionary(parts => parts[0], parts => parts[1]);
-        private bool isReplacements = false;
+        }
+        
+        private bool isYamlFallbacks = false;
 
         private readonly Dictionary<string, string> vcExceptions =
             new Dictionary<string, string>() {
@@ -119,30 +117,24 @@ namespace OpenUtau.Plugin.Builtin {
         private readonly string[] stopCs = { "b", "d", "g", "k", "p", "t" };
         private readonly string[] ucvCs = { "r", "l", "w", "y", "f"};
         private readonly string[] starlightccs = { "rl", "ll", "nn", "mm" };
-        private string[] tails = "-".Split(',');
 
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "";
-        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
-        private List<Replacement> splittingReplacements = new List<Replacement>();
-        // Store the merging replacements
-        private List<Replacement> mergingReplacements = new List<Replacement>();
-
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
 
             // Load dictionary from plugin folder.
-            string path = Path.Combine(PluginDir, YamlFile);
+            string path = Path.Combine(PluginDir, YamlFileName);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
-                File.WriteAllBytes(path, Data.Resources.envccv_template);
+                File.WriteAllBytes(path, YamlTemplate);
             }
             g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(path)).Build());
 
             // Load dictionary from singer folder.
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, YamlFile);
+                string file = Path.Combine(singer.Location, YamlFileName);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -151,7 +143,7 @@ namespace OpenUtau.Plugin.Builtin {
                     }
                 }
             }
-            g2ps.Add(new ArpabetG2p());
+            g2ps.Add(new ArpabetPlusG2p());
             return new G2pFallbacks(g2ps.ToArray());
         }
 
@@ -163,69 +155,23 @@ namespace OpenUtau.Plugin.Builtin {
             if (original == null) {
                 return null;
             }
-            List<string> modified = new List<string>(original);
-            List<string> finalPhonemes = new List<string>();
-            int i = 0;
-            bool hasReplacements = mergingReplacements.Any() == true || splittingReplacements.Any() == true; // Check for any replacements
-            if (hasReplacements) {
-                finalPhonemes = new List<string>();
-                while (i < modified.Count) {
-                    bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
-                        if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
-                            bool match = true;
-                            for (int j = 0; j < fromArray.Length; j++) {
-                                if (modified[i + j] != fromArray[j]) {
-                                    match = false;
-                                    break;
-                                }
-                            }
-                            if (match) {
-                                if (rule.to is string toString) {
-                                    finalPhonemes.Add(toString);
-                                } else if (rule.to is string[] toArray) {
-                                    finalPhonemes.AddRange(toArray);
-                                }
-                                i += fromArray.Length;
-                                replaced = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!replaced && splittingReplacements.Any()) {
-                        string currentPhoneme = modified[i];
-                        bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
-                            if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                                singleReplaced = true;
-                                break;
-                            }
-                        }
-                        if (!singleReplaced) {
-                            finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        }
-                        i++;
-                    } else if (!replaced) {
-                        finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        i++;
-                    }
+            var mappedOriginal = new List<string>();
+            foreach (var p in original) {
+                if (dictionaryReplacements.ContainsKey(p)) {
+                    mappedOriginal.Add(dictionaryReplacements[p]);
+                } else {
+                    mappedOriginal.Add(p);
                 }
-            } else {
-                finalPhonemes = new List<string>(modified);
             }
             List<string> finalProcessedPhonemes = new List<string>();
+            
             IEnumerable<string> phonemes;
-            if (hasReplacements) {
-                phonemes = finalPhonemes;
-            } else {
-                phonemes = original;
-            }
+            phonemes = mappedOriginal;
+           
             string[] tr_dr = new[] { "tr", "dr"};
             foreach (string s in phonemes) {
                 switch (s) {
-                    case var str when tr_dr.Contains(str) && !HasOto($"{str}{vowels}", note.tone) && !HasOto($"A {str}", note.tone):
+                    case var str when tr_dr.Contains(str) && !HasOto(str, note.tone) && !HasOto($"A {str}", note.tone):
                         finalProcessedPhonemes.AddRange(new string[] { s[0].ToString(), s[1].ToString() });
                         break;
                     default:
@@ -234,209 +180,6 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             }
             return finalProcessedPhonemes.ToArray();
-        }
-
-        public override void SetSinger(USinger singer) {
-            if (this.singer != singer) {
-                string file;
-                if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, YamlFile);
-                }
-                else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, YamlFile);
-                }
-                else {
-                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'envccv.yaml'.");
-                    return;
-                }
-                try {
-                    bool shouldWriteTemplate = false;
-                    bool shouldBackupOldFile = false;
-
-                    if (File.Exists(file)) {
-                        try {
-                            // Build YAML deserializer
-                            var deserializer = new DeserializerBuilder()
-                                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                                .Build();
-
-                            using var reader = new StreamReader(file);
-                            var config = deserializer.Deserialize<Dictionary<string, object>>(reader);
-
-                            if (config == null || !config.ContainsKey("version")) {
-                                shouldWriteTemplate = true;
-                                shouldBackupOldFile = true; // No version → backup old
-                            }
-                            else {
-                                string currentVersion = config["version"]?.ToString()?.Trim() ?? "";
-
-                                // If version is missing OR outdated → backup old + write new
-                                if (string.IsNullOrWhiteSpace(currentVersion) || currentVersion != LatestVersion) {
-                                    shouldWriteTemplate = true;
-                                    shouldBackupOldFile = true;
-                                }
-                            }
-                        }
-                        catch (Exception ex) {
-                            Log.Error(ex, $"Failed to read '{file}', backing up old file and writing a fresh one...");
-                            shouldWriteTemplate = true;
-                            shouldBackupOldFile = true;
-                        }
-                    }
-                    else {
-                        shouldWriteTemplate = true;
-                    }
-
-                    // If needed, back up the old file
-                    if (shouldBackupOldFile && File.Exists(file)) {
-                        try {
-                            string backupFile = Path.Combine(
-                                Path.GetDirectoryName(file)!,
-                                $"envccv_backup.yaml"
-                            );
-                            File.Move(file, backupFile);
-                            Log.Warning($"Old {YamlFile} has been backed up as: {backupFile}");
-                        }
-                        catch (Exception e) {
-                            Log.Error(e, $"Failed to back up old {YamlFile}. Proceeding with new template anyway.");
-                        }
-                    }
-
-                    // Write a fresh template if necessary
-                    if (shouldWriteTemplate) {
-                        try {
-                            File.WriteAllBytes(file, Data.Resources.envccv_template);
-                            Log.Information($"'{file}' created or updated to latest version {LatestVersion}");
-                        }
-                        catch (Exception e) {
-                            Log.Error(e, $"Failed to write '{YamlFile}' to {file}");
-                        }
-                    }
-                }
-                catch (Exception ex) {
-                    Log.Error(ex, $"Unexpected error while ensuring {YamlFile} at {file}");
-                }
-
-                if (File.Exists(file)) {
-                    try {
-                        var data = Core.Yaml.DefaultDeserializer.Deserialize<CZSampaYAMLData>(File.ReadAllText(file));
-
-                        // Load vowels
-                        try {
-                            var loadVowels = data.symbols
-                                ?.Where(s => s.type == "vowel")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            vowels = vowels.Concat(loadVowels).Distinct().ToArray();
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
-                        }
-                        // Load replacements
-                        try {
-                            if (data?.replacements != null && data.replacements.Any() == true) {
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-
-                                foreach (var replacement in data.replacements) {
-                                    try {
-                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
-                                        if (replacement.from != null && replacement.to != null) {
-                                            if (replacement.from is IEnumerable<object> fromList) {
-                                                // 'from' is a list (e.g., [ae, n])
-                                                string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
-                                                if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else if (replacement.from is string fromString) {
-                                                // 'from' is a single string (e.g., tr, aw, ae, m, ng)
-                                                if (replacement.to is string toString) {
-                                                    dictionaryReplacements[fromString] = toString;
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else {
-                                                Log.Error($"Error: Invalid 'from' type in replacement: {replacement}");
-                                            }
-                                        } else {
-                                            Log.Error($"Error: 'from' or 'to' is null in replacement: {replacement}");
-                                        }
-                                    } catch (Exception ex) {
-                                        Log.Error($"Failed to process replacement entry: {replacement}. Error: {ex.Message}");
-                                    }
-                                }
-                            } else {
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
-                        }
-                        // Load fallbacks
-                        try {
-                            if (data?.fallbacks?.Any() == true) {
-                                foreach (var df in data.fallbacks) {
-                                    if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
-                                        // Overwrite or add
-                                        replacements[df.from] = df.to;
-                                    } else {
-                                        Log.Warning("Ignored YAML fallback with missing 'from' or 'to' value.");
-                                    }
-                                }
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load fallbacks from YAML: {ex.Message}");
-                        }
-
-                    } catch (Exception ex) {
-                       Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
-                    }
-                }
-                ReadDictionaryAndInit();
-                this.singer = singer;
-            }
-        }
-        public class CZSampaYAMLData {
-            public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
-            public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
-            public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
-
-            public struct SymbolData {
-                public string symbol { get; set; }
-                public string type { get; set; }
-            }
-            public struct Fallbacks {
-                public string from { get; set; }
-                public string to { get; set; }
-            }
-        }
-        // can split or merge
-        public class Replacement {
-            public object from { get; set; }
-            public object to { get; set; }
-            public string where { get; set; } = "inside";
-
-            public List<string> FromList {
-                get {
-                    if (from is string s) return new List<string> { s };
-                    if (from is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
-
-            public List<string> ToList {
-                get {
-                    if (to is string s) return new List<string> { s };
-                    if (to is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
         }
 
         // prioritize yaml replacements over dictionary replacements
@@ -453,80 +196,11 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            // Replacement for note boundaries
-            List<string> currentPhonemes = new List<string>();
-            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
-            bool hasV = !string.IsNullOrEmpty(syllable.v);
-
-            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
-            currentPhonemes.AddRange(syllable.cc);
-            if (hasV) currentPhonemes.Add(syllable.v);
-
-            List<string> finalPhonemes = new List<string>();
-            int idx = 0;
-            while (idx < currentPhonemes.Count) {
-                bool replaced = false;
-                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
-                        bool match = true;
-                        for (int j = 0; j < fromArray.Length; j++) {
-                            if (currentPhonemes[idx + j] != fromArray[j]) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (match) {
-                            if (rule.to is string toString) {
-                                finalPhonemes.Add(toString);
-                            } else if (rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                            }
-                            idx += fromArray.Length;
-                            replaced = true;
-                            break;
-                        }
-                    }
-                }
-                
-                if (!replaced && splittingReplacements.Any()) {
-                    string currentPhoneme = currentPhonemes[idx];
-                    bool singleReplaced = false;
-                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                            finalPhonemes.AddRange(toArray);
-                            singleReplaced = true;
-                            break;
-                        }
-                    }
-                    if (!singleReplaced) {
-                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    }
-                    idx++;
-                } else if (!replaced) {
-                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    idx++;
-                }
-            }
-
-            string newPrevV = "";
-            string newV = "";
-            List<string> newCc = new List<string>();
-
-            if (finalPhonemes.Count > 0) {
-                if (hasPrevV) {
-                    newPrevV = finalPhonemes[0];
-                    finalPhonemes.RemoveAt(0);
-                }
-                if (hasV && finalPhonemes.Count > 0) {
-                    newV = finalPhonemes.Last();
-                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
-                }
-                newCc.AddRange(finalPhonemes);
-            }
-            
-            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
-            string[] cc = newCc.ToArray();
-            string v = newV;
+            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
+            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
+            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
+            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
             List<string> vowels = new List<string> { v };
             var lastC = cc.Length - 1;
             var firstC = 0;
@@ -535,13 +209,12 @@ namespace OpenUtau.Plugin.Builtin {
             int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
             int lastCPrevWord = syllable.prevWordConsonantsCount;
 
-            foreach (var entry in replacements) {
+            foreach (var entry in yamlFallbacks) {
                 if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Key, syllable.tone)) {
-                    isReplacements = true;
+                    isYamlFallbacks = true;
                     break;
                 }
             }
-
             string basePhoneme = null;
             var phonemes = new List<string>();
             // --------------------------- STARTING V ------------------------------- //
@@ -950,11 +623,15 @@ namespace OpenUtau.Plugin.Builtin {
 
                 }
             }
-
-                if (!HasOto(basePhoneme, syllable.vowelTone)) { basePhoneme = $"{cc.Last()}{v}"; }
-                phonemes.Add(basePhoneme);
-                return phonemes;
+                if (basePhoneme != null && !HasOto(basePhoneme, syllable.vowelTone)) { 
+                basePhoneme = cc.Length > 0 ? $"{cc.Last()}{v}" : v; 
             }
+            
+            if (basePhoneme != null) {
+                phonemes.Add(basePhoneme);
+            }
+            return phonemes;
+        }
 
         protected override List<string> ProcessEnding(Ending ending) {
             string[] cc = ending.cc.Select(c => ReplacePhoneme(c, ending.tone)).ToArray();
@@ -1088,8 +765,8 @@ namespace OpenUtau.Plugin.Builtin {
             //foreach (var consonant in new[] { "h" }) {
             //    alias = alias.Replace(consonant, "hh");
             //}
-            if (isReplacements) {
-                foreach (var syllable in replacements.OrderByDescending(f => f.Key.Length)) {
+            if (isYamlFallbacks) {
+                foreach (var syllable in yamlFallbacks.OrderByDescending(f => f.Key.Length)) {
                     alias = alias.Replace(syllable.Key, syllable.Value);
                 }
             }

--- a/OpenUtau.Plugin.Builtin/FilipinoPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/FilipinoPhonemizer.cs
@@ -15,6 +15,7 @@ using System.Text.RegularExpressions;
 namespace OpenUtau.Plugin.Builtin {
     [Phonemizer("Filipino Phonemizer", "FIL VCV & CVVC", "Cadlaxa", language: "FIL")]
     public class FilipinoPhonemizer : SyllableBasedPhonemizer {
+        private const string YamlFile = "filipino.yaml";
         private string[] vowels = {
         "a", "e", "i", "o", "u", "ay", "ey", "oy", "uy", "aw", "ew", "ow", "iw"
         };
@@ -57,7 +58,6 @@ namespace OpenUtau.Plugin.Builtin {
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
         private bool isMissingCPhonemes = false;
-        private bool vc_FallBack = false;
         private bool cPV_FallBack = false;
 
         private readonly Dictionary<string, string> vvDiphthongExceptions =
@@ -156,7 +156,7 @@ namespace OpenUtau.Plugin.Builtin {
                 finalPhonemes = new List<string>();
                 while (i < modified.Count) {
                     bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements)) {
+                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
                         if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
                             bool match = true;
                             for (int j = 0; j < fromArray.Length; j++) {
@@ -181,7 +181,7 @@ namespace OpenUtau.Plugin.Builtin {
                     if (!replaced && splittingReplacements.Any()) {
                         string currentPhoneme = modified[i];
                         bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements) {
+                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
                             if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
                                 finalPhonemes.AddRange(toArray);
                                 singleReplaced = true;
@@ -220,14 +220,14 @@ namespace OpenUtau.Plugin.Builtin {
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
             // LOAD DICTIONARY FROM FOLDER
-            string path = Path.Combine(PluginDir, "filipino.yaml");
+            string path = Path.Combine(PluginDir, YamlFile);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
                 File.WriteAllBytes(path, Data.Resources.filipino_template);
             }
             // LOAD DICTIONARY FROM SINGER FOLDER
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, "filipino.yaml");
+                string file = Path.Combine(singer.Location, YamlFile);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -244,18 +244,18 @@ namespace OpenUtau.Plugin.Builtin {
             if (this.singer != singer) {
                 string file;
                 if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, "filipino.yaml");
+                    file = Path.Combine(singer.Location, YamlFile);
                     if (!File.Exists(file)) {
                         try {
                             File.WriteAllBytes(file, Data.Resources.filipino_template);
                         } catch (Exception e) {
-                            Log.Error(e, $"Failed to write 'filipino.yaml' to singer folder at {file}");
+                            Log.Error(e, $"Failed to write '{YamlFile}' to singer folder at {file}");
                         }
                     }
                 } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, "filipino.yaml");
+                    file = Path.Combine(PluginDir, YamlFile);
                 } else {
-                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'filipino.yaml'.");
+                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate '{YamlFile}'.");
                     return; // Exit early to avoid null file issues
                 }
 
@@ -271,7 +271,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             vowels = vowels.Concat(loadVowels).Distinct().ToArray();
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from filipino.yaml: {ex.Message}");
+                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
                         }
                         // Load tails
                         try {
@@ -282,7 +282,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             tails = tails.Concat(loadTails).Distinct().ToArray();
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load tails from arpasing.yaml: {ex.Message}");
+                            Log.Error($"Failed to load tails from {YamlFile}: {ex.Message}");
                         }
                         // Load stop and tap consonants
                         try {
@@ -293,7 +293,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             consExceptions.AddRange(loadConsonants);
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load stop and tap consonants from filipino.yaml: {ex.Message}");
+                            Log.Error($"Failed to load stop and tap consonants from {YamlFile}: {ex.Message}");
                         }
                         // Load the various consonant types 
                         var fricatives = data.symbols
@@ -369,14 +369,15 @@ namespace OpenUtau.Plugin.Builtin {
 
                                 foreach (var replacement in data.replacements) {
                                     try {
+                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
                                         if (replacement.from != null && replacement.to != null) {
                                             if (replacement.from is IEnumerable<object> fromList) {
                                                 // 'from' is a list (e.g., [ae, n])
                                                 string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
                                                 if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString });
+                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -385,7 +386,7 @@ namespace OpenUtau.Plugin.Builtin {
                                                 if (replacement.to is string toString) {
                                                     dictionaryReplacements[fromString] = toString;
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -405,7 +406,7 @@ namespace OpenUtau.Plugin.Builtin {
                                 splittingReplacements = new List<Replacement>();
                             }
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from filipino.yaml: {ex.Message}");
+                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
                         }
                         // load fallbacks
                         try {
@@ -417,10 +418,10 @@ namespace OpenUtau.Plugin.Builtin {
                                 }
                             }
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load fallbacks from filipino.yaml: {ex.Message}");
+                            Log.Error($"Failed to load fallbacks from {YamlFile}: {ex.Message}");
                         }
                     } catch (Exception ex) {
-                       Log.Error($"Failed to parse filipino.yaml: {ex.Message}, content: {File.ReadAllText(file)}, Exception Type: {ex.GetType()}");
+                       Log.Error($"Failed to parse {YamlFile}: {ex.Message}, content: {File.ReadAllText(file)}, Exception Type: {ex.GetType()}");
                     }
                 }
                 ReadDictionaryAndInit();
@@ -450,6 +451,7 @@ namespace OpenUtau.Plugin.Builtin {
         public class Replacement {
             public object from { get; set; }
             public object to { get; set; }
+            public string where { get; set; } = "inside";
 
             public List<string> FromList {
                 get {
@@ -481,17 +483,87 @@ namespace OpenUtau.Plugin.Builtin {
             return phoneme;
         }
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
-            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
-            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
-            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
-            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
+            // Replacement for note boundaries
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
+            bool hasV = !string.IsNullOrEmpty(syllable.v);
+
+            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
+            currentPhonemes.AddRange(syllable.cc);
+            if (hasV) currentPhonemes.Add(syllable.v);
+
+            List<string> finalPhonemes = new List<string>();
+            int idx = 0;
+            while (idx < currentPhonemes.Count) {
+                bool replaced = false;
+                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
+                        bool match = true;
+                        for (int j = 0; j < fromArray.Length; j++) {
+                            if (currentPhonemes[idx + j] != fromArray[j]) {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match) {
+                            if (rule.to is string toString) {
+                                finalPhonemes.Add(toString);
+                            } else if (rule.to is string[] toArray) {
+                                finalPhonemes.AddRange(toArray);
+                            }
+                            idx += fromArray.Length;
+                            replaced = true;
+                            break;
+                        }
+                    }
+                }
+                
+                if (!replaced && splittingReplacements.Any()) {
+                    string currentPhoneme = currentPhonemes[idx];
+                    bool singleReplaced = false;
+                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
+                            finalPhonemes.AddRange(toArray);
+                            singleReplaced = true;
+                            break;
+                        }
+                    }
+                    if (!singleReplaced) {
+                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    }
+                    idx++;
+                } else if (!replaced) {
+                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    idx++;
+                }
+            }
+
+            string newPrevV = "";
+            string newV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                if (hasV && finalPhonemes.Count > 0) {
+                    newV = finalPhonemes.Last();
+                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
+                }
+                newCc.AddRange(finalPhonemes);
+            }
+            
+            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
+            string[] cc = newCc.ToArray();
+            string v = newV;
+            List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
-            string[] CurrentWordCc = syllable.CurrentWordCc.Select(ReplacePhoneme).ToArray();
-            string[] PreviousWordCc = syllable.PreviousWordCc.Select(ReplacePhoneme).ToArray();
+            string[] CurrentWordCc = syllable.CurrentWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
             int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
 
             // Check for missing vowel phonemes

--- a/OpenUtau.Plugin.Builtin/FilipinoPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/FilipinoPhonemizer.cs
@@ -11,34 +11,24 @@ using OpenUtau.Core.Ustx;
 using Serilog;
 using YamlDotNet.Core.Tokens;
 using System.Text.RegularExpressions;
+using OpenUtau.Core;
 
 namespace OpenUtau.Plugin.Builtin {
     [Phonemizer("Filipino Phonemizer", "FIL VCV & CVVC", "Cadlaxa", language: "FIL")]
     public class FilipinoPhonemizer : SyllableBasedPhonemizer {
-        private const string YamlFile = "filipino.yaml";
-        private string[] vowels = {
-        "a", "e", "i", "o", "u", "ay", "ey", "oy", "uy", "aw", "ew", "ow", "iw"
-        };
-        private string[] consonants = "".Split(',');
-        private static string[] affricate = "".Split(',');
-        private static string[] fricative = "".Split(',');
-        private static string[] aspirate = "".Split(',');
-        private static string[] semivowel = "".Split(',');
-        private static string[] liquid = "".Split(',');
-        private static string[] nasal = "".Split(',');
-        private static string[] stop = "".Split(',');
-        private static string[] tap = "".Split(',');
-        private Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
+        protected override string YamlFileName => "filipino.yaml";
+        protected override byte[] YamlTemplate => Data.Resources.filipino_template;
+        public FilipinoPhonemizer() {
+            this.vowels = new string[] {
+                "a", "e", "i", "o", "u", "ay", "ey", "oy", "uy", "aw", "ew", "ow", "iw"
+            };
+            this.consonants = Array.Empty<string>();
+        }
+    
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "";
-        private Dictionary<string, string> dictionaryReplacements;
-        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
-        // Store the splitting replacements
-        private List<Replacement> splittingReplacements = new List<Replacement>();
-        // Store the merging replacements
-        private List<Replacement> mergingReplacements = new List<Replacement>();
-
+    
         List<string> consExceptions = new List<string>();
 
         string[] diphthongs = new[] { "ay", "ey", "oy", "uy", "aw", "ew", "ow", "iw"  };
@@ -50,6 +40,8 @@ namespace OpenUtau.Plugin.Builtin {
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
         private bool isMissingVPhonemes = false;
+        private bool isYamlFallbacks = false;
+
 
         // For banks with missing custom consonants
         private readonly Dictionary<string, string> missingCphonemes = "N=n".Split(',')
@@ -87,16 +79,19 @@ namespace OpenUtau.Plugin.Builtin {
         private readonly string[] ccvException = { "ch", "dh", "dx", "fh", "gh", "hh", "jh", "kh", "ph", "ng", "sh", "th", "vh", "wh", "zh" };
         private readonly string[] RomajiException = { "a", "e", "i", "o", "u" };
         private static readonly string[] FinalConsonants = { "w", "y", "r", "l", "m", "n", "ng" };
-        private string[] tails = "-,R".Split(',');
         bool isTails = false;
 
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
+            if (!string.IsNullOrEmpty(note.phoneticHint)) {
+                return note.phoneticHint.Split(new[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+            }
+
             if (tails.Contains(note.lyric)) {
                 isTails = true;
                 return new string[] { note.lyric };
             }
-            if (original == null) {
+            if (original == null || original.Length == 0) {
                 string lyric = note.lyric.ToLowerInvariant();
                 List<string> fallbackSplit = new List<string>();
                 string[] vowels = GetVowels();
@@ -144,69 +139,17 @@ namespace OpenUtau.Plugin.Builtin {
                 }
                 if (hasTrailingApostrophe) {
                     fallbackSplit.Add("q");
+                    
                 }
                 original = fallbackSplit.ToArray();
             }
-
+            
             List<string> modified = new List<string>(original);
             List<string> finalPhonemes = new List<string>();
-            int i = 0;
-            bool hasReplacements = mergingReplacements.Any() == true || splittingReplacements.Any() == true; // Check for any replacements
-            if (hasReplacements) {
-                finalPhonemes = new List<string>();
-                while (i < modified.Count) {
-                    bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
-                        if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
-                            bool match = true;
-                            for (int j = 0; j < fromArray.Length; j++) {
-                                if (modified[i + j] != fromArray[j]) {
-                                    match = false;
-                                    break;
-                                }
-                            }
-                            if (match) {
-                                if (rule.to is string toString) {
-                                    finalPhonemes.Add(toString);
-                                } else if (rule.to is string[] toArray) {
-                                    finalPhonemes.AddRange(toArray);
-                                }
-                                i += fromArray.Length;
-                                replaced = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!replaced && splittingReplacements.Any()) {
-                        string currentPhoneme = modified[i];
-                        bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
-                            if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                                singleReplaced = true;
-                                break;
-                            }
-                        }
-                        if (!singleReplaced) {
-                            finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        }
-                        i++;
-                    } else if (!replaced) {
-                        finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        i++;
-                    }
-                }
-            } else {
-                finalPhonemes = new List<string>(modified);
-            }
+            finalPhonemes = new List<string>(modified);
             List<string> finalProcessedPhonemes = new List<string>();
             IEnumerable<string> phonemes;
-            if (hasReplacements) {
-                phonemes = finalPhonemes;
-            } else {
-                phonemes = original;
-            }
+            phonemes = finalPhonemes;
             foreach (string s in phonemes) {
                 switch (s) {
                     default:
@@ -220,14 +163,14 @@ namespace OpenUtau.Plugin.Builtin {
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
             // LOAD DICTIONARY FROM FOLDER
-            string path = Path.Combine(PluginDir, YamlFile);
+            string path = Path.Combine(PluginDir, YamlFileName);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
-                File.WriteAllBytes(path, Data.Resources.filipino_template);
+                File.WriteAllBytes(path, YamlTemplate);
             }
             // LOAD DICTIONARY FROM SINGER FOLDER
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, YamlFile);
+                string file = Path.Combine(singer.Location, YamlFileName);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -241,232 +184,15 @@ namespace OpenUtau.Plugin.Builtin {
             return new G2pFallbacks(g2ps.ToArray());
         }
         public override void SetSinger(USinger singer) {
-            if (this.singer != singer) {
-                string file;
-                if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, YamlFile);
-                    if (!File.Exists(file)) {
-                        try {
-                            File.WriteAllBytes(file, Data.Resources.filipino_template);
-                        } catch (Exception e) {
-                            Log.Error(e, $"Failed to write '{YamlFile}' to singer folder at {file}");
-                        }
-                    }
-                } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, YamlFile);
-                } else {
-                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate '{YamlFile}'.");
-                    return; // Exit early to avoid null file issues
-                }
+            base.SetSinger(singer);
 
-                if (File.Exists(file)) {
-                    try {
-                        var data = Core.Yaml.DefaultDeserializer.Deserialize<FilipinoYAMLData>(File.ReadAllText(file));
-                        // Load vowels
-                        try {
-                            var loadVowels = data.symbols
-                                ?.Where(s => s.type == "vowel")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            vowels = vowels.Concat(loadVowels).Distinct().ToArray();
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
-                        }
-                        // Load tails
-                        try {
-                            var loadTails = data.symbols
-                                ?.Where(s => s.type == "tail")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            tails = tails.Concat(loadTails).Distinct().ToArray();
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load tails from {YamlFile}: {ex.Message}");
-                        }
-                        // Load stop and tap consonants
-                        try {
-                            var loadConsonants = data.symbols
-                                ?.Where(s => s.type == "stop" || s.type == "tap")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            consExceptions.AddRange(loadConsonants);
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load stop and tap consonants from {YamlFile}: {ex.Message}");
-                        }
-                        // Load the various consonant types 
-                        var fricatives = data.symbols
-                            ?.Where(s => s.type == "fricative")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var aspirates = data.symbols
-                            ?.Where(s => s.type == "aspirate")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var semivowels = data.symbols
-                            ?.Where(s => s.type == "semivowel")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var liquids = data.symbols
-                            ?.Where(s => s.type == "liquid")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var nasals = data.symbols
-                            ?.Where(s => s.type == "nasal")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var stops = data.symbols
-                            ?.Where(s => s.type == "stop")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var taps = data.symbols
-                            ?.Where(s => s.type == "tap")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        var affricates = data.symbols
-                            ?.Where(s => s.type == "affricate")
-                            .Select(s => s.symbol)
-                            .ToList() ?? new List<string>();
-
-                        PhonemeOverrides = data.timings
-                            ?.ToDictionary(t => t.symbol, t => t.value)
-                            ?? new Dictionary<string, double>();
-
-                       
-                        // Load consonant types into their respective lists
-                        fricative = fricatives.Distinct().ToArray();
-                        aspirate = aspirates.Distinct().ToArray();
-                        semivowel = semivowels.Distinct().ToArray();
-                        liquid = liquids.Distinct().ToArray();
-                        nasal = nasals.Distinct().ToArray();
-                        stop = stops.Distinct().ToArray();
-                        tap = taps.Distinct().ToArray();
-                        affricate = affricates.Distinct().ToArray();
-                        consonants = fricatives
-                            .Concat(aspirates)
-                            .Concat(semivowels)
-                            .Concat(liquids)
-                            .Concat(nasals)
-                            .Concat(stop)
-                            .Concat(tap)
-                            .Concat(affricate)
-                            .Distinct()
-                            .ToArray();
-                        // Load replacements
-                        try {
-                            if (data?.replacements != null && data.replacements.Any() == true) {
-                                dictionaryReplacements = new Dictionary<string, string>();
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-
-                                foreach (var replacement in data.replacements) {
-                                    try {
-                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
-                                        if (replacement.from != null && replacement.to != null) {
-                                            if (replacement.from is IEnumerable<object> fromList) {
-                                                // 'from' is a list (e.g., [ae, n])
-                                                string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
-                                                if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else if (replacement.from is string fromString) {
-                                                // 'from' is a single string (e.g., tr, aw, ae, m, ng)
-                                                if (replacement.to is string toString) {
-                                                    dictionaryReplacements[fromString] = toString;
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else {
-                                                Log.Error($"Error: Invalid 'from' type in replacement: {replacement}");
-                                            }
-                                        } else {
-                                            Log.Error($"Error: 'from' or 'to' is null in replacement: {replacement}");
-                                        }
-                                    } catch (Exception ex) {
-                                        Log.Error($"Failed to process replacement entry: {replacement}. Error: {ex.Message}");
-                                    }
-                                }
-                            } else {
-                                dictionaryReplacements = new Dictionary<string, string>();
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
-                        }
-                        // load fallbacks
-                        try {
-                            if (data?.fallbacks?.Any() == true) {
-                                foreach (var df in data.fallbacks) {
-                                    if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
-                                        missingVphonemes[df.from] = df.to;
-                                    }
-                                }
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load fallbacks from {YamlFile}: {ex.Message}");
-                        }
-                    } catch (Exception ex) {
-                       Log.Error($"Failed to parse {YamlFile}: {ex.Message}, content: {File.ReadAllText(file)}, Exception Type: {ex.GetType()}");
-                    }
-                }
-                ReadDictionaryAndInit();
-                this.singer = singer;
-            }
-        }
-        public class FilipinoYAMLData {
-            public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
-            public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
-            public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
-            public Timings[] timings { get; set; } = Array.Empty<Timings>();
-
-            public struct SymbolData {
-                public string symbol { get; set; }
-                public string type { get; set; }
-            }
-            public struct Fallbacks {
-                public string from { get; set; }
-                public string to { get; set; }
-            }
-            public struct Timings {
-                public string symbol { get; set; }
-                public double value { get; set; }
-            }
-        }
-        // can split or merge
-        public class Replacement {
-            public object from { get; set; }
-            public object to { get; set; }
-            public string where { get; set; } = "inside";
-
-            public List<string> FromList {
-                get {
-                    if (from is string s) return new List<string> { s };
-                    if (from is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
-
-            public List<string> ToList {
-                get {
-                    if (to is string s) return new List<string> { s };
-                    if (to is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
+            if (this.singer != null && this.singer.Loaded) {
+                
+                consExceptions.Clear();
+                if (stop != null) consExceptions.AddRange(stop);
+                if (tap != null) consExceptions.AddRange(tap);
+                
+                consExceptions = consExceptions.Distinct().ToList();
             }
         }
 
@@ -483,80 +209,11 @@ namespace OpenUtau.Plugin.Builtin {
             return phoneme;
         }
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            // Replacement for note boundaries
-            List<string> currentPhonemes = new List<string>();
-            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
-            bool hasV = !string.IsNullOrEmpty(syllable.v);
-
-            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
-            currentPhonemes.AddRange(syllable.cc);
-            if (hasV) currentPhonemes.Add(syllable.v);
-
-            List<string> finalPhonemes = new List<string>();
-            int idx = 0;
-            while (idx < currentPhonemes.Count) {
-                bool replaced = false;
-                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
-                        bool match = true;
-                        for (int j = 0; j < fromArray.Length; j++) {
-                            if (currentPhonemes[idx + j] != fromArray[j]) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (match) {
-                            if (rule.to is string toString) {
-                                finalPhonemes.Add(toString);
-                            } else if (rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                            }
-                            idx += fromArray.Length;
-                            replaced = true;
-                            break;
-                        }
-                    }
-                }
-                
-                if (!replaced && splittingReplacements.Any()) {
-                    string currentPhoneme = currentPhonemes[idx];
-                    bool singleReplaced = false;
-                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                            finalPhonemes.AddRange(toArray);
-                            singleReplaced = true;
-                            break;
-                        }
-                    }
-                    if (!singleReplaced) {
-                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    }
-                    idx++;
-                } else if (!replaced) {
-                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    idx++;
-                }
-            }
-
-            string newPrevV = "";
-            string newV = "";
-            List<string> newCc = new List<string>();
-
-            if (finalPhonemes.Count > 0) {
-                if (hasPrevV) {
-                    newPrevV = finalPhonemes[0];
-                    finalPhonemes.RemoveAt(0);
-                }
-                if (hasV && finalPhonemes.Count > 0) {
-                    newV = finalPhonemes.Last();
-                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
-                }
-                newCc.AddRange(finalPhonemes);
-            }
-            
-            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
-            string[] cc = newCc.ToArray();
-            string v = newV;
+            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
+            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
+            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
+            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
             List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
@@ -578,6 +235,13 @@ namespace OpenUtau.Plugin.Builtin {
             foreach (var entry in missingCphonemes) {
                 if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Value, syllable.tone)) {
                     isMissingCPhonemes = true;
+                    break;
+                }
+            }
+
+            foreach (var entry in yamlFallbacks) {
+                if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Value, syllable.tone)) {
+                    isYamlFallbacks = true;
                     break;
                 }
             }
@@ -997,7 +661,8 @@ namespace OpenUtau.Plugin.Builtin {
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
-            if (tails.Contains(ending.prevV)) {
+            
+            if (tails.Contains(prevV)) {
                 return new List<string>();
             }
             if (ending.IsEndingV) {
@@ -1309,7 +974,11 @@ namespace OpenUtau.Plugin.Builtin {
                     alias = alias.Replace(fb.Key, fb.Value);
                 }
             }
-            return alias;
+            if (isYamlFallbacks) {
+                foreach (var fb in yamlFallbacks.OrderByDescending(f => f.Key.Length)) {
+                    alias = alias.Replace(fb.Key, fb.Value);
+                }
+            }
 
             return base.ValidateAlias(alias);
         }

--- a/OpenUtau.Plugin.Builtin/FilipinoPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/FilipinoPhonemizer.cs
@@ -79,7 +79,7 @@ namespace OpenUtau.Plugin.Builtin {
         private readonly string[] ccvException = { "ch", "dh", "dx", "fh", "gh", "hh", "jh", "kh", "ph", "ng", "sh", "th", "vh", "wh", "zh" };
         private readonly string[] RomajiException = { "a", "e", "i", "o", "u" };
         private static readonly string[] FinalConsonants = { "w", "y", "r", "l", "m", "n", "ng" };
-        bool isTails = false;
+
 
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
@@ -87,10 +87,6 @@ namespace OpenUtau.Plugin.Builtin {
                 return note.phoneticHint.Split(new[] { " " }, StringSplitOptions.RemoveEmptyEntries);
             }
 
-            if (tails.Contains(note.lyric)) {
-                isTails = true;
-                return new string[] { note.lyric };
-            }
             if (original == null || original.Length == 0) {
                 string lyric = note.lyric.ToLowerInvariant();
                 List<string> fallbackSplit = new List<string>();
@@ -450,45 +446,6 @@ namespace OpenUtau.Plugin.Builtin {
                         }
                     }
                 }
-
-                // CC Endings (trailing)
-                if (isTails && basePhoneme.Contains("-")) {
-                    for (int clusterLength = 3; clusterLength >= 2; clusterLength--) {
-                        if (clusterLength > cc.Length) {
-                            continue;
-                        }
-
-                        var cluster = new string[clusterLength];
-                        Array.Copy(cc, 0, cluster, 0, clusterLength);
-
-                        // All possible spacing patterns for the consonants.
-                        var consonantPatterns = new List<string>();
-
-                        if (clusterLength >= 3) {
-                            consonantPatterns.Add($"{cluster[0]} {cluster[1]}{cluster[2]}");
-                            consonantPatterns.Add($"{cluster[0]}{cluster[1]} {cluster[2]}");
-                            consonantPatterns.Add($"{cluster[0]} {cluster[1]} {cluster[2]}");
-                        } else if (clusterLength == 2) {
-                            consonantPatterns.Add($"{cluster[0]} {cluster[1]}");
-                            consonantPatterns.Add($"{cluster[0]}{cluster[1]}");
-                        }
-
-                        // Check for all possible patterns with the ending hyphen.
-                        foreach (var consPattern in consonantPatterns) {
-                            string[] endPatterns = { "-", $" -" };
-                            foreach (var end in endPatterns) {
-                                string endingcc = $"{consPattern}{end}";
-
-                                if (HasOto(endingcc, syllable.tone)) {
-                                    basePhoneme = endingcc;
-                                    lastC = 0;
-                                } else {
-                                    continue;
-                                }
-                            }
-                        }
-                    }
-                }
             }
 
             for (var i = firstC; i < lastC; i++) {
@@ -661,51 +618,48 @@ namespace OpenUtau.Plugin.Builtin {
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
+            string t = ending.HasTail ? ReplacePhoneme(ending.tail, ending.tone) : "-";
             
-            if (tails.Contains(prevV)) {
-                return new List<string>();
-            }
             if (ending.IsEndingV) {
-                var vR = $"{v} -";
-                var vR1 = $"{v} R";
-                var vR2 = $"{v}-";
-                if (HasOto(vR, ending.tone) || HasOto(ValidateAlias(vR), ending.tone) || HasOto(vR1, ending.tone) || HasOto(ValidateAlias(vR1), ending.tone) || HasOto(vR2, ending.tone) || HasOto(ValidateAlias(vR2), ending.tone)) {
-                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{v}", "ending", ending.tone, ""), ValidateAlias(AliasFormat($"{v}", "ending", ending.tone, "")));
+                var vR = $"{v} {t}";
+                var vR2 = $"{v}{t}";
+                if (HasOto(vR, ending.tone) || HasOto(ValidateAlias(vR), ending.tone) || HasOto(vR2, ending.tone) || HasOto(ValidateAlias(vR2), ending.tone)) {
+                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{v}", "ending", ending.tone, "", t), ValidateAlias(AliasFormat($"{v}", "ending", ending.tone, "", t)));
                 }
             } else if (ending.IsEndingVCWithOneConsonant) {
                 var vc = $"{v} {cc[0]}";
-                var vcr = $"{v} {cc[0]}-";
-                var vcr2 = $"{v}{cc[0]} -";
-                var vcr3 = $"{v}{cc[0]}-";
+                var vcr = $"{v} {cc[0]}{t}";
+                var vcr2 = $"{v}{cc[0]} {t}";
+                var vcr3 = $"{v}{cc[0]}{t}";
                 if (!RomajiException.Contains(cc[0])) {
                     if (HasOto(vcr, ending.tone) && HasOto(ValidateAlias(vcr), ending.tone) || HasOto(vcr2, ending.tone) && HasOto(ValidateAlias(vcr2), ending.tone) || HasOto(vcr3, ending.tone) && HasOto(ValidateAlias(vcr3), ending.tone)) {
-                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{v} {cc[0]}", "dynEnd", ending.tone, ""), ValidateAlias(AliasFormat($"{v} {cc[0]}", "dynEnd", ending.tone, "")));
+                        TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{v} {cc[0]}", "dynEnd", ending.tone, "", t), ValidateAlias(AliasFormat($"{v} {cc[0]}", "dynEnd", ending.tone, "", t)));
                     } else if (!HasOto(vcr, ending.tone) && !HasOto(ValidateAlias(vcr), ending.tone) || !HasOto(vcr2, ending.tone) && HasOto(ValidateAlias(vcr2), ending.tone) || !HasOto(vcr3, ending.tone) && HasOto(ValidateAlias(vcr3), ending.tone)) {
                         TryAddPhoneme(phonemes, ending.tone, vc);
                         if (vc.Contains(cc[0])) {
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "ending", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "ending", ending.tone, "", t));
                         }
                     } else {
                         TryAddPhoneme(phonemes, ending.tone, vc);
                         if (vc.Contains(cc[0])) {
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "ending", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[0]}", "ending", ending.tone, "", t));
                         }
                     }
                 }
             } else {
                 for (var i = lastC; i >= 0; i--) {
-                    var vr = $"{v} -";
+                    var vr = $"{v} {t}";
                     var vr1 = $"{v} R";
-                    var vr2 = $"{v}-";
-                    var vcc = $"{v} {string.Join("", cc.Take(2))}-";
-                    var vcc2 = $"{v}{string.Join(" ", cc.Take(2))} -";
+                    var vr2 = $"{v}{t}";
+                    var vcc = $"{v} {string.Join("", cc.Take(2))}{t}";
+                    var vcc2 = $"{v}{string.Join(" ", cc.Take(2))} {t}";
                     var vcc3 = $"{v}{string.Join(" ", cc.Take(2))}";
                     var vcc4 = $"{v} {string.Join("", cc.Take(2))}";
                     var vc = $"{v} {cc[0]}";
                     if (!RomajiException.Contains(cc[0])) {
                         if (i == 0) {
                             if (HasOto(vr, ending.tone) || HasOto(ValidateAlias(vr), ending.tone) || HasOto(vr2, ending.tone) || HasOto(ValidateAlias(vr2), ending.tone) || HasOto(vr1, ending.tone) || HasOto(ValidateAlias(vr1), ending.tone) && !HasOto(vc, ending.tone)) {
-                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{v}", "ending", ending.tone, ""));
+                                TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{v}", "ending", ending.tone, "", t));
                             }
                             break;
                         } else if (HasOto(vcc, ending.tone) && HasOto(ValidateAlias(vcc), ending.tone) && lastC == 1 && !ccvException.Contains(cc[0])) {
@@ -720,7 +674,7 @@ namespace OpenUtau.Plugin.Builtin {
                             TryAddPhoneme(phonemes, ending.tone, vcc3);
                             if (vcc3.EndsWith(cc.Last()) && lastC == 1) {
                                 if (consonants.Contains(cc.Last())) {
-                                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc.Last()}", "ending", ending.tone, ""));
+                                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc.Last()}", "ending", ending.tone, "", t));
                                 }
                             }
                             firstC = 1;
@@ -729,7 +683,7 @@ namespace OpenUtau.Plugin.Builtin {
                             TryAddPhoneme(phonemes, ending.tone, vcc4);
                             if (vcc4.EndsWith(cc.Last()) && lastC == 1) {
                                 if (consonants.Contains(cc.Last())) {
-                                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc.Last()}", "ending", ending.tone, ""));
+                                    TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc.Last()}", "ending", ending.tone, "", t));
                                 }
                             }
                             firstC = 1;
@@ -760,31 +714,31 @@ namespace OpenUtau.Plugin.Builtin {
                         if (!HasOto(cc2, ending.tone) && !HasOto($"{cc[i + 1]} {cc[i + 2]}", ending.tone)) {
                             // [C1 -] [- C2]
                             cc2 = AliasFormat($"{cc[i + 2]}", "cc_inB", ending.tone, "");
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_endB", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_endB", ending.tone, "", t));
                         }
                         if (!HasOto(cc1, ending.tone)) {
                             cc1 = ValidateAlias(cc1);
                         }
-                        if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone))) {
+                        if (HasOto(cc1, ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}{t}", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"), ending.tone))) {
                             // like [C1 C2][C2 ...]
                             TryAddPhoneme(phonemes, ending.tone, cc1);
-                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}-", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"), ending.tone)))) {
+                        } else if ((HasOto(cc[i], ending.tone) || HasOto(ValidateAlias(cc[i]), ending.tone) && (HasOto(cc2, ending.tone) || HasOto($"{cc[i + 1]} {cc[i + 2]}{t}", ending.tone) || HasOto(ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"), ending.tone)))) {
                             // like [C1 C2-][C3 ...]
                             TryAddPhoneme(phonemes, ending.tone, cc[i]);
-                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}-", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}-"))) {
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {cc[i + 2]}{t}", ValidateAlias($"{cc[i + 1]} {cc[i + 2]}{t}"))) {
                             // like [C1 C2-][C3 ...]
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1))) {
                             i++;
                         } else if (!HasOto(cc1, ending.tone) && !HasOto($"{cc[i]} {cc[i + 1]}", ending.tone)) {
                             // [C1 -] [- C2]
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_inB", ending.tone, ""));
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_endB", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_inB", ending.tone, "", t));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_endB", ending.tone, "", t));
                             i++;
                         } else {
                             // like [C1][C2 ...]
-                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} -", ValidateAlias($"{cc[i]} -"));
-                            TryAddPhoneme(phonemes, ending.tone, cc[i + 1], ValidateAlias(cc[i + 1]), $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"));
+                            TryAddPhoneme(phonemes, ending.tone, cc[i], ValidateAlias(cc[i]), $"{cc[i]} {t}", ValidateAlias($"{cc[i]} {t}"));
+                            TryAddPhoneme(phonemes, ending.tone, cc[i + 1], ValidateAlias(cc[i + 1]), $"{cc[i + 1]} {t}", ValidateAlias($"{cc[i + 1]} {t}"));
                             i++;
                         }
                     } else {
@@ -800,31 +754,31 @@ namespace OpenUtau.Plugin.Builtin {
                         // [C1 -] [- C2]
                         if (!HasOto(cc1, ending.tone) || !HasOto(ValidateAlias(cc1), ending.tone) && !HasOto($"{cc[i]} {cc[i + 1]}", ending.tone)) {
                             cc1 = AliasFormat($"{cc[i + 1]}", "cc_inB", ending.tone, "");
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i]}", "cc_endB", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i]}", "cc_endB", ending.tone, "", t));
                         }
                         if (!HasOto(cc1, ending.tone)) {
                             cc1 = ValidateAlias(cc1);
                         }
-                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}-", ValidateAlias($"{cc[i]} {cc[i + 1]}-"))) {
+                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]}{t}", ValidateAlias($"{cc[i]} {cc[i + 1]}{t}"))) {
                             // like [C1 C2-]
                             i++;
-                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]} -", ValidateAlias($"{cc[i]} {cc[i + 1]} -"))) {
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]} {cc[i + 1]} {t}", ValidateAlias($"{cc[i]} {cc[i + 1]} {t}"))) {
                             // like [C1 C2 -]
                             i++;
-                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}-", ValidateAlias($"{cc[i]}{cc[i + 1]}-"))) {
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}{t}", ValidateAlias($"{cc[i]}{cc[i + 1]}{t}"))) {
                             // like [C1C2-]
                             i++;
-                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]} -", ValidateAlias($"{cc[i]}{cc[i + 1]} -"))) {
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]} {t}", ValidateAlias($"{cc[i]}{cc[i + 1]} {t}"))) {
                             // like [C1C2 -]
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1))) {
                             // like [C1 C2][C2 -]
-                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} -", ValidateAlias($"{cc[i + 1]} -"), cc[i + 1], ValidateAlias(cc[i + 1]));
+                            TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]} {t}", ValidateAlias($"{cc[i + 1]} {t}"), cc[i + 1], ValidateAlias(cc[i + 1]));
                             i++;
                         } else if (!HasOto(cc1, ending.tone) && !HasOto($"{cc[i]} {cc[i + 1]}", ending.tone)) {
                             // [C1 -] [- C2]
                             TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 1]}", "cc_inB", ending.tone, ""));
-                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 2]}", "cc_endB", ending.tone, ""));
+                            TryAddPhoneme(phonemes, ending.tone, AliasFormat($"{cc[i + 2]}", "cc_endB", ending.tone, "", t));
                             i++;
                         }
                     }
@@ -832,7 +786,7 @@ namespace OpenUtau.Plugin.Builtin {
             }
             return phonemes;
         }
-        private string AliasFormat(string alias, string type, int tone, string prevV) {
+        private string AliasFormat(string alias, string type, int tone, string prevV, string t = "-") {
             var aliasFormats = new Dictionary<string, string[]> {
             // Define alias formats for different types
                 { "dynStart", new string[] { "" } },
@@ -844,14 +798,14 @@ namespace OpenUtau.Plugin.Builtin {
                 { "vvExtend", new string[] { "", "_", "-", "- " } },
                 { "cv", new string[] { "-", "", "- ", "_" } },
                 { "cvStart", new string[] { "-", "- ", "_" } },
-                { "ending", new string[] { " -", "-", " R" } },
-                { "ending_mix", new string[] { "-", " -", "R", " R", "_", "--" } },
+                { "ending", new string[] { $" {t}", $"{t}"} },
+                { "ending_mix", new string[] { $"{t}", $" {t}", "--" } },
                 { "cc", new string[] { "", "-", "- ", "_" } },
                 { "cc_start", new string[] { "- ", "-", "_" } },
-                { "cc_end", new string[] { " -", "-", "" } },
-                { "cc_inB", new string[] { "_", "", "- " } },
-                { "cc_endB", new string[] { "_", "", " -" } },
-                { "cc_mix", new string[] { " -", " R", "-", "", "_", "- ", "-" } },
+                { "cc_end", new string[] { $" {t}", $"{t}", "" } },
+                { "cc_inB", new string[] { "_", "-", "- " } },
+                { "cc_endB", new string[] { "_", $"{t}", $" {t}" } },
+                { "cc_mix", new string[] { $" {t}", " R", $"{t}", "", "_", $"{t} ", $"{t}" } },
                 { "cc1_mix", new string[] { "", " -", "-", " R", "_", "- ", "-" } },
             };
 

--- a/OpenUtau.Plugin.Builtin/GermanVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/GermanVCCVPhonemizer.cs
@@ -16,7 +16,7 @@ namespace OpenUtau.Plugin.Builtin {
         /// Pronunciation reference: https://docs.google.com/spreadsheets/d/12E62ImRDOXyS6g6BFJHT9pOU2cFmNrch1UEmuTZqeak/edit?pli=1#gid=0
         /// </summary>
         /// 
-
+        private const string YamlFile = "de_vccv.yaml";
         private string[] vowels = "a,6,e,E,2,9,i,I,y,Y,u,U,o,O,@,aU,OY,aI".Split(',');
         private readonly string[] consonants = "-,b,C,d,f,g,h,j,k,kh,l,m,n,N,p,ph,R;,s,S,t,th,v,x,z,Z,dZ,ks,pf,st,St,tS,w".Split(',');
         private readonly string[] longConsonants = "k,kh,p,ph,s,S,t,th,dZ,ks,pf,st,St,tS".Split(',');
@@ -49,7 +49,7 @@ namespace OpenUtau.Plugin.Builtin {
             var g2ps = new List<IG2p>();
 
             // Load dictionary from plugin folder.
-            string path = Path.Combine(PluginDir, "de_vccv.yaml");
+            string path = Path.Combine(PluginDir, YamlFile);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
                 File.WriteAllBytes(path, Data.Resources.de_vccv_template);
@@ -58,7 +58,7 @@ namespace OpenUtau.Plugin.Builtin {
 
             // Load dictionary from singer folder.
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, "de_vccv.yaml");
+                string file = Path.Combine(singer.Location, YamlFile);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -91,7 +91,7 @@ namespace OpenUtau.Plugin.Builtin {
                 finalPhonemes = new List<string>();
                 while (i < modified.Count) {
                     bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements)) {
+                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
                         if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
                             bool match = true;
                             for (int j = 0; j < fromArray.Length; j++) {
@@ -116,7 +116,7 @@ namespace OpenUtau.Plugin.Builtin {
                     if (!replaced && splittingReplacements.Any()) {
                         string currentPhoneme = modified[i];
                         bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements) {
+                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
                             if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
                                 finalPhonemes.AddRange(toArray);
                                 singleReplaced = true;
@@ -158,16 +158,16 @@ namespace OpenUtau.Plugin.Builtin {
             if (this.singer != singer) {
                 string file;
                 if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, "de_vccv.yaml");
+                    file = Path.Combine(singer.Location, YamlFile);
                     if (!File.Exists(file)) {
                         try {
                             File.WriteAllBytes(file, Data.Resources.envccv_template);
                         } catch (Exception e) {
-                            Log.Error(e, $"Failed to write 'de_vccv.yaml' to singer folder at {file}");
+                            Log.Error(e, $"Failed to write '{YamlFile}' to singer folder at {file}");
                         }
                     }
                 } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, "de_vccv.yaml");
+                    file = Path.Combine(PluginDir, YamlFile);
                 } else {
                     Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'de_vccv.yaml'.");
                     return; // Exit early to avoid null file issues
@@ -186,7 +186,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             vowels = vowels.Concat(loadVowels).Distinct().ToArray();
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from de_vccv.yaml: {ex.Message}");
+                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
                         }
                         // Load replacements
                         try {
@@ -196,14 +196,15 @@ namespace OpenUtau.Plugin.Builtin {
 
                                 foreach (var replacement in data.replacements) {
                                     try {
+                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
                                         if (replacement.from != null && replacement.to != null) {
                                             if (replacement.from is IEnumerable<object> fromList) {
                                                 // 'from' is a list (e.g., [ae, n])
                                                 string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
                                                 if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString });
+                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -212,7 +213,7 @@ namespace OpenUtau.Plugin.Builtin {
                                                 if (replacement.to is string toString) {
                                                     dictionaryReplacements[fromString] = toString;
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -231,7 +232,7 @@ namespace OpenUtau.Plugin.Builtin {
                                 splittingReplacements = new List<Replacement>();
                             }
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from de_vccv.yaml: {ex.Message}");
+                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
                         }
                         // Load fallbacks
                         try {
@@ -250,7 +251,7 @@ namespace OpenUtau.Plugin.Builtin {
                         }
 
                     } catch (Exception ex) {
-                       Log.Error($"Failed to parse de_vccv.yaml: {ex.Message}, Exception Type: {ex.GetType()}");
+                       Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
                     }
                 }
                 ReadDictionaryAndInit();
@@ -275,6 +276,7 @@ namespace OpenUtau.Plugin.Builtin {
         public class Replacement {
             public object from { get; set; }
             public object to { get; set; }
+            public string where { get; set; } = "inside";
 
             public List<string> FromList {
                 get {
@@ -307,16 +309,88 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
-            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
-            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
-            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
-            string[] cc = syllable.cc.Select(ReplacePhoneme).ToArray();
+           // Replacement for note boundaries
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
+            bool hasV = !string.IsNullOrEmpty(syllable.v);
 
+            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
+            currentPhonemes.AddRange(syllable.cc);
+            if (hasV) currentPhonemes.Add(syllable.v);
+
+            List<string> finalPhonemes = new List<string>();
+            int idx = 0;
+            while (idx < currentPhonemes.Count) {
+                bool replaced = false;
+                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
+                        bool match = true;
+                        for (int j = 0; j < fromArray.Length; j++) {
+                            if (currentPhonemes[idx + j] != fromArray[j]) {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match) {
+                            if (rule.to is string toString) {
+                                finalPhonemes.Add(toString);
+                            } else if (rule.to is string[] toArray) {
+                                finalPhonemes.AddRange(toArray);
+                            }
+                            idx += fromArray.Length;
+                            replaced = true;
+                            break;
+                        }
+                    }
+                }
+                
+                if (!replaced && splittingReplacements.Any()) {
+                    string currentPhoneme = currentPhonemes[idx];
+                    bool singleReplaced = false;
+                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
+                            finalPhonemes.AddRange(toArray);
+                            singleReplaced = true;
+                            break;
+                        }
+                    }
+                    if (!singleReplaced) {
+                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    }
+                    idx++;
+                } else if (!replaced) {
+                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    idx++;
+                }
+            }
+
+            string newPrevV = "";
+            string newV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                if (hasV && finalPhonemes.Count > 0) {
+                    newV = finalPhonemes.Last();
+                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
+                }
+                newCc.AddRange(finalPhonemes);
+            }
+            
+            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
+            string[] cc = newCc.ToArray();
+            string v = newV;
+            List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
+            string[] CurrentWordCc = syllable.CurrentWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
 
             foreach (var entry in replacements) {
                 if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Key, syllable.tone)) {

--- a/OpenUtau.Plugin.Builtin/GermanVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/GermanVCCVPhonemizer.cs
@@ -65,26 +65,13 @@ namespace OpenUtau.Plugin.Builtin {
 
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
-            if (tails.Contains(note.lyric)) {
-                return new string[] { note.lyric };
-            }
             if (original == null) {
                 return null;
-            }
-            var mappedOriginal = new List<string>();
-            foreach (var p in original) {
-                if (dictionaryReplacements.ContainsKey(p)) {
-                    mappedOriginal.Add(dictionaryReplacements[p]);
-                } else {
-                    mappedOriginal.Add(p);
-                }
             }
             List<string> finalProcessedPhonemes = new List<string>();
 
             string[] diphthongs = new[] { "aU", "OY", "aI" };
-            IEnumerable<string> phonemes;
-            phonemes = mappedOriginal;
-            foreach (string s in phonemes) {
+            foreach (string s in original) {
                 if (diphthongs.Contains(s)) {
                     finalProcessedPhonemes.AddRange(new string[] { s[0].ToString(), s[1] + '^'.ToString() });
                 } else {
@@ -314,17 +301,17 @@ namespace OpenUtau.Plugin.Builtin {
         protected override List<string> ProcessEnding(Ending ending) {
             string[] cc = ending.cc.Select(c => ReplacePhoneme(c, ending.tone)).ToArray();
             string v = ReplacePhoneme(ending.prevV, ending.tone);
-
+            string t = ending.HasTail ? ReplacePhoneme(ending.tail, ending.tone) : "-";
             var lastC = cc.Length - 1;
             var firstC = 0;
 
             var phonemes = new List<string>();
             if (ending.IsEndingV) {
-                var vr = $"{v}-";
+                var vr = $"{v}{t}";
                 if (HasOto(vr, ending.tone)) {
                     phonemes.Add(vr);
                 } else {
-                    phonemes.Add($"{v} -");
+                    phonemes.Add($"{v} {t}");
                 }
             } else if (ending.IsEndingVCWithOneConsonant) {
                 phonemes.Add($"{v}{cc[0]}");
@@ -343,7 +330,7 @@ namespace OpenUtau.Plugin.Builtin {
                 for (var i = firstC; i < lastC; i++) {
                     // all CCs except the first one are /C1C2/, the last one is /C1 C2-/
                     // but if there is no /C1C2/, we try /C1 C2-/, vise versa for the last one
-                    var cc1 = $"{cc[i]}{cc[i + 1]} -";
+                    var cc1 = $"{cc[i]}{cc[i + 1]} {t}";
                     // in most cases, use [C1][C2] -
                     if (!HasOto(cc1, ending.tone)) {
                         cc1 = ValidateAlias(cc1);
@@ -367,7 +354,7 @@ namespace OpenUtau.Plugin.Builtin {
                         cc1 = ValidateAlias(cc1);
                     }
                     if (i < cc.Length - 2) {
-                        var cc2 = $"{cc[i + 1]}{cc[i + 2]} -";
+                        var cc2 = $"{cc[i + 1]}{cc[i + 2]} {t}";
                         // in most cases, use [C2][C3] -
                         if (!HasOto(cc2, ending.tone)) {
                             cc2 = ValidateAlias(cc2);
@@ -390,13 +377,13 @@ namespace OpenUtau.Plugin.Builtin {
                         if (!HasOto(cc2, ending.tone)) {
                             cc2 = ValidateAlias(cc2);
                         }
-                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}{cc[i + 2]} -", ValidateAlias($"{cc[i]}{cc[i + 1]}{cc[i + 2]} -"))) {
+                        if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i]}{cc[i + 1]}{cc[i + 2]} {t}", ValidateAlias($"{cc[i]}{cc[i + 1]}{cc[i + 2]} {t}"))) {
                             // like [C1 C2-][C3 ...]
                             i++;
                         } else if (HasOto(cc1, ending.tone) && HasOto(cc2, ending.tone)) {
                             // like [C1 C2][C2 ...]
                             phonemes.Add(cc1);
-                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]}{cc[i + 2]} -", ValidateAlias($"{cc[i + 1]}{cc[i + 2]} -"))) {
+                        } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]}{cc[i + 2]} {t}", ValidateAlias($"{cc[i + 1]}{cc[i + 2]} {t}"))) {
                             // like [C1 C2-][C3 ...]
                             i++;
                         } else if (TryAddPhoneme(phonemes, ending.tone, $"{cc[i + 1]}{cc[i + 2]}", ValidateAlias($"{cc[i + 1]}{cc[i + 2]}"))) {

--- a/OpenUtau.Plugin.Builtin/GermanVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/GermanVCCVPhonemizer.cs
@@ -16,11 +16,12 @@ namespace OpenUtau.Plugin.Builtin {
         /// Pronunciation reference: https://docs.google.com/spreadsheets/d/12E62ImRDOXyS6g6BFJHT9pOU2cFmNrch1UEmuTZqeak/edit?pli=1#gid=0
         /// </summary>
         /// 
-        private const string YamlFile = "de_vccv.yaml";
-        private string[] vowels = "a,6,e,E,2,9,i,I,y,Y,u,U,o,O,@,aU,OY,aI".Split(',');
-        private readonly string[] consonants = "-,b,C,d,f,g,h,j,k,kh,l,m,n,N,p,ph,R;,s,S,t,th,v,x,z,Z,dZ,ks,pf,st,St,tS,w".Split(',');
-        private readonly string[] longConsonants = "k,kh,p,ph,s,S,t,th,dZ,ks,pf,st,St,tS".Split(',');
-        private Dictionary<string, string> dictionaryReplacements = ("aa=a,ae=E,ah=@,ao=O,aw=aU,ax=@,ay=aI," +
+        protected override string YamlFileName => "de_vccv.yaml";
+        protected override byte[] YamlTemplate => Data.Resources.de_vccv_template;
+        public GermanVCCVPhonemizer() {
+            this.vowels = "a,6,e,E,2,9,i,I,y,Y,u,U,o,O,@,aU,OY,aI".Split(',');
+            this.consonants = "-,b,C,d,f,g,h,j,k,kh,l,m,n,N,p,ph,R;,s,S,t,th,v,x,z,Z,dZ,ks,pf,st,St,tS,w".Split(',');
+            this.dictionaryReplacements = ("aa=a,ae=E,ah=@,ao=O,aw=aU,ax=@,ay=aI," +
             "b=b,cc=C,ch=tS,d=d,dh=z," + "ee=e,eh=E,er=6,ex=6," + "f=f,g=g,hh=h,ih=I,iy=i,jh=dZ,k=k,l=l,m=m,n=n,ng=N," +
             "oe=9,ohh=2,ooh=o,oy=OY," + "p=p,pf=pf,q=-,r=R;,rr=R;,s=s,sh=S,t=t," + "th=s,ts=ts," + "ue=y,uh=U,uw=u," + "v=v,w=w,x=x,y=j," +
             "yy=Y," + "z=z,zh=Z").Split(',')
@@ -28,37 +29,26 @@ namespace OpenUtau.Plugin.Builtin {
                 .Where(parts => parts.Length == 2)
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
+        }
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "cmudict_de.txt";
-        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
-        // Store the splitting replacements
-        private List<Replacement> splittingReplacements = new List<Replacement>();
-        // Store the merging replacements
-        private List<Replacement> mergingReplacements = new List<Replacement>();
-
-        // for fallbacks
-        private readonly Dictionary<string, string> replacements = "ax=x".Split(';')
-                .Select(entry => entry.Split('='))
-                .Where(parts => parts.Length == 2)
-                .Where(parts => parts[0] != parts[1])
-                .ToDictionary(parts => parts[0], parts => parts[1]);
-        private bool isReplacements = false;
+        private bool isYamlFallbacks = false;
 
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
 
             // Load dictionary from plugin folder.
-            string path = Path.Combine(PluginDir, YamlFile);
+            string path = Path.Combine(PluginDir, YamlFileName);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
-                File.WriteAllBytes(path, Data.Resources.de_vccv_template);
+                File.WriteAllBytes(path, YamlTemplate);
             }
             g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(path)).Build());
 
             // Load dictionary from singer folder.
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, YamlFile);
+                string file = Path.Combine(singer.Location, YamlFileName);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -70,10 +60,8 @@ namespace OpenUtau.Plugin.Builtin {
 
             // Load base g2p.
             g2ps.Add(new GermanG2p());
-
             return new G2pFallbacks(g2ps.ToArray());
         }
-        private string[] tails = "-".Split(',');
 
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
@@ -83,67 +71,19 @@ namespace OpenUtau.Plugin.Builtin {
             if (original == null) {
                 return null;
             }
-            List<string> modified = new List<string>(original);
-            List<string> finalPhonemes = new List<string>();
-            int i = 0;
-            bool hasReplacements = mergingReplacements.Any() == true || splittingReplacements.Any() == true; // Check for any replacements
-            if (hasReplacements) {
-                finalPhonemes = new List<string>();
-                while (i < modified.Count) {
-                    bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
-                        if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
-                            bool match = true;
-                            for (int j = 0; j < fromArray.Length; j++) {
-                                if (modified[i + j] != fromArray[j]) {
-                                    match = false;
-                                    break;
-                                }
-                            }
-                            if (match) {
-                                if (rule.to is string toString) {
-                                    finalPhonemes.Add(toString);
-                                } else if (rule.to is string[] toArray) {
-                                    finalPhonemes.AddRange(toArray);
-                                }
-                                i += fromArray.Length;
-                                replaced = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!replaced && splittingReplacements.Any()) {
-                        string currentPhoneme = modified[i];
-                        bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
-                            if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                                singleReplaced = true;
-                                break;
-                            }
-                        }
-                        if (!singleReplaced) {
-                            finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        }
-                        i++;
-                    } else if (!replaced) {
-                        finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        i++;
-                    }
+            var mappedOriginal = new List<string>();
+            foreach (var p in original) {
+                if (dictionaryReplacements.ContainsKey(p)) {
+                    mappedOriginal.Add(dictionaryReplacements[p]);
+                } else {
+                    mappedOriginal.Add(p);
                 }
-            } else {
-                finalPhonemes = new List<string>(modified);
             }
             List<string> finalProcessedPhonemes = new List<string>();
 
             string[] diphthongs = new[] { "aU", "OY", "aI" };
             IEnumerable<string> phonemes;
-            if (hasReplacements) {
-                phonemes = finalPhonemes;
-            } else {
-                phonemes = original;
-            }
+            phonemes = mappedOriginal;
             foreach (string s in phonemes) {
                 if (diphthongs.Contains(s)) {
                     finalProcessedPhonemes.AddRange(new string[] { s[0].ToString(), s[1] + '^'.ToString() });
@@ -152,147 +92,6 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             }
             return finalProcessedPhonemes.ToArray();
-        }
-
-        public override void SetSinger(USinger singer) {
-            if (this.singer != singer) {
-                string file;
-                if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, YamlFile);
-                    if (!File.Exists(file)) {
-                        try {
-                            File.WriteAllBytes(file, Data.Resources.envccv_template);
-                        } catch (Exception e) {
-                            Log.Error(e, $"Failed to write '{YamlFile}' to singer folder at {file}");
-                        }
-                    }
-                } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, YamlFile);
-                } else {
-                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'de_vccv.yaml'.");
-                    return; // Exit early to avoid null file issues
-                }
-
-                if (File.Exists(file)) {
-                    try {
-                        var data = Core.Yaml.DefaultDeserializer.Deserialize<GermanYAMLData>(File.ReadAllText(file));
-
-                        // Load vowels
-                        try {
-                            var loadVowels = data.symbols
-                                ?.Where(s => s.type == "vowel")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            vowels = vowels.Concat(loadVowels).Distinct().ToArray();
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
-                        }
-                        // Load replacements
-                        try {
-                            if (data?.replacements != null && data.replacements.Any() == true) {
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-
-                                foreach (var replacement in data.replacements) {
-                                    try {
-                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
-                                        if (replacement.from != null && replacement.to != null) {
-                                            if (replacement.from is IEnumerable<object> fromList) {
-                                                // 'from' is a list (e.g., [ae, n])
-                                                string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
-                                                if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else if (replacement.from is string fromString) {
-                                                // 'from' is a single string (e.g., tr, aw, ae, m, ng)
-                                                if (replacement.to is string toString) {
-                                                    dictionaryReplacements[fromString] = toString;
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else {
-                                                Log.Error($"Error: Invalid 'from' type in replacement: {replacement}");
-                                            }
-                                        } else {
-                                            Log.Error($"Error: 'from' or 'to' is null in replacement: {replacement}");
-                                        }
-                                    } catch (Exception ex) {
-                                        Log.Error($"Failed to process replacement entry: {replacement}. Error: {ex.Message}");
-                                    }
-                                }
-                            } else {
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from {YamlFile}: {ex.Message}");
-                        }
-                        // Load fallbacks
-                        try {
-                            if (data?.fallbacks?.Any() == true) {
-                                foreach (var df in data.fallbacks) {
-                                    if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
-                                        // Overwrite or add
-                                        replacements[df.from] = df.to;
-                                    } else {
-                                        Log.Warning("Ignored YAML fallback with missing 'from' or 'to' value.");
-                                    }
-                                }
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load fallbacks from YAML: {ex.Message}");
-                        }
-
-                    } catch (Exception ex) {
-                       Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
-                    }
-                }
-                ReadDictionaryAndInit();
-                this.singer = singer;
-            }
-        }
-        public class GermanYAMLData {
-            public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
-            public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
-            public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
-
-            public struct SymbolData {
-                public string symbol { get; set; }
-                public string type { get; set; }
-            }
-            public struct Fallbacks {
-                public string from { get; set; }
-                public string to { get; set; }
-            }
-        }
-        // can split or merge
-        public class Replacement {
-            public object from { get; set; }
-            public object to { get; set; }
-            public string where { get; set; } = "inside";
-
-            public List<string> FromList {
-                get {
-                    if (from is string s) return new List<string> { s };
-                    if (from is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
-
-            public List<string> ToList {
-                get {
-                    if (to is string s) return new List<string> { s };
-                    if (to is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
         }
 
         // prioritize yaml replacements over dictionary replacements
@@ -309,80 +108,11 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
-           // Replacement for note boundaries
-            List<string> currentPhonemes = new List<string>();
-            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
-            bool hasV = !string.IsNullOrEmpty(syllable.v);
-
-            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
-            currentPhonemes.AddRange(syllable.cc);
-            if (hasV) currentPhonemes.Add(syllable.v);
-
-            List<string> finalPhonemes = new List<string>();
-            int idx = 0;
-            while (idx < currentPhonemes.Count) {
-                bool replaced = false;
-                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
-                        bool match = true;
-                        for (int j = 0; j < fromArray.Length; j++) {
-                            if (currentPhonemes[idx + j] != fromArray[j]) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (match) {
-                            if (rule.to is string toString) {
-                                finalPhonemes.Add(toString);
-                            } else if (rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                            }
-                            idx += fromArray.Length;
-                            replaced = true;
-                            break;
-                        }
-                    }
-                }
-                
-                if (!replaced && splittingReplacements.Any()) {
-                    string currentPhoneme = currentPhonemes[idx];
-                    bool singleReplaced = false;
-                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                            finalPhonemes.AddRange(toArray);
-                            singleReplaced = true;
-                            break;
-                        }
-                    }
-                    if (!singleReplaced) {
-                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    }
-                    idx++;
-                } else if (!replaced) {
-                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    idx++;
-                }
-            }
-
-            string newPrevV = "";
-            string newV = "";
-            List<string> newCc = new List<string>();
-
-            if (finalPhonemes.Count > 0) {
-                if (hasPrevV) {
-                    newPrevV = finalPhonemes[0];
-                    finalPhonemes.RemoveAt(0);
-                }
-                if (hasV && finalPhonemes.Count > 0) {
-                    newV = finalPhonemes.Last();
-                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
-                }
-                newCc.AddRange(finalPhonemes);
-            }
-            
-            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
-            string[] cc = newCc.ToArray();
-            string v = newV;
+            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
+            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
+            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
+            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
             List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
@@ -392,9 +122,9 @@ namespace OpenUtau.Plugin.Builtin {
             string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
             int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
 
-            foreach (var entry in replacements) {
+            foreach (var entry in yamlFallbacks) {
                 if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Key, syllable.tone)) {
-                    isReplacements = true;
+                    isYamlFallbacks = true;
                     break;
                 }
             }
@@ -731,8 +461,8 @@ namespace OpenUtau.Plugin.Builtin {
                 alias = alias.Replace("Y^", "Y");
             }
 
-            if (isReplacements) {
-                foreach (var syllable in replacements.OrderByDescending(f => f.Key.Length)) {
+            if (isYamlFallbacks) {
+                foreach (var syllable in yamlFallbacks.OrderByDescending(f => f.Key.Length)) {
                     alias = alias.Replace(syllable.Key, syllable.Value);
                 }
             }
@@ -741,11 +471,6 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override double GetTransitionBasicLengthMs(string alias = "") {
-            foreach (var c in longConsonants) {
-                if (alias.Contains(c)) {
-                    return base.GetTransitionBasicLengthMs() * 2.0;
-                }
-            }
             return base.GetTransitionBasicLengthMs();
         }
     }

--- a/OpenUtau.Plugin.Builtin/SpanishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SpanishVCCVPhonemizer.cs
@@ -18,6 +18,7 @@ namespace OpenUtau.Plugin.Builtin {
         /// Based on the nJokis method.
         /// Supports automatic consonant substitutes, such as seseo, through ValidateAlias.
         ///</summary>
+        private const string YamlFile = "njokis_vccv.yaml";
 
         private string[] vowels = "a,e,i,o,u,BB,DD,ff,GG,ll,mm,nn,rrr,ss,xx".Split(',');
         private readonly string[] consonants = "b,B,ch,d,D,E,f,g,G,h,I,jj,k,l,L,m,n,nJ,p,r,rr,s,sh,t,U,w,x,y,z".Split(',');
@@ -50,7 +51,7 @@ namespace OpenUtau.Plugin.Builtin {
             var g2ps = new List<IG2p>();
 
             // Load dictionary from plugin folder.
-            string path = Path.Combine(PluginDir, "njokis_vccv.yaml");
+            string path = Path.Combine(PluginDir, YamlFile);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
                 File.WriteAllBytes(path, Data.Resources.njokis_template);
@@ -59,7 +60,7 @@ namespace OpenUtau.Plugin.Builtin {
 
             // Load dictionary from singer folder.
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, "njokis_vccv.yaml");
+                string file = Path.Combine(singer.Location, YamlFile);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -88,7 +89,7 @@ namespace OpenUtau.Plugin.Builtin {
                 finalPhonemes = new List<string>();
                 while (i < modified.Count) {
                     bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements)) {
+                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
                         if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
                             bool match = true;
                             for (int j = 0; j < fromArray.Length; j++) {
@@ -113,7 +114,7 @@ namespace OpenUtau.Plugin.Builtin {
                     if (!replaced && splittingReplacements.Any()) {
                         string currentPhoneme = modified[i];
                         bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements) {
+                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
                             if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
                                 finalPhonemes.AddRange(toArray);
                                 singleReplaced = true;
@@ -153,18 +154,18 @@ namespace OpenUtau.Plugin.Builtin {
             if (this.singer != singer) {
                 string file;
                 if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, "njokis_vccv.yaml");
+                    file = Path.Combine(singer.Location, YamlFile);
                     if (!File.Exists(file)) {
                         try {
                             File.WriteAllBytes(file, Data.Resources.njokis_template);
                         } catch (Exception e) {
-                            Log.Error(e, $"Failed to write 'njokis_vccv.yaml' to singer folder at {file}");
+                            Log.Error(e, $"Failed to write '{YamlFile}' to singer folder at {file}");
                         }
                     }
                 } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, "njokis_vccv.yaml");
+                    file = Path.Combine(PluginDir, YamlFile);
                 } else {
-                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate 'njokis_vccv.yaml'.");
+                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate '{YamlFile}'.");
                     return; // Exit early to avoid null file issues
                 }
 
@@ -181,7 +182,7 @@ namespace OpenUtau.Plugin.Builtin {
 
                             vowels = vowels.Concat(loadVowels).Distinct().ToArray();
                         } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from njokis_vccv.yaml: {ex.Message}");
+                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
                         }
                         // Load replacements
                         try {
@@ -191,14 +192,15 @@ namespace OpenUtau.Plugin.Builtin {
 
                                 foreach (var replacement in data.replacements) {
                                     try {
+                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
                                         if (replacement.from != null && replacement.to != null) {
                                             if (replacement.from is IEnumerable<object> fromList) {
                                                 // 'from' is a list (e.g., [ae, n])
                                                 string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
                                                 if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString });
+                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -207,7 +209,7 @@ namespace OpenUtau.Plugin.Builtin {
                                                 if (replacement.to is string toString) {
                                                     dictionaryReplacements[fromString] = toString;
                                                 } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray() });
+                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
                                                 } else {
                                                     Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
                                                 }
@@ -245,7 +247,7 @@ namespace OpenUtau.Plugin.Builtin {
                         }
 
                     } catch (Exception ex) {
-                        Log.Error($"Failed to parse njokis_vccv.yaml: {ex.Message}, Exception Type: {ex.GetType()}");
+                        Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
                     }
                 }
                 ReadDictionaryAndInit();
@@ -270,6 +272,7 @@ namespace OpenUtau.Plugin.Builtin {
         public class Replacement {
             public object from { get; set; }
             public object to { get; set; }
+            public string where { get; set; } = "inside";
 
             public List<string> FromList {
                 get {
@@ -302,15 +305,88 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
-            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
-            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
-            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
-            string[] cc = syllable.cc.Select(ReplacePhoneme).ToArray();
+            // Replacement for note boundaries
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
+            bool hasV = !string.IsNullOrEmpty(syllable.v);
+
+            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
+            currentPhonemes.AddRange(syllable.cc);
+            if (hasV) currentPhonemes.Add(syllable.v);
+
+            List<string> finalPhonemes = new List<string>();
+            int idx = 0;
+            while (idx < currentPhonemes.Count) {
+                bool replaced = false;
+                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
+                        bool match = true;
+                        for (int j = 0; j < fromArray.Length; j++) {
+                            if (currentPhonemes[idx + j] != fromArray[j]) {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match) {
+                            if (rule.to is string toString) {
+                                finalPhonemes.Add(toString);
+                            } else if (rule.to is string[] toArray) {
+                                finalPhonemes.AddRange(toArray);
+                            }
+                            idx += fromArray.Length;
+                            replaced = true;
+                            break;
+                        }
+                    }
+                }
+                
+                if (!replaced && splittingReplacements.Any()) {
+                    string currentPhoneme = currentPhonemes[idx];
+                    bool singleReplaced = false;
+                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
+                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
+                            finalPhonemes.AddRange(toArray);
+                            singleReplaced = true;
+                            break;
+                        }
+                    }
+                    if (!singleReplaced) {
+                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    }
+                    idx++;
+                } else if (!replaced) {
+                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
+                    idx++;
+                }
+            }
+
+            string newPrevV = "";
+            string newV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                if (hasV && finalPhonemes.Count > 0) {
+                    newV = finalPhonemes.Last();
+                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
+                }
+                newCc.AddRange(finalPhonemes);
+            }
+            
+            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
+            string[] cc = newCc.ToArray();
+            string v = newV;
+            List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
             var lastC = cc.Length - 1;
             var firstC = 0;
+            string[] CurrentWordCc = syllable.CurrentWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
 
             foreach (var entry in replacements) {
                 if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Key, syllable.tone)) {

--- a/OpenUtau.Plugin.Builtin/SpanishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SpanishVCCVPhonemizer.cs
@@ -65,24 +65,11 @@ namespace OpenUtau.Plugin.Builtin {
 
         protected override string[] GetSymbols(Note note) {
             string[] original = base.GetSymbols(note);
-            if (tails.Contains(note.lyric)) {
-                return new string[] { note.lyric };
-            }
             if (original == null) {
                 return null;
             }
-            var mappedOriginal = new List<string>();
-            foreach (var p in original) {
-                if (dictionaryReplacements.ContainsKey(p)) {
-                    mappedOriginal.Add(dictionaryReplacements[p]);
-                } else {
-                    mappedOriginal.Add(p);
-                }
-            }
             List<string> finalProcessedPhonemes = new List<string>();
-            IEnumerable<string> phonemes;
-            phonemes = mappedOriginal;
-            foreach (string s in phonemes) {
+            foreach (string s in original) {
                 switch (s) {
                     default:
                         finalProcessedPhonemes.Add(s);
@@ -398,17 +385,18 @@ namespace OpenUtau.Plugin.Builtin {
         protected override List<string> ProcessEnding(Ending ending) {
             string[] cc = ending.cc.Select(c => ReplacePhoneme(c, ending.tone)).ToArray();
             string v = ReplacePhoneme(ending.prevV, ending.tone);
+            string t = ending.HasTail ? ReplacePhoneme(ending.tail, ending.tone) : "-";
 
             var phonemes = new List<string>();
             if (ending.IsEndingV) {
-                TryAddPhoneme(phonemes, ending.tone, $"{v}-", ValidateAlias($"{v}-"));
+                TryAddPhoneme(phonemes, ending.tone, $"{v}{t}", ValidateAlias($"{v}{t}"));
             } else if (ending.IsEndingVCWithOneConsonant) {
-                var vcr = $"{v}{cc[0]}-";
+                var vcr = $"{v}{cc[0]}{t}";
                 if (HasOto(vcr, ending.tone)) {
                     phonemes.Add(vcr);
                 } else {
                     phonemes.Add($"{v} {cc[0]}");
-                    TryAddPhoneme(phonemes, ending.tone, $"{cc[0]}-", ValidateAlias($"{cc[0]}-"));
+                    TryAddPhoneme(phonemes, ending.tone, $"{cc[0]}{t}", ValidateAlias($"{cc[0]}{t}"));
                 }
             } else {
                 var vcc1 = $"{v} {string.Join("", cc)}";
@@ -444,7 +432,7 @@ namespace OpenUtau.Plugin.Builtin {
                         cc1 = ValidateAlias(cc1);
                     }
                     TryAddPhoneme(phonemes, ending.tone, cc1, ValidateAlias(cc1));
-                    TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()}-", ValidateAlias($"{cc.Last()}-"));
+                    TryAddPhoneme(phonemes, ending.tone, $"{cc.Last()}{t}", ValidateAlias($"{cc.Last()}{t}"));
                 }
             }
             return phonemes;

--- a/OpenUtau.Plugin.Builtin/SpanishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SpanishVCCVPhonemizer.cs
@@ -18,49 +18,39 @@ namespace OpenUtau.Plugin.Builtin {
         /// Based on the nJokis method.
         /// Supports automatic consonant substitutes, such as seseo, through ValidateAlias.
         ///</summary>
-        private const string YamlFile = "njokis_vccv.yaml";
+        protected override string YamlFileName => "njokis_vccv.yaml";
+        protected override byte[] YamlTemplate => Data.Resources.njokis_template;
+        protected override string YamlVersion => "1.0";
 
-        private string[] vowels = "a,e,i,o,u,BB,DD,ff,GG,ll,mm,nn,rrr,ss,xx".Split(',');
-        private readonly string[] consonants = "b,B,ch,d,D,E,f,g,G,h,I,jj,k,l,L,m,n,nJ,p,r,rr,s,sh,t,U,w,x,y,z".Split(',');
-        private readonly string[] shortConsonants = "r".Split(",");
-        private readonly string[] longConsonants = "ch,k,p,s,sh,t".Split(",");
-        private Dictionary<string, string> dictionaryReplacements = ("a=a;e=e;i=i;o=o;u=u;" +
+        public SpanishVCCVPhonemizer() {
+            this.vowels = "a,e,i,o,u,BB,DD,ff,GG,ll,mm,nn,rrr,ss,xx".Split(',');
+            this.consonants = "b,B,ch,d,D,E,f,g,G,h,I,jj,k,l,L,m,n,nJ,p,r,rr,s,sh,t,U,w,x,y,z".Split(',');
+            this.dictionaryReplacements = ("a=a;e=e;i=i;o=o;u=u;" +
                 "b=b;ch=ch;d=d;f=f;g=g;gn=nJ;k=k;l=l;ll=jj;m=m;n=n;p=p;r=r;rr=rr;s=s;t=t;w=w;x=x;y=y;z=z;I=I;U=U;B=B;D=D;G=G;Y=y").Split(';')
                 .Select(entry => entry.Split('='))
                 .Where(parts => parts.Length == 2)
                 .Where(parts => parts[0] != parts[1])
                 .ToDictionary(parts => parts[0], parts => parts[1]);
+        }
+
+        private bool isYamlFallbacks = false;
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;
         protected override string GetDictionaryName() => "cmudict_es.txt";
-        protected override Dictionary<string, string> GetDictionaryPhonemesReplacement() => dictionaryReplacements;
-        // Store the splitting replacements
-        private List<Replacement> splittingReplacements = new List<Replacement>();
-        // Store the merging replacements
-        private List<Replacement> mergingReplacements = new List<Replacement>();
-        private string[] tails = "-".Split(',');
-
-        private readonly Dictionary<string, string> replacements = "D=d".Split(';')
-                .Select(entry => entry.Split('='))
-                .Where(parts => parts.Length == 2)
-                .Where(parts => parts[0] != parts[1])
-                .ToDictionary(parts => parts[0], parts => parts[1]);
-        private bool isReplacements = false;
-
         protected override IG2p LoadBaseDictionary() {
             var g2ps = new List<IG2p>();
 
             // Load dictionary from plugin folder.
-            string path = Path.Combine(PluginDir, YamlFile);
+            string path = Path.Combine(PluginDir, YamlFileName);
             if (!File.Exists(path)) {
                 Directory.CreateDirectory(PluginDir);
-                File.WriteAllBytes(path, Data.Resources.njokis_template);
+                File.WriteAllBytes(path, YamlTemplate);
             }
             g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(path)).Build());
 
             // Load dictionary from singer folder.
             if (singer != null && singer.Found && singer.Loaded) {
-                string file = Path.Combine(singer.Location, YamlFile);
+                string file = Path.Combine(singer.Location, YamlFileName);
                 if (File.Exists(file)) {
                     try {
                         g2ps.Add(G2pDictionary.NewBuilder().Load(File.ReadAllText(file)).Build());
@@ -81,65 +71,17 @@ namespace OpenUtau.Plugin.Builtin {
             if (original == null) {
                 return null;
             }
-            List<string> modified = new List<string>(original);
-            List<string> finalPhonemes = new List<string>();
-            int i = 0;
-            bool hasReplacements = mergingReplacements.Any() == true || splittingReplacements.Any() == true; // Check for any replacements
-            if (hasReplacements) {
-                finalPhonemes = new List<string>();
-                while (i < modified.Count) {
-                    bool replaced = false;
-                    foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "inside")) {
-                        if (rule.from is string[] fromArray && i + fromArray.Length <= modified.Count) {
-                            bool match = true;
-                            for (int j = 0; j < fromArray.Length; j++) {
-                                if (modified[i + j] != fromArray[j]) {
-                                    match = false;
-                                    break;
-                                }
-                            }
-                            if (match) {
-                                if (rule.to is string toString) {
-                                    finalPhonemes.Add(toString);
-                                } else if (rule.to is string[] toArray) {
-                                    finalPhonemes.AddRange(toArray);
-                                }
-                                i += fromArray.Length;
-                                replaced = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!replaced && splittingReplacements.Any()) {
-                        string currentPhoneme = modified[i];
-                        bool singleReplaced = false;
-                        foreach (var rule in splittingReplacements.Where(r => r.where == "inside")) {
-                            if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                                singleReplaced = true;
-                                break;
-                            }
-                        }
-                        if (!singleReplaced) {
-                            finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        }
-                        i++;
-                    } else if (!replaced) {
-                        finalPhonemes.Add(ReplacePhoneme(modified[i], note.tone));
-                        i++;
-                    }
+            var mappedOriginal = new List<string>();
+            foreach (var p in original) {
+                if (dictionaryReplacements.ContainsKey(p)) {
+                    mappedOriginal.Add(dictionaryReplacements[p]);
+                } else {
+                    mappedOriginal.Add(p);
                 }
-            } else {
-                finalPhonemes = new List<string>(modified);
             }
             List<string> finalProcessedPhonemes = new List<string>();
             IEnumerable<string> phonemes;
-            if (hasReplacements) {
-                phonemes = finalPhonemes;
-            } else {
-                phonemes = original;
-            }
+            phonemes = mappedOriginal;
             foreach (string s in phonemes) {
                 switch (s) {
                     default:
@@ -148,147 +90,6 @@ namespace OpenUtau.Plugin.Builtin {
                 }
             }
             return finalProcessedPhonemes.ToArray();
-        }
-
-        public override void SetSinger(USinger singer) {
-            if (this.singer != singer) {
-                string file;
-                if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
-                    file = Path.Combine(singer.Location, YamlFile);
-                    if (!File.Exists(file)) {
-                        try {
-                            File.WriteAllBytes(file, Data.Resources.njokis_template);
-                        } catch (Exception e) {
-                            Log.Error(e, $"Failed to write '{YamlFile}' to singer folder at {file}");
-                        }
-                    }
-                } else if (!string.IsNullOrEmpty(PluginDir)) {
-                    file = Path.Combine(PluginDir, YamlFile);
-                } else {
-                    Log.Error("Singer location and PluginDir are both null or empty. Cannot locate '{YamlFile}'.");
-                    return; // Exit early to avoid null file issues
-                }
-
-                if (File.Exists(file)) {
-                    try {
-                        var data = Core.Yaml.DefaultDeserializer.Deserialize<NjokisYAMLData>(File.ReadAllText(file));
-
-                        // Load vowels
-                        try {
-                            var loadVowels = data.symbols
-                                ?.Where(s => s.type == "vowel")
-                                .Select(s => s.symbol)
-                                .ToList() ?? new List<string>();
-
-                            vowels = vowels.Concat(loadVowels).Distinct().ToArray();
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load vowels from {YamlFile}: {ex.Message}");
-                        }
-                        // Load replacements
-                        try {
-                            if (data?.replacements != null && data.replacements.Any() == true) {
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-
-                                foreach (var replacement in data.replacements) {
-                                    try {
-                                        string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
-                                        if (replacement.from != null && replacement.to != null) {
-                                            if (replacement.from is IEnumerable<object> fromList) {
-                                                // 'from' is a list (e.g., [ae, n])
-                                                string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
-                                                if (replacement.to is string toString) {
-                                                    mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else if (replacement.from is string fromString) {
-                                                // 'from' is a single string (e.g., tr, aw, ae, m, ng)
-                                                if (replacement.to is string toString) {
-                                                    dictionaryReplacements[fromString] = toString;
-                                                } else if (replacement.to is IEnumerable<object> toList) {
-                                                    splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
-                                                } else {
-                                                    Log.Error($"Error: Invalid 'to' type in replacement: {replacement}");
-                                                }
-                                            } else {
-                                                Log.Error($"Error: Invalid 'from' type in replacement: {replacement}");
-                                            }
-                                        } else {
-                                            Log.Error($"Error: 'from' or 'to' is null in replacement: {replacement}");
-                                        }
-                                    } catch (Exception ex) {
-                                        Log.Error($"Failed to process replacement entry: {replacement}. Error: {ex.Message}");
-                                    }
-                                }
-                            } else {
-                                mergingReplacements = new List<Replacement>();
-                                splittingReplacements = new List<Replacement>();
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load replacements from en-vccv.yaml: {ex.Message}");
-                        }
-                        // Load fallbacks
-                        try {
-                            if (data?.fallbacks?.Any() == true) {
-                                foreach (var df in data.fallbacks) {
-                                    if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
-                                        // Overwrite or add
-                                        replacements[df.from] = df.to;
-                                    } else {
-                                        Log.Warning("Ignored YAML fallback with missing 'from' or 'to' value.");
-                                    }
-                                }
-                            }
-                        } catch (Exception ex) {
-                            Log.Error($"Failed to load fallbacks from YAML: {ex.Message}");
-                        }
-
-                    } catch (Exception ex) {
-                        Log.Error($"Failed to parse {YamlFile}: {ex.Message}, Exception Type: {ex.GetType()}");
-                    }
-                }
-                ReadDictionaryAndInit();
-                this.singer = singer;
-            }
-        }
-        public class NjokisYAMLData {
-            public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
-            public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
-            public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
-
-            public struct SymbolData {
-                public string symbol { get; set; }
-                public string type { get; set; }
-            }
-            public struct Fallbacks {
-                public string from { get; set; }
-                public string to { get; set; }
-            }
-        }
-        // can split or merge
-        public class Replacement {
-            public object from { get; set; }
-            public object to { get; set; }
-            public string where { get; set; } = "inside";
-
-            public List<string> FromList {
-                get {
-                    if (from is string s) return new List<string> { s };
-                    if (from is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
-
-            public List<string> ToList {
-                get {
-                    if (to is string s) return new List<string> { s };
-                    if (to is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
-                    return new List<string>();
-                }
-            }
         }
 
         // prioritize yaml replacements over dictionary replacements
@@ -305,80 +106,11 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override List<string> ProcessSyllable(Syllable syllable) {
-            // Replacement for note boundaries
-            List<string> currentPhonemes = new List<string>();
-            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
-            bool hasV = !string.IsNullOrEmpty(syllable.v);
-
-            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
-            currentPhonemes.AddRange(syllable.cc);
-            if (hasV) currentPhonemes.Add(syllable.v);
-
-            List<string> finalPhonemes = new List<string>();
-            int idx = 0;
-            while (idx < currentPhonemes.Count) {
-                bool replaced = false;
-                foreach (var rule in mergingReplacements.Concat(splittingReplacements).Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                    if (rule.from is string[] fromArray && idx + fromArray.Length <= currentPhonemes.Count) {
-                        bool match = true;
-                        for (int j = 0; j < fromArray.Length; j++) {
-                            if (currentPhonemes[idx + j] != fromArray[j]) {
-                                match = false;
-                                break;
-                            }
-                        }
-                        if (match) {
-                            if (rule.to is string toString) {
-                                finalPhonemes.Add(toString);
-                            } else if (rule.to is string[] toArray) {
-                                finalPhonemes.AddRange(toArray);
-                            }
-                            idx += fromArray.Length;
-                            replaced = true;
-                            break;
-                        }
-                    }
-                }
-                
-                if (!replaced && splittingReplacements.Any()) {
-                    string currentPhoneme = currentPhonemes[idx];
-                    bool singleReplaced = false;
-                    foreach (var rule in splittingReplacements.Where(r => r.where == "all" || (hasPrevV && syllable.position == 0 && r.where == "boundary"))) {
-                        if (rule.from.ToString() == currentPhoneme && rule.to is string[] toArray) {
-                            finalPhonemes.AddRange(toArray);
-                            singleReplaced = true;
-                            break;
-                        }
-                    }
-                    if (!singleReplaced) {
-                        finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    }
-                    idx++;
-                } else if (!replaced) {
-                    finalPhonemes.Add(ReplacePhoneme(currentPhonemes[idx], syllable.tone));
-                    idx++;
-                }
-            }
-
-            string newPrevV = "";
-            string newV = "";
-            List<string> newCc = new List<string>();
-
-            if (finalPhonemes.Count > 0) {
-                if (hasPrevV) {
-                    newPrevV = finalPhonemes[0];
-                    finalPhonemes.RemoveAt(0);
-                }
-                if (hasV && finalPhonemes.Count > 0) {
-                    newV = finalPhonemes.Last();
-                    finalPhonemes.RemoveAt(finalPhonemes.Count - 1);
-                }
-                newCc.AddRange(finalPhonemes);
-            }
-            
-            var prevV = string.IsNullOrEmpty(newPrevV) ? "" : newPrevV;
-            string[] cc = newCc.ToArray();
-            string v = newV;
+            syllable.prevV = tails.Contains(syllable.prevV) ? "" : syllable.prevV;
+            var replacedPrevV = ReplacePhoneme(syllable.prevV, syllable.tone);
+            var prevV = string.IsNullOrEmpty(replacedPrevV) ? "" : replacedPrevV;
+            string[] cc = syllable.cc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
+            string v = ReplacePhoneme(syllable.v, syllable.vowelTone);
             List<string> vowels = new List<string> { v };
             string basePhoneme;
             var phonemes = new List<string>();
@@ -388,9 +120,9 @@ namespace OpenUtau.Plugin.Builtin {
             string[] PreviousWordCc = syllable.PreviousWordCc.Select(c => ReplacePhoneme(c, syllable.tone)).ToArray();
             int prevWordConsonantsCount = syllable.prevWordConsonantsCount;
 
-            foreach (var entry in replacements) {
+            foreach (var entry in yamlFallbacks) {
                 if (!HasOto(entry.Key, syllable.tone) && !HasOto(entry.Key, syllable.tone)) {
-                    isReplacements = true;
+                    isYamlFallbacks = true;
                     break;
                 }
             }
@@ -724,8 +456,8 @@ namespace OpenUtau.Plugin.Builtin {
             //foreach (var consonant in new[] { "y" }) {
             //    alias = alias.Replace("y", "i");
             // }
-            if (isReplacements) {
-                foreach (var syllable in replacements.OrderByDescending(f => f.Key.Length)) {
+            if (isYamlFallbacks) {
+                foreach (var syllable in yamlFallbacks.OrderByDescending(f => f.Key.Length)) {
                     alias = alias.Replace(syllable.Key, syllable.Value);
                 }
             }
@@ -758,16 +490,6 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         protected override double GetTransitionBasicLengthMs(string alias = "") {
-            foreach (var c in shortConsonants) {
-                if (alias.Contains(c) && !alias.Contains("rr") && !alias.StartsWith(c) && !alias.Contains("ar") && !alias.Contains("er") && !alias.Contains("ir") && !alias.Contains("or") && !alias.Contains("ur")) {
-                    return base.GetTransitionBasicLengthMs() * 0.50;
-                }
-            }
-            foreach (var c in longConsonants) {
-                if (alias.Contains(c) && !alias.StartsWith(c) && !alias.StartsWith("-" + c)) {
-                    return base.GetTransitionBasicLengthMs() * 2.0;
-                }
-            }
             return base.GetTransitionBasicLengthMs();
         }
     }

--- a/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
@@ -117,6 +117,11 @@ namespace OpenUtau.Plugin.Builtin {
             /// </summary>
             public string[] cc;
             /// <summary>
+            /// The exact lyric/symbol of the tail (e.g., "R", "br", "-", etc.)
+            /// </summary>
+            public string tail;
+            public bool HasTail => !string.IsNullOrEmpty(tail);
+            /// <summary>
             /// last note position + duration, all phonemes must be less than this
             /// </summary>
             public int position;
@@ -161,17 +166,44 @@ namespace OpenUtau.Plugin.Builtin {
 
             var phonemes = new List<Phoneme>();
             foreach (var syllable in syllables) {
-                // INTERCEPT: Apply boundary rules automatically before the child phonemizer sees it!
                 var modifiedSyllable = ApplyBoundaryReplacements(syllable);
+                
+                if (tails.Contains(modifiedSyllable.v)) {
+                    var ending = new Ending {
+                        prevV = modifiedSyllable.prevV,
+                        cc = modifiedSyllable.cc,
+                        tail = modifiedSyllable.v,
+                        position = modifiedSyllable.position,
+                        duration = modifiedSyllable.duration,
+                        tone = modifiedSyllable.tone,
+                        attr = modifiedSyllable.attr
+                    };
+                    
+                    var endingPhonemes = ProcessEnding(ending);
+                    
+                    if (endingPhonemes != null) {
+                        phonemes.AddRange(MakePhonemes(endingPhonemes, modifiedSyllable.duration, modifiedSyllable.position, false));
+                    }
+                    continue; 
+                }
                 phonemes.AddRange(MakePhonemes(ProcessSyllable(modifiedSyllable), modifiedSyllable.duration, modifiedSyllable.position, false));
             }
+
             if (!nextNeighbour.HasValue) {
                 var tryEnding = MakeEnding(notes);
                 if (tryEnding.HasValue) {
                     var ending = tryEnding.Value;
-                    // INTERCEPT: Apply ending boundary rules!
+
+                    if (nextNeighbour.HasValue && tails.Contains(nextNeighbour.Value.lyric)) {
+                        ending.tail = nextNeighbour.Value.lyric;
+                    }
+                    
                     var modifiedEnding = ApplyBoundaryReplacements(ending);
-                    phonemes.AddRange(MakePhonemes(ProcessEnding(modifiedEnding), modifiedEnding.duration, modifiedEnding.position, true));
+                    var endingPhonemes = ProcessEnding(modifiedEnding);
+
+                    if (endingPhonemes != null) {
+                        phonemes.AddRange(MakePhonemes(endingPhonemes, modifiedEnding.duration, modifiedEnding.position, true));
+                    }
                 }
             }
 
@@ -440,6 +472,10 @@ namespace OpenUtau.Plugin.Builtin {
                 if (lyrics == null) {
                     return new string[0];
                 } else return lyrics.Split(" ");
+            }
+
+            if (tails.Contains(note.lyric)) {
+                return new string[] { note.lyric };
             }
 
             if (hasDictionary) {

--- a/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
@@ -161,13 +161,17 @@ namespace OpenUtau.Plugin.Builtin {
 
             var phonemes = new List<Phoneme>();
             foreach (var syllable in syllables) {
-                phonemes.AddRange(MakePhonemes(ProcessSyllable(syllable), syllable.duration, syllable.position, false));
+                // INTERCEPT: Apply boundary rules automatically before the child phonemizer sees it!
+                var modifiedSyllable = ApplyBoundaryReplacements(syllable);
+                phonemes.AddRange(MakePhonemes(ProcessSyllable(modifiedSyllable), modifiedSyllable.duration, modifiedSyllable.position, false));
             }
             if (!nextNeighbour.HasValue) {
                 var tryEnding = MakeEnding(notes);
                 if (tryEnding.HasValue) {
                     var ending = tryEnding.Value;
-                    phonemes.AddRange(MakePhonemes(ProcessEnding(ending), ending.duration, ending.position, true));
+                    // INTERCEPT: Apply ending boundary rules!
+                    var modifiedEnding = ApplyBoundaryReplacements(ending);
+                    phonemes.AddRange(MakePhonemes(ProcessEnding(modifiedEnding), modifiedEnding.duration, modifiedEnding.position, true));
                 }
             }
 
@@ -219,11 +223,154 @@ namespace OpenUtau.Plugin.Builtin {
         }
 
         public override void SetSinger(USinger singer) {
-            this.singer = singer;
-            if (!hasDictionary) {
-                ReadDictionaryAndInit();
-            } else {
-                Init();
+            if (this.singer != singer) {
+                this.singer = singer;
+
+                if (this.singer == null || !this.singer.Loaded) {
+                    return;
+                }
+
+                if (string.IsNullOrEmpty(YamlFileName)) {
+                    if (backupVowels != null) this.vowels = backupVowels;
+                    else this.vowels = GetVowels();
+
+                    if (backupConsonants != null) this.consonants = backupConsonants;
+                    else this.consonants = GetConsonants();
+                    
+                    if (backupDictionaryReplacements != null) {
+                        dictionaryReplacements.Clear();
+                        foreach (var kvp in backupDictionaryReplacements) {
+                            dictionaryReplacements[kvp.Key] = kvp.Value;
+                        }
+                    }
+                    if (!hasDictionary) {
+                        ReadDictionaryAndInit();
+                    } else {
+                        Init();
+                    }
+                    return; 
+                }
+
+                string file = null;
+                if (singer != null && singer.Found && singer.Loaded && !string.IsNullOrEmpty(singer.Location)) {
+                    file = Path.Combine(singer.Location, YamlFileName);
+                } else if (!string.IsNullOrEmpty(PluginDir)) {
+                    file = Path.Combine(PluginDir, YamlFileName);
+                }
+
+                if (!string.IsNullOrEmpty(file)) {
+                    bool shouldWriteTemplate = false;
+                    bool shouldBackupOldFile = false;
+
+                    if (File.Exists(file)) {
+                        if (YamlTemplate != null && !string.IsNullOrEmpty(YamlVersion)) {
+                            try {
+                                var checkData = Core.Yaml.DefaultDeserializer.Deserialize<YAMLData>(File.ReadAllText(file));
+                                string currentVersion = checkData?.version?.Trim() ?? "";
+
+                                if (string.IsNullOrEmpty(currentVersion) || currentVersion != YamlVersion) {
+                                    shouldWriteTemplate = true;
+                                    shouldBackupOldFile = true;
+                                }
+                            } catch (Exception ex) {
+                                Log.Error(ex, $"Failed to read version from '{file}'. Backing up and resetting to template...");
+                                shouldWriteTemplate = true;
+                                shouldBackupOldFile = true;
+                            }
+                        }
+                    } else if (YamlTemplate != null) {
+                        shouldWriteTemplate = true;
+                    }
+
+                    if (shouldBackupOldFile && File.Exists(file)) {
+                        try {
+                            string backupFile = Path.Combine(Path.GetDirectoryName(file), $"{Path.GetFileNameWithoutExtension(YamlFileName)}_backup{Path.GetExtension(YamlFileName)}");
+                            if (File.Exists(backupFile)) File.Delete(backupFile);
+                            File.Move(file, backupFile);
+                            Log.Information($"Old {YamlFileName} backed up to {backupFile}");
+                        } catch (Exception e) {
+                            Log.Error(e, $"Failed to back up {YamlFileName}");
+                        }
+                    }
+
+                    if (shouldWriteTemplate) {
+                        try {
+                            File.WriteAllBytes(file, YamlTemplate);
+                            Log.Information($"'{file}' created or updated to version {YamlVersion ?? "default"}");
+                        } catch (Exception e) {
+                            Log.Error(e, $"Failed to write template to {file}");
+                        }
+                    }
+
+                    if (File.Exists(file)) {
+                        try {
+                            var data = Core.Yaml.DefaultDeserializer.Deserialize<YAMLData>(File.ReadAllText(file));
+                            
+                            if (backupVowels == null) backupVowels = GetVowels() ?? Array.Empty<string>();
+                            if (backupConsonants == null) backupConsonants = GetConsonants() ?? Array.Empty<string>();
+
+                            var yamlVowels = data.symbols?.Where(s => s.type == "vowel" || s.type == "diphthong").Select(s => s.symbol).ToArray() ?? Array.Empty<string>();
+                            vowels = backupVowels.Concat(yamlVowels).Distinct().ToArray();
+
+                            tails = (tails ?? Array.Empty<string>()).Concat(data.symbols?.Where(s => s.type == "tail").Select(s => s.symbol) ?? Array.Empty<string>()).Distinct().ToArray();
+                            
+                            fricative = data.symbols?.Where(s => s.type == "fricative").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+                            aspirate = data.symbols?.Where(s => s.type == "aspirate").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+                            semivowel = data.symbols?.Where(s => s.type == "semivowel").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+                            liquid = data.symbols?.Where(s => s.type == "liquid").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+                            nasal = data.symbols?.Where(s => s.type == "nasal").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+                            stop = data.symbols?.Where(s => s.type == "stop").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+                            tap = data.symbols?.Where(s => s.type == "tap").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+                            affricate = data.symbols?.Where(s => s.type == "affricate").Select(s => s.symbol).Distinct().ToArray() ?? Array.Empty<string>();
+
+                            var yamlConsonants = fricative.Concat(aspirate).Concat(semivowel).Concat(liquid).Concat(nasal).Concat(stop).Concat(tap).Concat(affricate).ToArray();
+                            consonants = backupConsonants.Concat(yamlConsonants).Distinct().ToArray();
+
+                            PhonemeOverrides = data.timings?.ToDictionary(t => t.symbol, t => t.value) ?? new Dictionary<string, double>();
+                            if (backupDictionaryReplacements == null) {
+                                backupDictionaryReplacements = new Dictionary<string, string>(dictionaryReplacements);
+                            }
+                            dictionaryReplacements.Clear();
+                            foreach (var kvp in backupDictionaryReplacements) {
+                                dictionaryReplacements[kvp.Key] = kvp.Value;
+                            }
+
+                            mergingReplacements.Clear();
+                            splittingReplacements.Clear();
+
+                            if (data?.replacements != null && data.replacements.Any()) {
+                                foreach (var replacement in data.replacements) {
+                                    string ruleScope = string.IsNullOrEmpty(replacement.where) ? "inside" : replacement.where.ToLowerInvariant();
+                                    if (replacement.from is IEnumerable<object> fromList) {
+                                        string[] fromArray = fromList.Select(item => item.ToString()).ToArray();
+                                        if (replacement.to is string toString) mergingReplacements.Add(new Replacement { from = fromArray, to = toString, where = ruleScope });
+                                        else if (replacement.to is IEnumerable<object> toList) splittingReplacements.Add(new Replacement { from = fromArray, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
+                                    } else if (replacement.from is string fromString) {
+                                        if (replacement.to is string toString) dictionaryReplacements[fromString] = toString;
+                                        else if (replacement.to is IEnumerable<object> toList) splittingReplacements.Add(new Replacement { from = fromString, to = toList.Select(item => item.ToString()).ToArray(), where = ruleScope });
+                                    }
+                                }
+                            }
+
+                            if (data?.fallbacks != null) {
+                                yamlFallbacks.Clear();
+                                foreach (var df in data.fallbacks) {
+                                    if (!string.IsNullOrEmpty(df.from) && !string.IsNullOrEmpty(df.to)) {
+                                        yamlFallbacks[df.from] = df.to;
+                                    }
+                                }
+                            }
+                        } catch (Exception ex) {
+                            Log.Error($"Failed to parse {YamlFileName}: {ex.Message}");
+                        }
+                    }
+                }
+
+                if (!hasDictionary) {
+                    ReadDictionaryAndInit();
+                } else {
+                    Init();
+                }
             }
         }
 
@@ -309,6 +456,15 @@ namespace OpenUtau.Plugin.Builtin {
                         if (subResult == null) {
                             return null;
                         }
+                    } else {
+                        for (int i = 0; i < subResult.Length; i++) {
+                            string phoneme = subResult[i];
+                            if (dictionaryReplacements.TryGetValue(phoneme, out string replaced)) {
+                                subResult[i] = replaced;
+                            } else if (dictionaryReplacements.TryGetValue(subResult[i], out string replacedExact)) {
+                                subResult[i] = replacedExact;
+                            }
+                        }
                     }
                     result.AddRange(subResult);
                 }
@@ -323,7 +479,12 @@ namespace OpenUtau.Plugin.Builtin {
         /// you may leave it be and provide symbol replacements with this method.
         /// </summary>
         /// <returns></returns>
-        protected virtual Dictionary<string, string> GetDictionaryPhonemesReplacement() { return null; }
+        protected virtual Dictionary<string, string> GetDictionaryPhonemesReplacement() {
+            return dictionaryReplacements ?? new Dictionary<string, string>();
+        }
+        private string[] backupVowels = null;
+        private string[] backupConsonants = null;
+        private Dictionary<string, string> backupDictionaryReplacements = null;
 
         /// <summary>
         /// separates symbols to syllables, without an ending.
@@ -447,10 +608,11 @@ namespace OpenUtau.Plugin.Builtin {
             if (symbols.Length == 0) {
                 symbols = new string[] { "" };
             }
+
+            symbols = ApplyReplacements(symbols.ToList(), false).ToArray();
             symbols = ApplyExtensions(symbols, notes);
             List<int> vowelIds = ExtractVowels(symbols);
             if (vowelIds.Count == 0) {
-                // no syllables or all consonants, the last phoneme will be interpreted as vowel
                 vowelIds.Add(symbols.Length - 1);
             }
             if (notes.Length < vowelIds.Count) {
@@ -674,6 +836,249 @@ namespace OpenUtau.Plugin.Builtin {
             return true;
         }
 
+        protected virtual string YamlFileName => null;
+        protected virtual byte[] YamlTemplate => null;
+        protected virtual string YamlVersion => null;
+
+        protected string[] vowels = Array.Empty<string>();
+        protected string[] consonants = Array.Empty<string>();
+        protected string[] tails = "-,R".Split(',');
+        protected string[] affricate = Array.Empty<string>();
+        protected string[] fricative = Array.Empty<string>();
+        protected string[] aspirate = Array.Empty<string>();
+        protected string[] semivowel = Array.Empty<string>();
+        protected string[] liquid = Array.Empty<string>();
+        protected string[] nasal = Array.Empty<string>();
+        protected string[] stop = Array.Empty<string>();
+        protected string[] tap = Array.Empty<string>();
+
+        protected Dictionary<string, string> dictionaryReplacements = new Dictionary<string, string>();
+        protected Dictionary<string, double> PhonemeOverrides = new Dictionary<string, double>();
+        protected Dictionary<string, string> yamlFallbacks = new Dictionary<string, string>();
+        protected List<string> consExceptions = new List<string>();
+
+        public class YAMLData {
+            public string version { get; set; }
+            public SymbolData[] symbols { get; set; } = Array.Empty<SymbolData>();
+            public Replacement[] replacements { get; set; } = Array.Empty<Replacement>();
+            public Fallbacks[] fallbacks { get; set; } = Array.Empty<Fallbacks>();
+            public Timings[] timings { get; set; } = Array.Empty<Timings>();
+
+            public struct SymbolData { public string symbol { get; set; } public string type { get; set; } }
+            public struct Fallbacks { public string from { get; set; } public string to { get; set; } }
+            public struct Timings { public string symbol { get; set; } public double value { get; set; } }
+        }
+
+        public class Replacement {
+            public object from { get; set; }
+            public object to { get; set; }
+            public string where { get; set; } = "inside";
+
+            public List<string> FromList {
+                get {
+                    if (from is string s) return new List<string> { s };
+                    if (from is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
+                    return new List<string>();
+                }
+            }
+
+            public List<string> ToList {
+                get {
+                    if (to is string s) return new List<string> { s };
+                    if (to is IEnumerable<object> list) return list.Select(x => x.ToString()).ToList();
+                    return new List<string>();
+                }
+            }
+        }
+
+        protected List<Replacement> mergingReplacements = new List<Replacement>();
+        protected List<Replacement> splittingReplacements = new List<Replacement>();
+
+        protected virtual bool IsGroupKeyword(string rulePhoneme) {
+            string baseGroup = rulePhoneme.Split(new[] { '!', '+' })[0];
+            return new[] { "vowel", "vowels", "consonant", "consonants", 
+                           "affricate", "fricative", "aspirate", "semivowel", 
+                           "liquid", "nasal", "stop", "tap" }.Contains(baseGroup);
+        }
+
+        protected virtual bool IsGroupMatch(string rulePhoneme, string actualPhoneme) {
+            string baseGroup = rulePhoneme.Split(new[] { '!', '+' })[0];
+            
+            if (rulePhoneme.Contains("!")) {
+                string[] exceptions = rulePhoneme.Split('!')[1].Split(',');
+                if (exceptions.Contains(actualPhoneme)) return false;
+            }
+            
+            if (rulePhoneme.Contains("+")) {
+                string[] inclusions = rulePhoneme.Split('+')[1].Split(',');
+                if (!inclusions.Contains(actualPhoneme)) return false;
+            }
+
+            switch (baseGroup) {
+                case "vowel": case "vowels": return GetVowels().Contains(actualPhoneme);
+                case "consonant": case "consonants": return GetConsonants().Contains(actualPhoneme);
+                case "affricate": return affricate.Contains(actualPhoneme);
+                case "fricative": return fricative.Contains(actualPhoneme);
+                case "aspirate": return aspirate.Contains(actualPhoneme);
+                case "semivowel": return semivowel.Contains(actualPhoneme);
+                case "liquid": return liquid.Contains(actualPhoneme);
+                case "nasal": return nasal.Contains(actualPhoneme);
+                case "stop": return stop.Contains(actualPhoneme);
+                case "tap": return tap.Contains(actualPhoneme);
+                default: return false;
+            }
+        }
+
+        protected virtual List<string> ApplyReplacements(List<string> inputPhonemes, bool isBoundary) {
+            if (!mergingReplacements.Any() && !splittingReplacements.Any()) return inputPhonemes;
+
+            List<string> finalPhonemes = new List<string>();
+            int idx = 0;
+            
+            var validRules = mergingReplacements.Concat(splittingReplacements)
+                .Where(r => r.where == "all" || (!isBoundary && r.where == "inside") || (isBoundary && r.where == "boundary")).ToList();
+                
+            var validSplits = splittingReplacements
+                .Where(r => r.where == "all" || (!isBoundary && r.where == "inside") || (isBoundary && r.where == "boundary")).ToList();
+
+            while (idx < inputPhonemes.Count) {
+                bool replaced = false;
+                foreach (var rule in validRules) {
+                    if (rule.from is string[] fromArray && idx + fromArray.Length <= inputPhonemes.Count) {
+                        bool match = true;
+                        var captures = new Dictionary<string, Queue<string>>();
+                        
+                        for (int j = 0; j < fromArray.Length; j++) {
+                            string rulePh = fromArray[j];
+                            string actualPh = inputPhonemes[idx + j];
+                            
+                            if (IsGroupKeyword(rulePh)) {
+                                if (IsGroupMatch(rulePh, actualPh)) {
+                                    if (!captures.ContainsKey(rulePh)) captures[rulePh] = new Queue<string>();
+                                    captures[rulePh].Enqueue(actualPh);
+                                } else {
+                                    match = false; break;
+                                }
+                            } else if (rulePh != actualPh) {
+                                match = false; break;
+                            }
+                        }
+                        
+                        if (match) {
+                            if (rule.to is string toString) {
+                                finalPhonemes.Add(IsGroupKeyword(toString) && captures.ContainsKey(toString) && captures[toString].Count > 0 ? captures[toString].Dequeue() : toString);
+                            } else if (rule.to is string[] toArray) {
+                                foreach (string toPh in toArray) {
+                                    finalPhonemes.Add(IsGroupKeyword(toPh) && captures.ContainsKey(toPh) && captures[toPh].Count > 0 ? captures[toPh].Dequeue() : toPh);
+                                }
+                            }
+                            idx += fromArray.Length;
+                            replaced = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!replaced && validSplits.Any()) {
+                    string currentPhoneme = inputPhonemes[idx];
+                    bool singleReplaced = false;
+                    foreach (var rule in validSplits) {
+                        string rulePh = rule.from.ToString();
+                        if (IsGroupKeyword(rulePh) ? IsGroupMatch(rulePh, currentPhoneme) : rulePh == currentPhoneme) {
+                            if (rule.to is string[] toArray) {
+                                foreach(string toPh in toArray) {
+                                    finalPhonemes.Add(toPh == rulePh ? currentPhoneme : toPh);
+                                }
+                                singleReplaced = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!singleReplaced) finalPhonemes.Add(inputPhonemes[idx]);
+                    idx++;
+                } else if (!replaced) {
+                    finalPhonemes.Add(inputPhonemes[idx]);
+                    idx++;
+                }
+            }
+            return finalPhonemes;
+        }
+
+        private Syllable ApplyBoundaryReplacements(Syllable syllable) {
+            if (!mergingReplacements.Any() && !splittingReplacements.Any()) return syllable;
+
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(syllable.prevV);
+            bool hasV = !string.IsNullOrEmpty(syllable.v);
+
+            if (hasPrevV) currentPhonemes.Add(syllable.prevV);
+            if (syllable.cc != null) currentPhonemes.AddRange(syllable.cc);
+            if (hasV) currentPhonemes.Add(syllable.v);
+
+            bool isBoundary = hasPrevV && syllable.position == 0;
+            List<string> finalPhonemes = ApplyReplacements(currentPhonemes, isBoundary);
+
+            string newPrevV = "";
+            string newV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                if (hasV && finalPhonemes.Count > 0) {
+                    var vowelsList = GetVowels();
+                    int vIndex = finalPhonemes.Count - 1;
+                    
+                    for (int i = finalPhonemes.Count - 1; i >= 0; i--) {
+                        if (vowelsList.Contains(finalPhonemes[i])) {
+                            vIndex = i;
+                            break;
+                        }
+                    }
+                    newV = finalPhonemes[vIndex];
+                    for (int i = 0; i < vIndex; i++) {
+                        newCc.Add(finalPhonemes[i]);
+                    }
+                } else {
+                    newCc.AddRange(finalPhonemes);
+                }
+            }
+            
+            syllable.prevV = newPrevV;
+            syllable.cc = newCc.ToArray();
+            syllable.v = newV;
+            return syllable;
+        }
+
+        private Ending ApplyBoundaryReplacements(Ending ending) {
+            if (!mergingReplacements.Any() && !splittingReplacements.Any()) return ending;
+
+            List<string> currentPhonemes = new List<string>();
+            bool hasPrevV = !string.IsNullOrEmpty(ending.prevV);
+
+            if (hasPrevV) currentPhonemes.Add(ending.prevV);
+            if (ending.cc != null) currentPhonemes.AddRange(ending.cc);
+
+            List<string> finalPhonemes = ApplyReplacements(currentPhonemes, true);
+
+            string newPrevV = "";
+            List<string> newCc = new List<string>();
+
+            if (finalPhonemes.Count > 0) {
+                if (hasPrevV) {
+                    newPrevV = finalPhonemes[0];
+                    finalPhonemes.RemoveAt(0);
+                }
+                newCc.AddRange(finalPhonemes);
+            }
+            
+            ending.prevV = newPrevV;
+            ending.cc = newCc.ToArray();
+            return ending;
+        }
+
         #endregion
 
         #region private
@@ -704,16 +1109,28 @@ namespace OpenUtau.Plugin.Builtin {
         private void ReadDictionary(string dictionaryName) {
             try {
                 var phonemeSymbols = new Dictionary<string, bool>();
+                
                 foreach (var vowel in GetVowels()) {
-                    phonemeSymbols.Add(vowel, true);
+                    phonemeSymbols[vowel] = true; 
                 }
                 foreach (var consonant in GetConsonants()) {
-                    phonemeSymbols.Add(consonant, false);
+                    phonemeSymbols[consonant] = false;
                 }
+
+                var childDict = GetDictionaryPhonemesReplacement() ?? new Dictionary<string, string>();
+                var safeDict = new Dictionary<string, string>();
+                
+                foreach (var kvp in childDict) {
+                    safeDict[kvp.Key] = kvp.Value;
+                    safeDict[kvp.Key.ToUpperInvariant()] = kvp.Value; // Safely catches 'AA'
+                    safeDict[kvp.Key.ToLowerInvariant()] = kvp.Value; // Safely catches 'aa'
+                }
+
                 dictionaries[GetType()] = new G2pRemapper(
                     LoadBaseDictionary(),
                     phonemeSymbols,
-                    GetDictionaryPhonemesReplacement());
+                    safeDict); 
+
             } catch (Exception ex) {
                 Log.Error(ex, $"Failed to read dictionary {dictionaryName}");
             }

--- a/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/SyllableBasedPhonemizer.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Serilog;
 using System.Threading.Tasks;
 using static OpenUtau.Api.Phonemizer;
+using System.Collections;
 
 namespace OpenUtau.Plugin.Builtin {
     /// <summary>
@@ -931,38 +932,54 @@ namespace OpenUtau.Plugin.Builtin {
         protected List<Replacement> splittingReplacements = new List<Replacement>();
 
         protected virtual bool IsGroupKeyword(string rulePhoneme) {
-            string baseGroup = rulePhoneme.Split(new[] { '!', '+' })[0];
+            string baseGroup = rulePhoneme.Split(new[] { '!', '=', '+' })[0];
             return new[] { "vowel", "vowels", "consonant", "consonants", 
                            "affricate", "fricative", "aspirate", "semivowel", 
                            "liquid", "nasal", "stop", "tap" }.Contains(baseGroup);
         }
 
         protected virtual bool IsGroupMatch(string rulePhoneme, string actualPhoneme) {
-            string baseGroup = rulePhoneme.Split(new[] { '!', '+' })[0];
-            
-            if (rulePhoneme.Contains("!")) {
-                string[] exceptions = rulePhoneme.Split('!')[1].Split(',');
-                if (exceptions.Contains(actualPhoneme)) return false;
-            }
-            
+            string baseGroup = rulePhoneme.Split(new[] { '!', '=', '+' })[0];
             if (rulePhoneme.Contains("+")) {
-                string[] inclusions = rulePhoneme.Split('+')[1].Split(',');
-                if (!inclusions.Contains(actualPhoneme)) return false;
+                string added = rulePhoneme.Substring(rulePhoneme.IndexOf('+') + 1).Split(new[] { '!', '=' })[0];
+                // If it matches another group name, or a literal letter, it passes
+                foreach (string inc in added.Split(',')) {
+                    if (IsGroupKeyword(inc) ? IsGroupMatch(inc, actualPhoneme) : inc == actualPhoneme) {
+                        return true;
+                    }
+                }
             }
 
+            // BASE GROUP: If it wasn't an addition, it must belong to the base group.
+            bool inBaseGroup = false;
             switch (baseGroup) {
-                case "vowel": case "vowels": return GetVowels().Contains(actualPhoneme);
-                case "consonant": case "consonants": return GetConsonants().Contains(actualPhoneme);
-                case "affricate": return affricate.Contains(actualPhoneme);
-                case "fricative": return fricative.Contains(actualPhoneme);
-                case "aspirate": return aspirate.Contains(actualPhoneme);
-                case "semivowel": return semivowel.Contains(actualPhoneme);
-                case "liquid": return liquid.Contains(actualPhoneme);
-                case "nasal": return nasal.Contains(actualPhoneme);
-                case "stop": return stop.Contains(actualPhoneme);
-                case "tap": return tap.Contains(actualPhoneme);
-                default: return false;
+                case "vowel": case "vowels": inBaseGroup = GetVowels().Contains(actualPhoneme); break;
+                case "consonant": case "consonants": inBaseGroup = GetConsonants().Contains(actualPhoneme); break;
+                case "affricate": inBaseGroup = affricate.Contains(actualPhoneme); break;
+                case "fricative": inBaseGroup = fricative.Contains(actualPhoneme); break;
+                case "aspirate": inBaseGroup = aspirate.Contains(actualPhoneme); break;
+                case "semivowel": inBaseGroup = semivowel.Contains(actualPhoneme); break;
+                case "liquid": inBaseGroup = liquid.Contains(actualPhoneme); break;
+                case "nasal": inBaseGroup = nasal.Contains(actualPhoneme); break;
+                case "stop": inBaseGroup = stop.Contains(actualPhoneme); break;
+                case "tap": inBaseGroup = tap.Contains(actualPhoneme); break;
             }
+
+            if (!inBaseGroup) return false;
+
+            // EXCLUSIONS (!): Reject if it's in the excluded list.
+            if (rulePhoneme.Contains("!")) {
+                string excluded = rulePhoneme.Substring(rulePhoneme.IndexOf('!') + 1).Split(new[] { '=', '+' })[0];
+                if (excluded.Split(',').Contains(actualPhoneme)) return false;
+            }
+
+            // RESTRICTIONS (=): Reject if an equals list exists, and the phoneme isn't in it.
+            if (rulePhoneme.Contains("=")) {
+                string restricted = rulePhoneme.Substring(rulePhoneme.IndexOf('=') + 1).Split(new[] { '!', '+' })[0];
+                if (!restricted.Split(',').Contains(actualPhoneme)) return false;
+            }
+
+            return true;
         }
 
         protected virtual List<string> ApplyReplacements(List<string> inputPhonemes, bool isBoundary) {
@@ -979,8 +996,16 @@ namespace OpenUtau.Plugin.Builtin {
 
             while (idx < inputPhonemes.Count) {
                 bool replaced = false;
+                
                 foreach (var rule in validRules) {
-                    if (rule.from is string[] fromArray && idx + fromArray.Length <= inputPhonemes.Count) {
+                    string[] fromArray = null;
+                    if (rule.from is IList fromList) {
+                        fromArray = fromList.Cast<object>().Select(x => x?.ToString()).ToArray();
+                    } else if (rule.from is string[] strArr) {
+                        fromArray = strArr;
+                    }
+
+                    if (fromArray != null && fromArray.Length > 0 && idx + fromArray.Length <= inputPhonemes.Count) {
                         bool match = true;
                         var captures = new Dictionary<string, Queue<string>>();
                         
@@ -1001,13 +1026,21 @@ namespace OpenUtau.Plugin.Builtin {
                         }
                         
                         if (match) {
-                            if (rule.to is string toString) {
-                                finalPhonemes.Add(IsGroupKeyword(toString) && captures.ContainsKey(toString) && captures[toString].Count > 0 ? captures[toString].Dequeue() : toString);
-                            } else if (rule.to is string[] toArray) {
+                            string[] toArray = null;
+                            if (rule.to is IList toList) {
+                                toArray = toList.Cast<object>().Select(x => x?.ToString()).ToArray();
+                            } else if (rule.to is string[] strArr) {
+                                toArray = strArr;
+                            } else if (rule.to is string toStr) {
+                                toArray = new string[] { toStr };
+                            }
+
+                            if (toArray != null) {
                                 foreach (string toPh in toArray) {
                                     finalPhonemes.Add(IsGroupKeyword(toPh) && captures.ContainsKey(toPh) && captures[toPh].Count > 0 ? captures[toPh].Dequeue() : toPh);
                                 }
                             }
+                            
                             idx += fromArray.Length;
                             replaced = true;
                             break;
@@ -1019,12 +1052,28 @@ namespace OpenUtau.Plugin.Builtin {
                     string currentPhoneme = inputPhonemes[idx];
                     bool singleReplaced = false;
                     foreach (var rule in validSplits) {
-                        string rulePh = rule.from.ToString();
+                        if (rule.from is IList || rule.from is string[]) continue;
+
+                        string rulePh = rule.from?.ToString();
+                        if (rulePh == null) continue;
+
                         if (IsGroupKeyword(rulePh) ? IsGroupMatch(rulePh, currentPhoneme) : rulePh == currentPhoneme) {
-                            if (rule.to is string[] toArray) {
+                            
+                            string[] toArray = null;
+                            if (rule.to is IList toList) {
+                                toArray = toList.Cast<object>().Select(x => x?.ToString()).ToArray();
+                            } else if (rule.to is string[] strArr) {
+                                toArray = strArr;
+                            }
+
+                            if (toArray != null) {
                                 foreach(string toPh in toArray) {
                                     finalPhonemes.Add(toPh == rulePh ? currentPhoneme : toPh);
                                 }
+                                singleReplaced = true;
+                                break;
+                            } else if (rule.to is string toStr) {
+                                finalPhonemes.Add(toStr == rulePh ? currentPhoneme : toStr);
                                 singleReplaced = true;
                                 break;
                             }


### PR DESCRIPTION
**Introduced a new parameter to specify the scope of the replacement:**
- `all`: Applies to all phonemes, including word boundaries.
- `inside`:  Applies only within notes (maintains the current default behavior).
- `boundary`: Applies only to boundary transitions (e.g., word-to-word transitions).
*Note*: The `where` parameter is optional and defaults to `inside` if not added to the replacement entries.
---
**Example replacement entries:**
```
 - {from: [d, r], to: [d, q, r], where: boundary}
 - {from: [n, b], to: [m, b], where: boundary}
 - {from: [t, r], to: tr, where: inside}
 - {from: aw1, to: [ae, w], where: all}
 - {from: ax, to: ah}
```