### PR TITLE
Fix expression panel rendering and layering

### DIFF
--- a/OpenUtau/Controls/PianoRoll.axaml
+++ b/OpenUtau/Controls/PianoRoll.axaml
@@ -624,6 +624,9 @@
       <GridSplitter Grid.Row="4" Grid.ColumnSpan="3" Height="10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
                     Background="{DynamicResource SystemControlBackgroundAltHighBrush}" IsVisible="{Binding NotesViewModel.ShowExpressions}"
                     Focusable="False" Cursor="SizeNorthSouth"/>
+      <Rectangle Grid.Row="5" Grid.Column="1" IsHitTestVisible="False"
+                 IsVisible="{Binding NotesViewModel.ShowExpressions}"
+                 Fill="{DynamicResource SystemControlBackgroundAltHighBrush}"/>
       <c:TrackBackground Grid.Row="5" Grid.Column="1" IsHitTestVisible="False"
                          IsVisible="{Binding NotesViewModel.ShowExpressions}"
                          Foreground="{DynamicResource TrackBackgroundAltBrush}"

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -168,6 +168,7 @@ namespace OpenUtau.App.ViewModels {
                             ExpTrackHeight = t.Item1.Height / descriptor.options.Length;
                             ExpShadowOpacity = 0;
                         } else {
+                            ExpTrackHeight = 0;
                             ExpShadowOpacity = 0.3;
                         }
                         ShowCurveToolbox = descriptor.type == UExpressionType.Curve;

--- a/OpenUtau/ViewModels/NotesViewModel.cs
+++ b/OpenUtau/ViewModels/NotesViewModel.cs
@@ -167,6 +167,8 @@ namespace OpenUtau.App.ViewModels {
                         if (descriptor.type == UExpressionType.Options && descriptor.options.Length > 0) {
                             ExpTrackHeight = t.Item1.Height / descriptor.options.Length;
                             ExpShadowOpacity = 0;
+                        } else {
+                            ExpShadowOpacity = 0.3;
                         }
                         ShowCurveToolbox = descriptor.type == UExpressionType.Curve;
                     } else {


### PR DESCRIPTION
Fixed two bugs related with expression panel:
1. The semi-transparent background expression isn't shown as expected
2. A layering issue causes singer portrait to bleed into expression panel

Before:
<img width="2497" height="1360" alt="image" src="https://github.com/user-attachments/assets/4a1d432e-fdbb-42d1-b3f2-9f7bbf7a6082" />

After:
<img width="2416" height="1364" alt="image" src="https://github.com/user-attachments/assets/b3b1643a-4a84-4d70-938a-5297a6bbb94a" />
