### PR TITLE
Add extra logs folder instruction to bug-report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -52,6 +52,7 @@ body:
       description: |
         Find the log corresponding to the bug and attach it here.
         Log files are under Logs folder.
+        The Logs folder can be opened through `Help` > `Open Logs Location`.
         When in doubt, delete all log files, reproduce the bug, and attach the new log file.
     validations:
       required: true


### PR DESCRIPTION
Some people seem to still be confused about how to find the logs folder, so I've added an extra line explaining how to access it from inside OpenUtau.