### PR TITLE
fix(EnglishCpVPhonemizer): assign this.singer before ReadDictionaryAndInit

### DIFF
--- a/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishCpVPhonemizer.cs
@@ -523,8 +523,8 @@ namespace OpenUtau.Plugin.Builtin {
                         Log.Error($"Failed to parse en-cPv.yaml: {ex.Message}, Exception Type: {ex.GetType()}");
                     }
                 }
-                ReadDictionaryAndInit();
                 this.singer = singer;
+                ReadDictionaryAndInit();
             }
         }
 


### PR DESCRIPTION
## Problem
`EnglishCpVPhonemizer.SetSinger()` calls `ReadDictionaryAndInit()` before
assigning `this.singer`. `ReadDictionaryAndInit()` loads the base dictionary
which references `singer.Found` — a `NullReferenceException` is thrown,
caught silently inside `ReadDictionary`, leaving `dict` null.

Subsequent `Process()` calls then return a single empty-string phoneme
for every input.

## Repro
Build `OpenUtau.Test` and run:
```csharp
var phonemizer = new EnglishCpVPhonemizer();
phonemizer.SetSinger(anyLoadedSinger);  // dict stays null
var result = phonemizer.Process(note, ...);  // returns [""]
```

## Fix
Swap the two lines in `SetSinger` so `this.singer` is set before init.

## Impact
Makes `EnglishCpVPhonemizer` actually work in headless test environments
and any scenario where `ReadDictionaryAndInit` runs before a real `Process`.

Discovered during conformance testing against an en_liee voicebank.
Prior to this fix, tests had to use a reflection workaround to set
`this.singer` before invoking `SetSinger`.