### PR TITLE
ZH CVV+ Phonemizer missing prefix map suffix for non-tail notes

### DIFF
--- a/OpenUtau.Plugin.Builtin/ChineseCVVPlusPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/ChineseCVVPlusPhonemizer.cs
@@ -354,7 +354,7 @@ namespace OpenUtau.Plugin.Builtin {
                 return new Result {
                     phonemes = new Phoneme[] {
                         new Phoneme() {
-                            phoneme = phoneme, // Output the entered lyrics.
+                            phoneme = GetOtoAlias(singer, phoneme, notes[0]), // 防止无尾音歌词在多音阶情况下丢失prefix map suffix
                         }
                     }
                 };


### PR DESCRIPTION
Phonemizer only applies `GetOtoAlias` to notes that trigger the tail vowel logic (e.g., 'ai', 'an'), simple notes like 'da', 'wu', or 'gi' that do not require a tail vowel were bypassing this mapping. 