### PR TITLE
ci: fix pr-test workflow

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -20,7 +20,7 @@ jobs:
             arch: linux-x64
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-dotnet@v4
       with:
@@ -33,3 +33,4 @@ jobs:
 
     - name: test
       run: dotnet test OpenUtau.Test
+      timeout-minutes: 30

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -12,16 +12,12 @@ jobs:
         os: 
           - runs-on: windows-latest
             arch: win-x64
-          - runs-on: windows-11-arm
-            arch: win-arm64
           - runs-on: macos-15-intel
             arch: osx-x64
           - runs-on: macos-latest
             arch: osx-arm64
           - runs-on: ubuntu-latest
             arch: linux-x64
-          - runs-on: ubuntu-24.04-arm
-            arch: linux-arm64
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Fixes to `.github/workflows/pr-test.yml`:

- **Drop Windows ARM and Linux ARM** from the test matrix — reduces CI time and runner cost
- **Update `actions/checkout@v1` → `@v4`** — v1 is ancient and deprecated
- **Add `timeout-minutes: 30`** to the test step — prevents hung runs from consuming minutes forever

Remaining platforms: Windows x64, macOS x64, macOS arm64, Linux x64