### PR TITLE
Fix NuGet restore flakiness on MyGet outage (add nuget.org fallback)

### DIFF
--- a/OpenUtau/nuget.config
+++ b/OpenUtau/nuget.config
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- 
-  To use the Avalonia CI feed to get unstable packages, move this file to the root of your solution.
--->
-
 <configuration>
   <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="AvaloniaCI" value="https://www.myget.org/F/avalonia-ci/api/v2" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The `OpenUtau/nuget.config` only listed the MyGet Avalonia CI feed (`myget.org/F/avalonia-ci`). When that feed returns HTTP 500 (intermittent outage), `dotnet restore` has no fallback source and fails with NU1301 for packages like HarfBuzzSharp, Material.Avalonia, etc.

**Fix:** Added `<clear />` and `<add key="nuget.org">` so restore can fall back to stable packages on nuget.org. The AvaloniaCI feed is kept as a secondary source.

Relevant failing CI runs (macos-15-intel, windows-latest) all hit the same pattern:
```
error NU1301: Failed to retrieve information ... Response status code ... 500 (Internal Server Error)
```
from `https://www.myget.org/F/avalonia-ci/...`