### PR TITLE
Fix mono audio bug

### DIFF
--- a/OpenUtau.Core/PlaybackManager.cs
+++ b/OpenUtau.Core/PlaybackManager.cs
@@ -320,7 +320,7 @@ namespace OpenUtau.Core {
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exporting to {exportPath}."));
 
                     CheckFileWritable(exportPath);
-                    WaveFileWriter.CreateWaveFile16(exportPath, new ExportAdapter(projectMix).ToMono(1, 0));
+                    WaveFileWriter.CreateWaveFile16(exportPath, new ExportAdapter(projectMix));
                     DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exported to {exportPath}."));
                 } catch (IOException ioe) {
                     var customEx = new MessageCustomizableException($"Failed to export {exportPath}.", $"<translate:errors.failed.export>: {exportPath}", ioe);
@@ -349,7 +349,7 @@ namespace OpenUtau.Core {
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exporting to {file}."));
 
                         CheckFileWritable(file);
-                        WaveFileWriter.CreateWaveFile16(file, new ExportAdapter(trackMixes[i]).ToMono(1, 0));
+                        WaveFileWriter.CreateWaveFile16(file, new ExportAdapter(trackMixes[i]));
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exported to {file}."));
                     }
                 } catch (IOException ioe) {

--- a/OpenUtau.Core/PlaybackManager.cs
+++ b/OpenUtau.Core/PlaybackManager.cs
@@ -349,7 +349,7 @@ namespace OpenUtau.Core {
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exporting to {file}."));
 
                         CheckFileWritable(file);
-                        WaveFileWriter.CreateWaveFile16(file, new ExportAdapter(trackMixes[i]));
+                        WaveFileWriter.CreateWaveFile16(file, new ExportAdapter(trackMixes[i]).ToMono(1, 1));
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"Exported to {file}."));
                     }
                 } catch (IOException ioe) {


### PR DESCRIPTION
**Mixdown Mono Audio Bug**
- Current implementation results in the 'Mixdown To Wave' audio render to produce a Mono output, in which only the left channel contributes to the Mono output
-  This results in audio panning information entered by the user from being lost, and for imported audio tracks which utilise both channels from being improperly mixed down when rendering.
- Render Waves per Track also faces issue of being improperly mixed down (Left channel contribution)

Solution:
- 'Mixdown To Wave' results in stereo output as to align with how OpenUTAU renders the audio within the track player.
- 'Render To Files' is rendered as Mono, but both Left and Right channels contribute to the output for any edge cases where both channels are necessary for the correct output.