### PR TITLE
Fix #2089: Set IlcInstructionSet to sse4.2 for self-contained builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         run: dotnet restore OpenUtau -r ${{ matrix.arch.rid }}
 
       - name: Build (Windows and Linux)
-        run: dotnet publish OpenUtau -c Release -r ${{ matrix.arch.rid }} --self-contained true -o bin/${{ matrix.arch.name }}/
+        run: dotnet publish OpenUtau -c Release -r ${{ matrix.arch.rid }} --self-contained true -p:IlcInstructionSet=sse4.2 -o bin/${{ matrix.arch.name }}/
         if: ${{ matrix.arch.os != 'osx' }}
 
       - name: Build (MacOS)


### PR DESCRIPTION
This PR fixes #2089.

Added `-p:IlcInstructionSet=sse4.2` to the dotnet publish command for Windows and Linux self-contained builds.

This allows OpenUtau to run on older CPUs that don't support AVX2 (e.g., Intel Celeron 4205U).

Tested on Celeron 4205U with Windows 10 - all features work without crash.