### PR TITLE
Added a track selection feature

### DIFF
--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -2,7 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:controls="clr-namespace:OpenUtau.App.Controls"
              xmlns:vm="using:OpenUtau.App.ViewModels"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="104"
              x:Class="OpenUtau.App.Controls.TrackHeader" Width="300" Height="104" TrackNo="{Binding TrackNo}">

--- a/OpenUtau/Controls/TrackHeader.axaml
+++ b/OpenUtau/Controls/TrackHeader.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:OpenUtau.App.Controls"
              xmlns:vm="using:OpenUtau.App.ViewModels"
              mc:Ignorable="d" d:DesignWidth="300" d:DesignHeight="104"
              x:Class="OpenUtau.App.Controls.TrackHeader" Width="300" Height="104" TrackNo="{Binding TrackNo}">
@@ -76,7 +77,8 @@
       </ContextMenu.Styles>
     </ContextMenu>
   </UserControl.Resources>
-  <Border Margin="1,1,1,1" BorderThickness="1" BorderBrush="{DynamicResource NeutralAccentBrushSemi}" CornerRadius="2">
+  <Border Margin="1,1,1,1" BorderThickness="1" BorderBrush="{Binding HeaderBorderBrush}"
+           CornerRadius="2" PointerPressed="HeaderPointerPressed">
     <Grid ColumnDefinitions="auto,*,auto" Background="Transparent">
       <Panel Grid.Column="0" VerticalAlignment="Stretch">
         <Border BorderThickness="0,0,1,1" MaxHeight="101" VerticalAlignment="Top" CornerRadius="0,0,2,0"

--- a/OpenUtau/Controls/TrackHeader.axaml.cs
+++ b/OpenUtau/Controls/TrackHeader.axaml.cs
@@ -44,12 +44,15 @@ namespace OpenUtau.App.Controls {
         private double trackHeight;
         private Point offset;
         private int trackNo;
+        private readonly KeyModifiers cmdKey =
+            OS.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
 
         public TrackHeaderViewModel? ViewModel;
 
         private List<IDisposable> unbinds = new List<IDisposable>();
 
         private UTrack? track;
+        private TrackHeaderCanvas? canvas;
 
         public TrackHeader() {
             InitializeComponent();
@@ -66,6 +69,7 @@ namespace OpenUtau.App.Controls {
 
         internal void Bind(UTrack track, TrackHeaderCanvas canvas) {
             this.track = track;
+            this.canvas = canvas;
             unbinds.Add(this.Bind(TrackHeightProperty, canvas.GetObservable(TrackHeaderCanvas.TrackHeightProperty)));
             unbinds.Add(this.Bind(HeightProperty, canvas.GetObservable(TrackHeaderCanvas.TrackHeightProperty)));
             unbinds.Add(this.Bind(OffsetProperty, canvas.WhenAnyValue(x => x.TrackOffset, trackOffset => new Point(0, -trackOffset * TrackHeight))));
@@ -79,6 +83,21 @@ namespace OpenUtau.App.Controls {
                 ViewModel.IsSingerVisible = trackHeight >= ViewConstants.TrackHeightDelta * 3;
                 ViewModel.IsPhonemizerVisible = trackHeight >= ViewConstants.TrackHeightDelta * 4;
                 ViewModel.IsRendererVisible = trackHeight >= ViewConstants.TrackHeightDelta * 5;
+            }
+        }
+
+        void HeaderPointerPressed(object? sender, PointerPressedEventArgs args) {
+            if (!args.GetCurrentPoint(this).Properties.IsLeftButtonPressed ||
+                track == null ||
+                canvas?.DataContext is not TracksViewModel tracksViewModel) {
+                return;
+            }
+            if (args.KeyModifiers == KeyModifiers.Shift) {
+                tracksViewModel.SelectTracksUntil(track);
+            } else if (args.KeyModifiers == cmdKey) {
+                tracksViewModel.ToggleSelectTrack(track);
+            } else {
+                tracksViewModel.SelectTrack(track);
             }
         }
 

--- a/OpenUtau/Controls/TrackHeaderCanvas.cs
+++ b/OpenUtau/Controls/TrackHeaderCanvas.cs
@@ -100,9 +100,10 @@ namespace OpenUtau.App.Controls {
                 });
             MessageBus.Current.Listen<TrackSelectionEvent>()
                 .Subscribe(e => {
+                    var selectedTracks = new HashSet<UTrack>(e.selectedTracks);
                     foreach (var (track, header) in trackHeaders) {
                         if (header.ViewModel != null) {
-                            header.ViewModel.IsSelected = e.selectedTracks.Contains(track);
+                            header.ViewModel.IsSelected = selectedTracks.Contains(track);
                         }
                     }
                 });

--- a/OpenUtau/Controls/TrackHeaderCanvas.cs
+++ b/OpenUtau/Controls/TrackHeaderCanvas.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Reactive.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using OpenUtau.App.ViewModels;
-using OpenUtau.Core;
 using OpenUtau.Core.Ustx;
 using ReactiveUI;
 
@@ -98,6 +98,20 @@ namespace OpenUtau.App.Controls {
                         }
                     }
                 });
+            MessageBus.Current.Listen<TrackSelectionEvent>()
+                .Subscribe(e => {
+                    foreach (var (track, header) in trackHeaders) {
+                        if (header.ViewModel != null) {
+                            header.ViewModel.IsSelected = e.selectedTracks.Contains(track);
+                        }
+                    }
+                });
+            MessageBus.Current.Listen<ThemeChangedEvent>()
+                .Subscribe(_ => {
+                    foreach (var (_, header) in trackHeaders) {
+                        header.ViewModel?.RefreshSelectionStyle();
+                    }
+                });
         }
 
         protected override void OnInitialized() {
@@ -153,6 +167,9 @@ namespace OpenUtau.App.Controls {
 
         void Add(UTrack track) {
             var vm = new TrackHeaderViewModel(track);
+            if (DataContext is TracksViewModel tracksViewModel) {
+                vm.IsSelected = tracksViewModel.SelectedTracks.Contains(track);
+            }
             var header = new TrackHeader() {
                 DataContext = vm,
                 ViewModel = vm,

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reactive;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -40,10 +39,12 @@ namespace OpenUtau.App.ViewModels {
         [Reactive] public bool Mute { get; set; }
         [Reactive] public bool Muted { get; set; }
         [Reactive] public bool Solo { get; set; }
+        [Reactive] public bool IsSelected { get; set; }
         [Reactive] public Bitmap? Avatar { get; set; }
-        [Reactive] public bool IsSingerVisible  { get; set; }
-        [Reactive] public bool IsPhonemizerVisible  { get; set; }
-        [Reactive] public bool IsRendererVisible  { get; set; }
+        [Reactive] public bool IsSingerVisible { get; set; }
+        [Reactive] public bool IsPhonemizerVisible { get; set; }
+        [Reactive] public bool IsRendererVisible { get; set; }
+        [Reactive] public IBrush HeaderBorderBrush { get; set; } = ThemeManager.NeutralAccentBrushSemi;
 
         public ViewModelActivator Activator { get; }
 
@@ -56,6 +57,9 @@ namespace OpenUtau.App.ViewModels {
             SelectRendererCommand = ReactiveCommand.Create<string>(_ => { });
             Activator = new ViewModelActivator();
             track = new UTrack(DocManager.Inst.Project);
+            this.WhenAnyValue(x => x.IsSelected)
+                .Subscribe(_ => RefreshSelectionStyle());
+            RefreshSelectionStyle();
         }
 
         public TrackHeaderViewModel(UTrack track) {
@@ -63,36 +67,16 @@ namespace OpenUtau.App.ViewModels {
             SelectSingerCommand = ReactiveCommand.Create<USinger>(singer => {
                 if (track.Singer != singer) {
                     DocManager.Inst.StartUndoGroup("command.track.singer");
-                    Log.Information($"Loading Singer: {singer.Name}");
-                    DocManager.Inst.ExecuteCmd(new TrackChangeSingerCommand(DocManager.Inst.Project, track, singer));
-                    if (!string.IsNullOrEmpty(singer?.Id) &&
-                        Preferences.Default.SingerPhonemizers.TryGetValue(Singer.Id, out var phonemizerName) &&
-                        TryChangePhonemizer(phonemizerName)) {
-                    } else if (!string.IsNullOrEmpty(singer?.DefaultPhonemizer)) {
-                        TryChangePhonemizer(singer.DefaultPhonemizer);
-                    }
-                    if (singer == null || !singer.Found) {
-                        var settings = new URenderSettings();
-                        DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, track, settings));
-                    } else if (singer.SingerType != track.RendererSettings.Renderer?.SingerType) {
-                        var settings = new URenderSettings {
-                            renderer = Core.Render.Renderers.GetDefaultRenderer(singer.SingerType),
-                        };
-                        DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, track, settings));
-                    }
+                    ApplySingerToTrack(track, singer);
                     DocManager.Inst.ExecuteCmd(new VoiceColorRemappingNotification(track.TrackNo, true));
                     DocManager.Inst.EndUndoGroup();
-                    if (!string.IsNullOrEmpty(singer?.Id) && singer.Found) {
-                        Preferences.Default.RecentSingers.Remove(singer.Id);
-                        Preferences.Default.RecentSingers.Insert(0, singer.Id);
-                        if (Preferences.Default.RecentSingers.Count > 16) {
-                            Preferences.Default.RecentSingers.RemoveRange(
-                                16, Preferences.Default.RecentSingers.Count - 16);
-                        }
-                    }
+                    UpdateRecentSingers(singer);
                     Preferences.Save();
                     MessageBus.Current.SendMessage(new PianorollRefreshEvent("Part"));
                 }
+                Preferences.Save();
+                MessageBus.Current.SendMessage(new PianorollRefreshEvent("Part"));
+                MessageBus.Current.SendMessage(new TracksRefreshEvent());
                 this.RaisePropertyChanged(nameof(Singer));
                 this.RaisePropertyChanged(nameof(Renderer));
                 RefreshAvatar();
@@ -130,14 +114,6 @@ namespace OpenUtau.App.ViewModels {
             });
 
             Activator = new ViewModelActivator();
-            this.WhenActivated((CompositeDisposable disposables) => {
-                Disposable.Create(() => {
-                    MessageBus.Current.Listen<TracksRefreshEvent>()
-                        .Subscribe(_ => {
-                            ManuallyRaise();
-                        }).DisposeWith(disposables);
-                });
-            });
 
             TrackName = track.TrackName;
             TrackAccentColor = ThemeManager.GetTrackColor(track.TrackColor).AccentColor;
@@ -172,8 +148,17 @@ namespace OpenUtau.App.ViewModels {
                 .Subscribe(solo => {
                     track.Solo = solo;
                 });
+            this.WhenAnyValue(x => x.IsSelected)
+                .Subscribe(_ => RefreshSelectionStyle());
 
             RefreshAvatar();
+            RefreshSelectionStyle();
+        }
+
+        public void RefreshSelectionStyle() {
+            HeaderBorderBrush = IsSelected
+                ? TrackAccentColor
+                : ThemeManager.NeutralAccentBrushSemi;
         }
 
         public void ToggleSolo() {
@@ -234,12 +219,63 @@ namespace OpenUtau.App.ViewModels {
             this.RaisePropertyChanged(nameof(Muted));
         }
 
-        private bool TryChangePhonemizer(string phonemizerName) {
+        private static bool IsTrackSelected(UTrack projectTrack) {
+            var tracksViewModel = (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)
+                ?.MainWindow?.DataContext as MainWindowViewModel;
+            return tracksViewModel?.TracksViewModel.SelectedTracks.Contains(projectTrack) == true;
+        }
+
+        private void ApplySingerToTrack(UTrack targetTrack, USinger? singer) {
+            if (singer is USinger selectedSinger) {
+                Log.Information($"Loading Singer: {selectedSinger.Name}");
+                DocManager.Inst.ExecuteCmd(new TrackChangeSingerCommand(DocManager.Inst.Project, targetTrack, selectedSinger));
+                if (!string.IsNullOrEmpty(selectedSinger.Id) &&
+                    Preferences.Default.SingerPhonemizers.TryGetValue(selectedSinger.Id, out var phonemizerName) &&
+                    TryChangePhonemizer(targetTrack, phonemizerName)) {
+                } else if (!string.IsNullOrEmpty(selectedSinger.DefaultPhonemizer)) {
+                    TryChangePhonemizer(targetTrack, selectedSinger.DefaultPhonemizer);
+                }
+                if (selectedSinger.SingerType != targetTrack.RendererSettings.Renderer?.SingerType) {
+                    var settings = new URenderSettings();
+                    if (selectedSinger.Found) {
+                        settings = new URenderSettings {
+                            renderer = Core.Render.Renderers.GetDefaultRenderer(selectedSinger.SingerType),
+                        };
+                    }
+                    DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, targetTrack, settings));
+                }
+            } else {
+                DocManager.Inst.ExecuteCmd(new TrackChangeSingerCommand(DocManager.Inst.Project, targetTrack, USinger.CreateMissing(string.Empty)));
+                var settings = new URenderSettings();
+                DocManager.Inst.ExecuteCmd(new TrackChangeRenderSettingCommand(DocManager.Inst.Project, targetTrack, settings));
+            }
+        }
+
+        private void UpdateRecentSingers(USinger? singer) {
+            if (!string.IsNullOrEmpty(singer?.Id) && singer.Found) {
+                Preferences.Default.RecentSingers.Remove(singer.Id);
+                Preferences.Default.RecentSingers.Insert(0, singer.Id);
+                if (Preferences.Default.RecentSingers.Count > 16) {
+                    Preferences.Default.RecentSingers.RemoveRange(
+                        16, Preferences.Default.RecentSingers.Count - 16);
+                }
+            }
+        }
+
+        private SingerMenuItemViewModel CreateSingerMenuItem(USinger singer) {
+            return new SingerMenuItemViewModel() {
+                Header = singer.LocalizedName,
+                Command = SelectSingerCommand,
+                CommandParameter = singer,
+            };
+        }
+
+        private bool TryChangePhonemizer(UTrack targetTrack, string phonemizerName) {
             try {
                 var factory = PhonemizerFactory.Get(phonemizerName);
                 var phonemizer = factory?.Create();
                 if (phonemizer != null) {
-                    DocManager.Inst.ExecuteCmd(new TrackChangePhonemizerCommand(DocManager.Inst.Project, track, phonemizer));
+                    DocManager.Inst.ExecuteCmd(new TrackChangePhonemizerCommand(DocManager.Inst.Project, targetTrack, phonemizer));
                     return true;
                 }
             } catch (Exception e) {
@@ -254,33 +290,21 @@ namespace OpenUtau.App.ViewModels {
                 items.AddRange(Preferences.Default.RecentSingers
                 .Select(id => SingerManager.Inst.Singers.Values.FirstOrDefault(singer => singer.Id == id))
                 .OfType<USinger>()
-                .Select(singer => new SingerMenuItemViewModel() {
-                    Header = singer.LocalizedName,
-                    Command = SelectSingerCommand,
-                    CommandParameter = singer,
-                }));
-                items.Add(new SingerMenuItemViewModel() {
+                .Select(CreateSingerMenuItem));
+                items.Add(new MenuItemViewModel() {
                     Header = ThemeManager.GetString("tracks.favorite") + " ...",
                     Items = Preferences.Default.FavoriteSingers
                         .Select(id => SingerManager.Inst.Singers.Values.FirstOrDefault(singer => singer.Id == id))
                         .OfType<USinger>()
                         .LocalizedOrderBy(singer => singer.LocalizedName)
-                        .Select(singer => new SingerMenuItemViewModel() {
-                            Header = singer.LocalizedName,
-                            Command = SelectSingerCommand,
-                            CommandParameter = singer,
-                        }).ToArray(),
+                        .Select(CreateSingerMenuItem).ToArray(),
                 });
                 var keys = SingerManager.Inst.SingerGroups.Keys.OrderBy(k => k);
                 foreach (var key in keys) {
-                    items.Add(new SingerMenuItemViewModel() {
+                    items.Add(new MenuItemViewModel() {
                         Header = $"{key} ...",
                         Items = SingerManager.Inst.SingerGroups[key]
-                            .Select(singer => new SingerMenuItemViewModel() {
-                                Header = singer.LocalizedName,
-                                Command = SelectSingerCommand,
-                                CommandParameter = singer,
-                            }).ToArray(),
+                            .Select(CreateSingerMenuItem).ToArray(),
                     });
                 }
             } else {
@@ -453,8 +477,17 @@ namespace OpenUtau.App.ViewModels {
         }
 
         public void ManuallyRaise() {
+            TrackName = track.TrackName;
+            TrackAccentColor = ThemeManager.GetTrackColor(track.TrackColor).AccentColor;
+            TrackColor = Preferences.Default.UseTrackColor
+                ? ThemeManager.GetTrackColor(track.TrackColor)
+                : ThemeManager.GetTrackColor("Blue");
+            RefreshSelectionStyle();
             this.RaisePropertyChanged(nameof(Singer));
             this.RaisePropertyChanged(nameof(TrackNo));
+            this.RaisePropertyChanged(nameof(TrackName));
+            this.RaisePropertyChanged(nameof(TrackAccentColor));
+            this.RaisePropertyChanged(nameof(TrackColor));
             this.RaisePropertyChanged(nameof(Phonemizer));
             this.RaisePropertyChanged(nameof(PhonemizerTag));
             this.RaisePropertyChanged(nameof(Renderer));
@@ -517,6 +550,7 @@ namespace OpenUtau.App.ViewModels {
                 TrackColor = Preferences.Default.UseTrackColor
                 ? ThemeManager.GetTrackColor(track.TrackColor)
                 : ThemeManager.GetTrackColor("Blue");
+                RefreshSelectionStyle();
             }
         }
 

--- a/OpenUtau/ViewModels/TrackHeaderViewModel.cs
+++ b/OpenUtau/ViewModels/TrackHeaderViewModel.cs
@@ -74,8 +74,6 @@ namespace OpenUtau.App.ViewModels {
                     Preferences.Save();
                     MessageBus.Current.SendMessage(new PianorollRefreshEvent("Part"));
                 }
-                Preferences.Save();
-                MessageBus.Current.SendMessage(new PianorollRefreshEvent("Part"));
                 MessageBus.Current.SendMessage(new TracksRefreshEvent());
                 this.RaisePropertyChanged(nameof(Singer));
                 this.RaisePropertyChanged(nameof(Renderer));
@@ -219,12 +217,6 @@ namespace OpenUtau.App.ViewModels {
             this.RaisePropertyChanged(nameof(Muted));
         }
 
-        private static bool IsTrackSelected(UTrack projectTrack) {
-            var tracksViewModel = (Application.Current?.ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)
-                ?.MainWindow?.DataContext as MainWindowViewModel;
-            return tracksViewModel?.TracksViewModel.SelectedTracks.Contains(projectTrack) == true;
-        }
-
         private void ApplySingerToTrack(UTrack targetTrack, USinger? singer) {
             if (singer is USinger selectedSinger) {
                 Log.Information($"Loading Singer: {selectedSinger.Name}");
@@ -235,7 +227,7 @@ namespace OpenUtau.App.ViewModels {
                 } else if (!string.IsNullOrEmpty(selectedSinger.DefaultPhonemizer)) {
                     TryChangePhonemizer(targetTrack, selectedSinger.DefaultPhonemizer);
                 }
-                if (selectedSinger.SingerType != targetTrack.RendererSettings.Renderer?.SingerType) {
+                if (!selectedSinger.Found || selectedSinger.SingerType != targetTrack.RendererSettings.Renderer?.SingerType) {
                     var settings = new URenderSettings();
                     if (selectedSinger.Found) {
                         settings = new URenderSettings {

--- a/OpenUtau/ViewModels/TracksViewModel.cs
+++ b/OpenUtau/ViewModels/TracksViewModel.cs
@@ -31,6 +31,12 @@ namespace OpenUtau.App.ViewModels {
             this.allmute = allmute;
         }
     }
+    public class TrackSelectionEvent {
+        public readonly UTrack[] selectedTracks;
+        public TrackSelectionEvent(UTrack[] selectedTracks) {
+            this.selectedTracks = selectedTracks;
+        }
+    }
     public class PartsSelectionEvent {
         public readonly UPart[] selectedParts;
         public readonly UPart[] tempSelectedParts;
@@ -94,6 +100,7 @@ namespace OpenUtau.App.ViewModels {
         private readonly ObservableAsPropertyHelper<double> smallChangeY;
 
         public readonly List<UPart> SelectedParts = new List<UPart>();
+        public readonly List<UTrack> SelectedTracks = new List<UTrack>();
         private readonly HashSet<UPart> TempSelectedParts = new HashSet<UPart>();
 
         public TracksViewModel() {
@@ -265,6 +272,44 @@ namespace OpenUtau.App.ViewModels {
                     SelectedParts.ToArray(), TempSelectedParts.ToArray()));
         }
 
+        public void DeselectTracks() {
+            SelectedTracks.Clear();
+            MessageBus.Current.SendMessage(new TrackSelectionEvent(SelectedTracks.ToArray()));
+        }
+
+        public void SelectTrack(UTrack track) {
+            if (SelectedTracks.Count == 1 && SelectedTracks[0] == track) {
+                return;
+            }
+            SelectedTracks.Clear();
+            SelectedTracks.Add(track);
+            MessageBus.Current.SendMessage(new TrackSelectionEvent(SelectedTracks.ToArray()));
+        }
+
+        public void ToggleSelectTrack(UTrack track) {
+            if (SelectedTracks.Contains(track)) {
+                SelectedTracks.Remove(track);
+            } else {
+                SelectedTracks.Add(track);
+            }
+            MessageBus.Current.SendMessage(new TrackSelectionEvent(SelectedTracks.ToArray()));
+        }
+
+        public void SelectTracksUntil(UTrack track) {
+            if (SelectedTracks.Count == 0) {
+                SelectTrack(track);
+                return;
+            }
+            int start = SelectedTracks.Min(selected => selected.TrackNo);
+            int end = track.TrackNo;
+            if (start > end) {
+                (start, end) = (end, start);
+            }
+            SelectedTracks.Clear();
+            SelectedTracks.AddRange(Project.tracks.Where(t => start <= t.TrackNo && t.TrackNo <= end));
+            MessageBus.Current.SendMessage(new TrackSelectionEvent(SelectedTracks.ToArray()));
+        }
+
         public void SelectPart(UPart part) {
             TempSelectedParts.Clear();
             SelectedParts.Add(part);
@@ -424,19 +469,23 @@ namespace OpenUtau.App.ViewModels {
                 } else if (cmd is RemoveTrackCommand removeTrack) {
                     if (!isUndo) {
                         Tracks.Remove(removeTrack.track);
+                        SelectedTracks.Remove(removeTrack.track);
                     } else {
                         Tracks.Add(removeTrack.track);
                     }
                 }
                 Notify();
                 MessageBus.Current.SendMessage(new TracksRefreshEvent());
+                MessageBus.Current.SendMessage(new TrackSelectionEvent(SelectedTracks.ToArray()));
             } else if (cmd is UNotification) {
                 if (cmd is LoadProjectNotification loadProjectNotif) {
                     Parts.Clear();
                     Parts.AddRange(loadProjectNotif.project.parts);
                     Tracks.Clear();
                     Tracks.AddRange(loadProjectNotif.project.tracks);
+                    SelectedTracks.Clear();
                     MessageBus.Current.SendMessage(new TracksRefreshEvent());
+                    MessageBus.Current.SendMessage(new TrackSelectionEvent(SelectedTracks.ToArray()));
                 } else if (cmd is SetPlayPosTickNotification setPlayPosTick) {
                     SetPlayPos(setPlayPosTick.playPosTick, setPlayPosTick.waitingRendering);
                     if (!setPlayPosTick.pause || Preferences.Default.LockStartTime == 1) {
@@ -446,6 +495,9 @@ namespace OpenUtau.App.ViewModels {
                     if (SelectedParts.Count != 1 || SelectedParts.First() != loadPartNotif.part) {
                         DeselectParts();
                         SelectPart(loadPartNotif.part);
+                    }
+                    if (0 <= loadPartNotif.part.trackNo && loadPartNotif.part.trackNo < Project.tracks.Count) {
+                        SelectTrack(Project.tracks[loadPartNotif.part.trackNo]);
                     }
                 }
                 Notify();


### PR DESCRIPTION
This is a pull request that splits #2055.
This pull request introduces multi-track selection capabilities and visual improvements to the track header in OpenUtau. The most significant changes include adding track selection logic (including shift/control/cmd multi-select), updating the UI to reflect selection state, and refactoring the track header view model for better maintainability and style updates.

**Multi-track selection and UI feedback:**

* Added `TrackSelectionEvent` and `SelectedTracks` list to `TracksViewModel` to manage and broadcast track selection state, enabling multi-track selection via Shift and Ctrl/Cmd keys. (`OpenUtau/ViewModels/TracksViewModel.cs` [[1]](diffhunk://#diff-48cd1b5fc31fe44c8d073a32a900218ac81b8e48f045b939d9ca75661fc76f3dR34-R39) [[2]](diffhunk://#diff-48cd1b5fc31fe44c8d073a32a900218ac81b8e48f045b939d9ca75661fc76f3dR103)
* Implemented pointer handling in `TrackHeader` to support single, range (Shift), and toggle (Ctrl/Cmd) selection of tracks, and bound border color to selection state. (`OpenUtau/Controls/TrackHeader.axaml`, `OpenUtau/Controls/TrackHeader.axaml.cs` [[1]](diffhunk://#diff-e96107afa8a9e7462c049d0fadfcfef04860eafcf45b13d721ad71c3794dcdb6R5) [[2]](diffhunk://#diff-e96107afa8a9e7462c049d0fadfcfef04860eafcf45b13d721ad71c3794dcdb6L79-R81) [[3]](diffhunk://#diff-ff9cf060a39d650cba13c7119dd845ba2dd5782b64556b2bf91c047581f039a6R47-R55) [[4]](diffhunk://#diff-ff9cf060a39d650cba13c7119dd845ba2dd5782b64556b2bf91c047581f039a6R72) [[5]](diffhunk://#diff-ff9cf060a39d650cba13c7119dd845ba2dd5782b64556b2bf91c047581f039a6R89-R103)
* Updated `TrackHeaderViewModel` to include `IsSelected` and `HeaderBorderBrush` properties, and to update its appearance when selection changes. (`OpenUtau/ViewModels/TrackHeaderViewModel.cs` [[1]](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7R42-R47) [[2]](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7R60-R79) [[3]](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7R151-R161) [[4]](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7R480-R490) [[5]](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7R553)

**Synchronization and style refresh:**

* `TrackHeaderCanvas` now listens for `TrackSelectionEvent` and `ThemeChangedEvent` to update header selection and styling in real-time. (`OpenUtau/Controls/TrackHeaderCanvas.cs` [OpenUtau/Controls/TrackHeaderCanvas.csR101-R114](diffhunk://#diff-ac01e30de305ab4840e6740cec6ac516dfc394463da712751082b459bdf903aeR101-R114))
* When adding a track header, its selection state is initialized based on the current selection. (`OpenUtau/Controls/TrackHeaderCanvas.cs` [OpenUtau/Controls/TrackHeaderCanvas.csR170-R172](diffhunk://#diff-ac01e30de305ab4840e6740cec6ac516dfc394463da712751082b459bdf903aeR170-R172))

**Code refactoring and maintainability:**

* Refactored singer selection logic in `TrackHeaderViewModel` for better code reuse and clarity, and extracted helper methods. (`OpenUtau/ViewModels/TrackHeaderViewModel.cs` [[1]](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7R60-R79) [[2]](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7L237-R278) [[3]](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7L257-R307)
* Removed unnecessary activation/disposal logic from `TrackHeaderViewModel`. (`OpenUtau/ViewModels/TrackHeaderViewModel.cs` [OpenUtau/ViewModels/TrackHeaderViewModel.csL133-L140](diffhunk://#diff-7b53ebe1989cec5d8268101e3556802dd6f891b736ee5e158ce0d8278b4439e7L133-L140))

These changes collectively improve the usability and maintainability of the track selection and header UI in OpenUtau, providing a more intuitive and visually responsive user experience.