### PR TITLE
Unify DiffSinger scripts (.ds) exporting, support variance expressions

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -37,12 +37,7 @@ namespace OpenUtau.Core.DiffSinger {
         };
 
         private static readonly Dictionary<string, Func<float, float, float>> varianceDeltaFunctions =
-            new Dictionary<string, Func<float, float, float>>() {
-                {ENE, (x, y) => x + y * 12 / 100},
-                {Format.Ustx.BREC, (x, y) => x + y * 12 / 100},
-                {Format.Ustx.VOIC, (x, y) => x + (y - 100) * 12 / 100},
-                {Format.Ustx.TENC, (x, y) => x + y / 20},
-            };
+            DiffSingerUtils.VarianceDeltaFunctions;
 
         static readonly object lockObj = new object();
 

--- a/OpenUtau.Core/DiffSinger/DiffSingerScript.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerScript.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -9,29 +9,37 @@ using OpenUtau.Core.Render;
 using OpenUtau.Core.Ustx;
 
 namespace OpenUtau.Core.DiffSinger {
+    public class DsScriptExportOptions {
+        public bool exportPitch = true;
+        public bool exportVariance = false;
+    }
+
     public class DiffSingerScript{
         public double offsetMs;
         public string[] text;
         public string[] ph_seq;
         public double[] phDurMs;
-        public int[] ph_num;//number of phonemes in each note's time range, excluding slur notes
-        public int[] noteSeq;//notenum per note, including slur notes
-        public double[] noteDurMs;//duration in ms per note, including slur notes
-        public int[] note_slur;//1 if slur, 0 if not, per note, including slur notes
+        public int[] ph_num;
+        public int[] noteSeq;
+        public double[] noteDurMs;
+        public int[] note_slur;
         public double[]? f0_seq = null;
         public double frameMs;
         public double[]? gender = null;
         public double[]? velocity = null;
-        
-        //if v2 is true, export diffsinger script for diffsinger's refactor-v2 branch
-        public DiffSingerScript(RenderPhrase phrase, bool v2 = false, bool exportPitch = true) {
+        public double[]? energy = null;
+        public double[]? breathiness = null;
+        public double[]? voicing = null;
+        public double[]? tension = null;
+
+        public DiffSingerScript(RenderPhrase phrase, DsScriptExportOptions options) {
             float headMs = DiffSingerUtils.GetHeadMs(phrase);
             float tailMs = DiffSingerUtils.GetTailMs(phrase);
 
             var notes = phrase.notes;
             var phones = phrase.phones;
             DiffSingerSinger singer = phrase.singer as DiffSingerSinger;
-            
+
             text = notes.Select(n => n.lyric)
                 .Where(s=>!s.StartsWith("+"))
                 .Prepend("SP")
@@ -49,7 +57,7 @@ namespace OpenUtau.Core.DiffSinger {
                 .ToArray();
             //ph_num
             var phNumList = new List<int>();
-            int ep = 4;//the max error between note position and phoneme position is 4 ticks
+            int ep = 4;
             int prevNotePhId = 0;
             int phId = 0;
             int phCount = phones.Length;
@@ -61,71 +69,53 @@ namespace OpenUtau.Core.DiffSinger {
                 prevNotePhId = phId;
             }
             phNumList.Add(phCount - prevNotePhId);
-            phNumList.Add(1);//tail AP
-            ++phNumList[0];//head AP
+            phNumList.Add(1);
+            ++phNumList[0];
             ph_num = phNumList.ToArray();
 
-            if(v2){
-                //Build note arrays with rest notes inserted for gaps between notes
-                var noteSeqList = new List<int> { 0 };//head padding
-                var noteDurList = new List<double> { headMs+(notes[0].positionMs-phones[0].positionMs) };
-                var noteSlurList = new List<int> { 0 };//head padding
-                double prevNoteEndMs = notes[0].positionMs;
-                foreach(var note in notes) {
-                    double gapMs = note.positionMs - prevNoteEndMs;
-                    if (gapMs > 0) {
-                        //Insert a rest note for the gap
-                        noteSeqList.Add(0);
-                        noteDurList.Add(gapMs);
-                        noteSlurList.Add(0);
-                    }
-                    noteSeqList.Add((note.lyric == "SP" || note.lyric == "AP") ? 0 : note.tone);
-                    noteDurList.Add(note.durationMs);
-                    noteSlurList.Add(note.lyric.StartsWith("+") ? 1 : 0);
-                    prevNoteEndMs = note.positionMs + note.durationMs;
+            //Build note arrays with rest notes inserted for gaps between notes
+            var noteSeqList = new List<int> { 0 };//head padding
+            var noteDurList = new List<double> { headMs+(notes[0].positionMs-phones[0].positionMs) };
+            var noteSlurList = new List<int> { 0 };//head padding
+            double prevNoteEndMs = notes[0].positionMs;
+            foreach(var note in notes) {
+                double gapMs = note.positionMs - prevNoteEndMs;
+                if (gapMs > 0) {
+                    //Insert a rest note for the gap
+                    noteSeqList.Add(0);
+                    noteDurList.Add(gapMs);
+                    noteSlurList.Add(0);
                 }
-                noteSeqList.Add(0);//tail padding
-                noteDurList.Add(tailMs);
-                noteSlurList.Add(0);//tail padding
-                noteSeq = noteSeqList.ToArray();
-                noteDurMs = noteDurList.ToArray();
-                note_slur = noteSlurList.ToArray();
-            }else{
-                noteSeq = phones
-                    .Select(p => (p.phoneme == "SP" || p.phoneme == "AP") ? 0 : p.tone)
-                    .Prepend(0)
-                    .Append(0)
-                    .ToArray();
-                noteDurMs = notes
-                    .Select(n => n.durationMs)
-                    .Prepend(headMs+(notes[0].positionMs-phones[0].positionMs))
-                    .Append(tailMs)
-                    .ToArray();
-                note_slur = notes
-                    .Select(n => n.lyric.StartsWith("+") ? 1 : 0)
-                    .Prepend(0)
-                    .Append(0)
-                    .ToArray();
+                noteSeqList.Add((note.lyric == "SP" || note.lyric == "AP") ? 0 : note.tone);
+                noteDurList.Add(note.durationMs);
+                noteSlurList.Add(note.lyric.StartsWith("+") ? 1 : 0);
+                prevNoteEndMs = note.positionMs + note.durationMs;
             }
-            
+            noteSeqList.Add(0);//tail padding
+            noteDurList.Add(tailMs);
+            noteSlurList.Add(0);//tail padding
+            noteSeq = noteSeqList.ToArray();
+            noteDurMs = noteDurList.ToArray();
+            note_slur = noteSlurList.ToArray();
+
             frameMs = singer?.dsConfig.frameMs() ?? 10;
-            
+
             var phDurFrames = DiffSingerUtils.DurationsMsToFrames(phDurMs, frameMs);
             int headFrames = phDurFrames[0];
             int tailFrames = phDurFrames[^1];
             var totalFrames = phDurFrames.Sum();
 
             //f0
-            if(exportPitch){
-                f0_seq = DiffSingerUtils.SampleCurve(phrase, phrase.pitches, 
-                    0, frameMs, totalFrames, headFrames, tailFrames, 
+            if(options.exportPitch){
+                f0_seq = DiffSingerUtils.SampleCurve(phrase, phrase.pitches,
+                    0, frameMs, totalFrames, headFrames, tailFrames,
                     x => MusicMath.ToneToFreq(x * 0.01));
             }
 
             //velc
             var velocityCurve = phrase.curves.FirstOrDefault(curve => curve.Item1 == DiffSingerUtils.VELC);
             if (velocityCurve != null) {
-                velocity = DiffSingerUtils.SampleCurve(phrase, velocityCurve.Item2, 
+                velocity = DiffSingerUtils.SampleCurve(phrase, velocityCurve.Item2,
                     0, frameMs, totalFrames, headFrames, tailFrames,
                     x=>Math.Pow(2, (x - 100) / 100));
             }
@@ -141,25 +131,79 @@ namespace OpenUtau.Core.DiffSinger {
                         x => (x < 0) ? (-x * positiveScale) : (-x * negativeScale))
                         .ToArray();
                 }
+
+                //variance curves
+                if (options.exportVariance && singer.HasVariancePredictor) {
+                    var variancePredictor = singer.getVariancePredictor();
+                    VarianceResult varianceResult;
+                    lock (variancePredictor) {
+                        varianceResult = variancePredictor.Process(phrase);
+                    }
+                    if (varianceResult.energy != null) {
+                        energy = ComputeVarianceCurve(
+                            phrase, varianceResult.energy, varianceResult,
+                            phrase.curves.FirstOrDefault(c => c.Item1 == DiffSingerUtils.ENE)?.Item2,
+                            DiffSingerUtils.ENE,
+                            frameMs, totalFrames, headFrames, tailFrames);
+                    }
+                    if (varianceResult.breathiness != null) {
+                        breathiness = ComputeVarianceCurve(
+                            phrase, varianceResult.breathiness, varianceResult,
+                            phrase.breathiness,
+                            Format.Ustx.BREC,
+                            frameMs, totalFrames, headFrames, tailFrames);
+                    }
+                    if (varianceResult.voicing != null) {
+                        voicing = ComputeVarianceCurve(
+                            phrase, varianceResult.voicing, varianceResult,
+                            phrase.voicing,
+                            Format.Ustx.VOIC,
+                            frameMs, totalFrames, headFrames, tailFrames);
+                    }
+                    if (varianceResult.tension != null) {
+                        tension = ComputeVarianceCurve(
+                            phrase, varianceResult.tension, varianceResult,
+                            phrase.tension,
+                            Format.Ustx.TENC,
+                            frameMs, totalFrames, headFrames, tailFrames);
+                    }
+                }
             }
 
             offsetMs = phrase.phones[0].positionMs - headMs;
         }
-        
+
+        private static double[] ComputeVarianceCurve(
+                RenderPhrase phrase, float[] predicted, VarianceResult varianceResult,
+                float[] userCurve, string abbr,
+                double frameMs, int totalFrames, int headFrames, int tailFrames) {
+            var resampled = DiffSingerUtils.ResamplePaddedCurve(
+                predicted, totalFrames,
+                varianceResult.headFrames, varianceResult.tailFrames,
+                headFrames, tailFrames,
+                varianceResult.frameMs, (float)frameMs);
+            var userSampled = DiffSingerUtils.SampleCurve(
+                phrase, userCurve, 0, frameMs, totalFrames, headFrames, tailFrames,
+                x => x).Select(x => (float)x).ToArray();
+            var deltaFunc = DiffSingerUtils.VarianceDeltaFunctions[abbr];
+            return resampled.Zip(userSampled, deltaFunc)
+                .Select(x => (double)x).ToArray();
+        }
+
         public RawDiffSingerScript toRaw() {
             return new RawDiffSingerScript(this);
         }
 
-        static public void SavePart(UProject project, UVoicePart part, string filePath, bool v2 = false, bool exportPitch = true) {
+        static public void SavePart(UProject project, UVoicePart part, string filePath, DsScriptExportOptions options) {
             var ScriptArray = RenderPhrase.FromPart(project, project.tracks[part.trackNo], part)
-                .Select(x => new DiffSingerScript(x, v2, exportPitch).toRaw())
+                .Select(x => new DiffSingerScript(x, options).toRaw())
                 .ToArray();
             File.WriteAllText(filePath,
                 JsonConvert.SerializeObject(ScriptArray, Formatting.Indented),
                 new UTF8Encoding(false));
         }
     }
-    
+
     public class RawDiffSingerScript {
         public double offset;
         public string text;
@@ -178,9 +222,21 @@ namespace OpenUtau.Core.DiffSinger {
         public string? gender = null;
         public string? velocity_timestep = null;
         public string? velocity = null;
+        public string? energy_timestep = null;
+        public string? energy = null;
+        public string? breathiness_timestep = null;
+        public string? breathiness = null;
+        public string? voicing_timestep = null;
+        public string? voicing = null;
+        public string? tension_timestep = null;
+        public string? tension = null;
 
         static string FormatMsAsSeconds(double ms) {
             return (ms / 1000).ToString("G9", CultureInfo.InvariantCulture);
+        }
+
+        static string FormatValue(double x) {
+            return x.ToString("f3", CultureInfo.InvariantCulture);
         }
 
         public RawDiffSingerScript(DiffSingerScript script) {
@@ -188,7 +244,7 @@ namespace OpenUtau.Core.DiffSinger {
             text = String.Join(" ", script.text);
             ph_seq = String.Join(" ", script.ph_seq);
             ph_num = String.Join(" ", script.ph_num);
-            note_seq = String.Join(" ", 
+            note_seq = String.Join(" ",
                 script.noteSeq
                 .Select(x => x <= 0 ? "rest" : MusicMath.GetToneName(x)));
             ph_dur = String.Join(" ",script.phDurMs.Select(FormatMsAsSeconds));
@@ -196,7 +252,7 @@ namespace OpenUtau.Core.DiffSinger {
             note_dur_seq = ph_dur;
             note_slur = String.Join(" ", script.note_slur);
             is_slur_seq = String.Join(" ", script.ph_seq.Select(x => "0"));
-            
+
             if(script.f0_seq!=null){
                 f0_seq = String.Join(" ", script.f0_seq.Select(x => x.ToString("f1", CultureInfo.InvariantCulture)));
             }
@@ -204,12 +260,32 @@ namespace OpenUtau.Core.DiffSinger {
 
             if(script.gender != null) {
                 gender_timestep = f0_timestep;
-                gender = String.Join(" ", script.gender.Select(x => x.ToString("f3", CultureInfo.InvariantCulture)));
+                gender = String.Join(" ", script.gender.Select(FormatValue));
             }
 
             if (script.velocity != null) {
                 velocity_timestep = f0_timestep;
-                velocity = String.Join(" ", script.velocity.Select(x => x.ToString("f3", CultureInfo.InvariantCulture)));
+                velocity = String.Join(" ", script.velocity.Select(FormatValue));
+            }
+
+            if (script.energy != null) {
+                energy_timestep = f0_timestep;
+                energy = String.Join(" ", script.energy.Select(FormatValue));
+            }
+
+            if (script.breathiness != null) {
+                breathiness_timestep = f0_timestep;
+                breathiness = String.Join(" ", script.breathiness.Select(FormatValue));
+            }
+
+            if (script.voicing != null) {
+                voicing_timestep = f0_timestep;
+                voicing = String.Join(" ", script.voicing.Select(FormatValue));
+            }
+
+            if (script.tension != null) {
+                tension_timestep = f0_timestep;
+                tension = String.Join(" ", script.tension.Select(FormatValue));
             }
         }
     }

--- a/OpenUtau.Core/DiffSinger/DiffSingerUtils.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerUtils.cs
@@ -16,6 +16,14 @@ namespace OpenUtau.Core.DiffSinger {
         public const int headFrames = 8;
         public const int tailFrames = 8;
 
+        public static readonly Dictionary<string, Func<float, float, float>> VarianceDeltaFunctions =
+            new() {
+                {ENE, (x, y) => x + y * 12 / 100},
+                {Format.Ustx.BREC, (x, y) => x + y * 12 / 100},
+                {Format.Ustx.VOIC, (x, y) => x + (y - 100) * 12 / 100},
+                {Format.Ustx.TENC, (x, y) => x + y / 20},
+            };
+
         public static float GetHeadMs(double frameMs) {
             return (float)(frameMs * headFrames);
         }

--- a/OpenUtau/Strings/Strings.axaml
+++ b/OpenUtau/Strings/Strings.axaml
@@ -104,6 +104,12 @@ OpenUtau aims to be an open source editing environment for UTAU community, with 
   <system:String x:Key="dialogs.splitpart.caption">Splitting Part</system:String>
   <system:String x:Key="dialogs.splitpart.intheway">There are one or more note(s) overlapping with the playhead.
 Do you want to continue by splitting at the nearest position after current playhead with no notes in the way?</system:String>
+  <system:String x:Key="dialogs.exportds.caption">Export DiffSinger Scripts</system:String>
+  <system:String x:Key="dialogs.exportds.curves">Curves</system:String>
+  <system:String x:Key="dialogs.exportds.pitch">Pitch (f0)</system:String>
+  <system:String x:Key="dialogs.exportds.variance">Variance expressions</system:String>
+  <system:String x:Key="dialogs.exportds.variance.hint">Enable DiffSinger Tensor Cache in Preferences to export variance curves.</system:String>
+  <system:String x:Key="dialogs.exportds.notrendered">Please render all parts before exporting.</system:String>
   <system:String x:Key="dialogs.messagebox.cancel">Cancel</system:String>
   <system:String x:Key="dialogs.messagebox.copy">Copy error to clipboard</system:String>
   <system:String x:Key="dialogs.messagebox.no">No</system:String>
@@ -275,8 +281,6 @@ Do you want to continue by splitting at the nearest position after current playh
   <system:String x:Key="menu.file.exit">Exit</system:String>
   <system:String x:Key="menu.file.exportaudio">Export Audio</system:String>
   <system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>
   <system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>
   <system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>
   <system:String x:Key="menu.file.exportproject">Export Project</system:String>

--- a/OpenUtau/Strings/Strings.de-DE.axaml
+++ b/OpenUtau/Strings/Strings.de-DE.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Verlassen</system:String>
   <system:String x:Key="menu.file.exportaudio">Audio exportieren</system:String>
   <system:String x:Key="menu.file.exportds">Exportiere DiffSinger Scripts zu</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Exportiere DiffSinger Scripts zu (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Exportiere DiffSinger Scripts zu (v2, ohne pitch curve)</system:String>
   <system:String x:Key="menu.file.exportmidi">Midi Datei exportieren</system:String>
   <system:String x:Key="menu.file.exportmixdown">Zu Wav Datei konvertieren</system:String>
   <system:String x:Key="menu.file.exportproject">Projekt exportieren</system:String>

--- a/OpenUtau/Strings/Strings.es-ES.axaml
+++ b/OpenUtau/Strings/Strings.es-ES.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Salir</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
   <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.es-MX.axaml
+++ b/OpenUtau/Strings/Strings.es-MX.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">_Salir</system:String>
   <system:String x:Key="menu.file.exportaudio">Exportar audio</system:String>
   <system:String x:Key="menu.file.exportds">Exportar Scripts de DiffSinger a...</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Exportar Scripts de DiffSinger a... (V2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Exportar Scripts de DiffSinger a... (V2, sin curva de tono)</system:String>
   <system:String x:Key="menu.file.exportmidi">Exportar como MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Mezclar a Wav</system:String>
   <system:String x:Key="menu.file.exportproject">Exportar proyecto</system:String>

--- a/OpenUtau/Strings/Strings.fi-FI.axaml
+++ b/OpenUtau/Strings/Strings.fi-FI.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Lopeta OpenUtau</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
   <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.fr-FR.axaml
+++ b/OpenUtau/Strings/Strings.fr-FR.axaml
@@ -185,8 +185,6 @@ Nouveau tempo :</system:String>
   <system:String x:Key="menu.file.exit">Quitter</system:String>
   <system:String x:Key="menu.file.exportaudio">Exporter l'audio</system:String>
   <system:String x:Key="menu.file.exportds">Exporter les scripts DiffSingers vers</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Exporter les scripts DiffSingers vers (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Exporter les scripts DiffSingers vers (v2, sans courbe de pitch)</system:String>
   <system:String x:Key="menu.file.exportmidi">Exporter un MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Mixer en fichier Wav</system:String>
   <system:String x:Key="menu.file.exportproject">Exporter le projet</system:String>

--- a/OpenUtau/Strings/Strings.id-ID.axaml
+++ b/OpenUtau/Strings/Strings.id-ID.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Keluar</system:String>
   <system:String x:Key="menu.file.exportaudio">Ekspor Audio</system:String>
   <system:String x:Key="menu.file.exportds">Ekspor Skrip DiffSinger Ke</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Ekspor Skrip DiffSinger Ke (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Ekspor Skrip DiffSinger Ke (v2, tanpa kurva nada)</system:String>
   <system:String x:Key="menu.file.exportmidi">Ekspor Berkas Midi</system:String>
   <system:String x:Key="menu.file.exportmixdown">Campur ke Berkas Wav</system:String>
   <system:String x:Key="menu.file.exportproject">Ekspor Proyek</system:String>

--- a/OpenUtau/Strings/Strings.it-IT.axaml
+++ b/OpenUtau/Strings/Strings.it-IT.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Esci</system:String>
   <system:String x:Key="menu.file.exportaudio">Esporta Audio</system:String>
   <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
   <system:String x:Key="menu.file.exportmidi">Esporta File MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Mixdown su file WAV</system:String>
   <system:String x:Key="menu.file.exportproject">Esporta progetto</system:String>

--- a/OpenUtau/Strings/Strings.ja-JP.axaml
+++ b/OpenUtau/Strings/Strings.ja-JP.axaml
@@ -186,8 +186,6 @@
   <system:String x:Key="menu.file.exit">OpenUtauを終了</system:String>
   <system:String x:Key="menu.file.exportaudio">音声をエクスポート</system:String>
   <system:String x:Key="menu.file.exportds">DiffSinger Scriptsをエクスポート...</system:String>
-  <system:String x:Key="menu.file.exportds.v2">DiffSinger Scriptsをエクスポート(v2)...</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">DiffSinger Scriptsをエクスポート(v2, ピッチカーブなし)...</system:String>
   <system:String x:Key="menu.file.exportmidi">MIDIをエクスポート</system:String>
   <system:String x:Key="menu.file.exportmixdown">ミックスダウンしたWavファイルを出力</system:String>
   <system:String x:Key="menu.file.exportproject">プロジェクトファイルをエクスポート</system:String>

--- a/OpenUtau/Strings/Strings.ko-KR.axaml
+++ b/OpenUtau/Strings/Strings.ko-KR.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">나가기</system:String>
   <system:String x:Key="menu.file.exportaudio">[내보내기] 오디오</system:String>
   <system:String x:Key="menu.file.exportds">[다른 이름으로 저장] DiffSinger 스크립트로...</system:String>
-  <system:String x:Key="menu.file.exportds.v2">[다른 이름으로 저장] DiffSinger 스크립트로 (v2)...</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">[다른 이름으로 저장] DiffSinger 스크립트로 (v2, 피치선 제외)...</system:String>
   <system:String x:Key="menu.file.exportmidi">Midi로...</system:String>
   <system:String x:Key="menu.file.exportmixdown">Wav로 믹스다운</system:String>
   <system:String x:Key="menu.file.exportproject">[내보내기] 프로젝트</system:String>

--- a/OpenUtau/Strings/Strings.nl-NL.axaml
+++ b/OpenUtau/Strings/Strings.nl-NL.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">_Afsluiten</system:String>
   <system:String x:Key="menu.file.exportaudio">Exporteer audio</system:String>
   <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
   <system:String x:Key="menu.file.exportmidi">Exporteer midi bestand</system:String>
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <system:String x:Key="menu.file.exportproject">Exporteer project</system:String>

--- a/OpenUtau/Strings/Strings.pl-PL.axaml
+++ b/OpenUtau/Strings/Strings.pl-PL.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Zamknij</system:String>
   <system:String x:Key="menu.file.exportaudio">Eksportuj audio</system:String>
   <system:String x:Key="menu.file.exportds">Eksportuj skrypt DiffSinger do...</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Eksportuj skrypt DiffSinger do... (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Eksportuj skrypt DiffSinger do... (v2, bez krzywej wysokości dźwięku)</system:String>
   <system:String x:Key="menu.file.exportmidi">Eksportuj plik MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Zmiksuj do pliku WAV</system:String>
   <system:String x:Key="menu.file.exportproject">Eksportuj projekt</system:String>

--- a/OpenUtau/Strings/Strings.pt-BR.axaml
+++ b/OpenUtau/Strings/Strings.pt-BR.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Fechar</system:String>
   <system:String x:Key="menu.file.exportaudio">Exportar Áudio</system:String>
   <system:String x:Key="menu.file.exportds">Exportar Scripts do DiffSinger Para</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Exportar Scripts do DiffSinger Para (V2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Exportar Scripts do DiffSinger Para (V2, sem curva de tom)</system:String>
   <system:String x:Key="menu.file.exportmidi">Exportar Arquivo Midi</system:String>
   <system:String x:Key="menu.file.exportmixdown">Mixdown Para Arquivo Wav</system:String>
   <system:String x:Key="menu.file.exportproject">Exportar Projeto</system:String>

--- a/OpenUtau/Strings/Strings.ro-RO.axaml
+++ b/OpenUtau/Strings/Strings.ro-RO.axaml
@@ -184,8 +184,6 @@
   <!--<system:String x:Key="menu.file.exit">Exit</system:String>-->
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
   <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.ru-RU.axaml
+++ b/OpenUtau/Strings/Strings.ru-RU.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Выход</system:String>
   <system:String x:Key="menu.file.exportaudio">Экспортировать аудио</system:String>
   <system:String x:Key="menu.file.exportds">Экспортировать скрипты DiffSinger</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Экспортировать скрипты DiffSinger (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Экспортировать скрипты DiffSinger (v2, без кривой питча)</system:String>
   <system:String x:Key="menu.file.exportmidi">Экспорт midi-файла</system:String>
   <system:String x:Key="menu.file.exportmixdown">Свести в wav файл</system:String>
   <system:String x:Key="menu.file.exportproject">Экспортировать проект</system:String>

--- a/OpenUtau/Strings/Strings.th-TH.axaml
+++ b/OpenUtau/Strings/Strings.th-TH.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">ออก</system:String>
   <!--<system:String x:Key="menu.file.exportaudio">Export Audio</system:String>-->
   <!--<system:String x:Key="menu.file.exportds">Export DiffSinger Scripts To</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2">Export DiffSinger Scripts To (v2)</system:String>-->
-  <!--<system:String x:Key="menu.file.exportds.v2withoutpitch">Export DiffSinger Scripts To (v2, without pitch curve)</system:String>-->
   <!--<system:String x:Key="menu.file.exportmidi">Export Midi File</system:String>-->
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <!--<system:String x:Key="menu.file.exportproject">Export Project</system:String>-->

--- a/OpenUtau/Strings/Strings.vi-VN.axaml
+++ b/OpenUtau/Strings/Strings.vi-VN.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">Thoát ra</system:String>
   <system:String x:Key="menu.file.exportaudio">Xuất ra tệp nhạc</system:String>
   <system:String x:Key="menu.file.exportds">Xuất thành dự án DiffSinger</system:String>
-  <system:String x:Key="menu.file.exportds.v2">Xuất thành dự án DiffSinger (v2)</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">Xuất thành dự án DiffSinger (v2, không kèm luyến giọng)</system:String>
   <system:String x:Key="menu.file.exportmidi">Xuất thành MIDI</system:String>
   <system:String x:Key="menu.file.exportmixdown">Gộp thành một tệp nhạc</system:String>
   <system:String x:Key="menu.file.exportproject">Xuất thành dự án</system:String>

--- a/OpenUtau/Strings/Strings.zh-CN.axaml
+++ b/OpenUtau/Strings/Strings.zh-CN.axaml
@@ -49,6 +49,12 @@
   <system:String x:Key="dialogs.installdependency.message">安装 </system:String>
   <system:String x:Key="dialogs.installdll.caption">安装音素器</system:String>
   <system:String x:Key="dialogs.installdll.message">安装 </system:String>
+  <system:String x:Key="dialogs.exportds.caption">导出DiffSinger脚本</system:String>
+  <system:String x:Key="dialogs.exportds.curves">曲线</system:String>
+  <system:String x:Key="dialogs.exportds.pitch">音高 (f0)</system:String>
+  <system:String x:Key="dialogs.exportds.variance">唱法参数</system:String>
+  <system:String x:Key="dialogs.exportds.variance.hint">请在偏好设置中启用DiffSinger张量缓存以导出唱法参数曲线。</system:String>
+  <system:String x:Key="dialogs.exportds.notrendered">请先渲染所有片段后再导出。</system:String>
   <system:String x:Key="dialogs.messagebox.cancel">取消</system:String>
   <system:String x:Key="dialogs.messagebox.copy">将错误信息复制到剪贴板</system:String>
   <system:String x:Key="dialogs.messagebox.no">否</system:String>
@@ -206,8 +212,6 @@
   <system:String x:Key="menu.file.exit">退出</system:String>
   <system:String x:Key="menu.file.exportaudio">导出音频</system:String>
   <system:String x:Key="menu.file.exportds">导出DiffSinger脚本至</system:String>
-  <system:String x:Key="menu.file.exportds.v2">导出DiffSinger脚本至（v2）</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">导出DiffSinger脚本至（v2，不包含音高曲线）</system:String>
   <system:String x:Key="menu.file.exportmidi">导出Midi文件</system:String>
   <system:String x:Key="menu.file.exportmixdown">混缩为Wav文件</system:String>
   <system:String x:Key="menu.file.exportproject">导出工程</system:String>

--- a/OpenUtau/Strings/Strings.zh-TW.axaml
+++ b/OpenUtau/Strings/Strings.zh-TW.axaml
@@ -184,8 +184,6 @@
   <system:String x:Key="menu.file.exit">結束</system:String>
   <system:String x:Key="menu.file.exportaudio">匯出音訊</system:String>
   <system:String x:Key="menu.file.exportds">匯出 DiffSinger 指令碼至</system:String>
-  <system:String x:Key="menu.file.exportds.v2">匯出 DiffSinger 指令碼至（v2）</system:String>
-  <system:String x:Key="menu.file.exportds.v2withoutpitch">匯出 DiffSinger 指令碼至（v2，不含音高曲線）</system:String>
   <system:String x:Key="menu.file.exportmidi">匯出 MIDI 檔案</system:String>
   <!--<system:String x:Key="menu.file.exportmixdown">Mixdown To Wav File</system:String>-->
   <system:String x:Key="menu.file.exportproject">匯出專案</system:String>

--- a/OpenUtau/ViewModels/DsScriptExportViewModel.cs
+++ b/OpenUtau/ViewModels/DsScriptExportViewModel.cs
@@ -1,0 +1,18 @@
+using OpenUtau.Core.DiffSinger;
+using OpenUtau.Core.Util;
+using ReactiveUI.Fody.Helpers;
+
+namespace OpenUtau.App.ViewModels {
+    public class DsScriptExportViewModel : ViewModelBase {
+        [Reactive] public bool ExportPitch { get; set; } = true;
+        [Reactive] public bool ExportVariance { get; set; } = false;
+        public bool TensorCacheEnabled => Preferences.Default.DiffSingerTensorCache;
+
+        public DsScriptExportOptions BuildOptions() {
+            return new DsScriptExportOptions {
+                exportPitch = ExportPitch,
+                exportVariance = TensorCacheEnabled && ExportVariance,
+            };
+        }
+    }
+}

--- a/OpenUtau/Views/DsScriptExportDialog.axaml
+++ b/OpenUtau/Views/DsScriptExportDialog.axaml
@@ -1,0 +1,51 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="380" d:DesignHeight="260"
+        x:Class="OpenUtau.App.Views.DsScriptExportDialog"
+        Icon="/Assets/open-utau.ico"
+        Title="{DynamicResource dialogs.exportds.caption}"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="Height" Width="380" CanResize="False">
+  <Window.Styles>
+    <Style Selector="TextBlock">
+      <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+    <Style Selector="CheckBox">
+      <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+    </Style>
+  </Window.Styles>
+  <Border Margin="{Binding $parent.WindowDecorationMargin}">
+    <StackPanel Margin="12" Spacing="8">
+
+      <!-- Curves -->
+      <TextBlock Text="{DynamicResource dialogs.exportds.curves}"
+                 FontWeight="SemiBold"/>
+      <Grid ColumnDefinitions="Auto,Auto">
+        <CheckBox Grid.Column="0" IsChecked="{Binding ExportPitch}" VerticalAlignment="Center"/>
+        <TextBlock Grid.Column="1" Text="{DynamicResource dialogs.exportds.pitch}" Margin="6,0,0,0"/>
+      </Grid>
+      <Grid ColumnDefinitions="Auto,Auto">
+        <CheckBox Grid.Column="0" IsChecked="{Binding ExportVariance}" IsEnabled="{Binding TensorCacheEnabled}" VerticalAlignment="Center"/>
+        <TextBlock Grid.Column="1" Text="{DynamicResource dialogs.exportds.variance}" Margin="6,0,0,0"/>
+      </Grid>
+      <TextBlock Text="{DynamicResource dialogs.exportds.variance.hint}"
+                 FontSize="12"
+                 Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                 TextWrapping="Wrap"
+                 IsVisible="{Binding !TensorCacheEnabled}"/>
+
+      <!-- OK / Cancel -->
+      <Grid ColumnDefinitions="*,8,*" Margin="0,4,0,0">
+        <Button Grid.Column="0" Content="{DynamicResource dialogs.messagebox.ok}"
+                HorizontalAlignment="Stretch"
+                Click="OnOkClicked"/>
+        <Button Grid.Column="2" Content="{DynamicResource dialogs.messagebox.cancel}"
+                HorizontalAlignment="Stretch"
+                Click="OnCancelClicked"/>
+      </Grid>
+    </StackPanel>
+  </Border>
+</Window>

--- a/OpenUtau/Views/DsScriptExportDialog.axaml.cs
+++ b/OpenUtau/Views/DsScriptExportDialog.axaml.cs
@@ -1,0 +1,35 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace OpenUtau.App.Views {
+    public partial class DsScriptExportDialog : Window {
+        public bool Confirmed { get; private set; }
+
+        public DsScriptExportDialog() {
+            InitializeComponent();
+        }
+
+        void OnOkClicked(object? sender, RoutedEventArgs e) {
+            Confirmed = true;
+            Close();
+        }
+
+        void OnCancelClicked(object? sender, RoutedEventArgs e) {
+            Close();
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e) {
+            if (e.Key == Key.Escape) {
+                e.Handled = true;
+                Close();
+            } else if (e.Key == Key.Return) {
+                e.Handled = true;
+                Confirmed = true;
+                Close();
+            } else {
+                base.OnKeyDown(e);
+            }
+        }
+    }
+}

--- a/OpenUtau/Views/MainWindow.axaml
+++ b/OpenUtau/Views/MainWindow.axaml
@@ -45,8 +45,6 @@
               <MenuItem Header="{DynamicResource menu.file.exportustto}" Click="OnMenuExportUstTo"/>
               <MenuItem Header="{DynamicResource menu.file.exportmidi}" Click="OnMenuExportMidi"/>
               <MenuItem Header="{DynamicResource menu.file.exportds}" Click="OnMenuExportDsTo"/>
-              <MenuItem Header="{DynamicResource menu.file.exportds.v2}" Click="OnMenuExportDsV2To"/>
-              <MenuItem Header="{DynamicResource menu.file.exportds.v2withoutpitch}" Click="OnMenuExportDsV2WithoutPitchTo"/>
             </MenuItem>
             <MenuItem Header="{DynamicResource menu.file.openexportlocation}" Click="OnMenuOpenProjectLocation"/>
           </MenuItem>

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -403,6 +403,24 @@ namespace OpenUtau.App.Views {
 
         async void OnMenuExportDsTo(object sender, RoutedEventArgs e) {
             var project = DocManager.Inst.Project;
+            bool allRendered = project.parts
+                .OfType<UVoicePart>()
+                .All(part => part.Mix != null);
+            if (!allRendered) {
+                await MessageBox.Show(
+                    this,
+                    ThemeManager.GetString("dialogs.exportds.notrendered"),
+                    ThemeManager.GetString("errors.caption"),
+                    MessageBox.MessageBoxButtons.Ok);
+                return;
+            }
+            var vm = new DsScriptExportViewModel();
+            var dialog = new DsScriptExportDialog { DataContext = vm };
+            await dialog.ShowDialog(this);
+            if (!dialog.Confirmed) {
+                return;
+            }
+            var options = vm.BuildOptions();
             var file = await FilePicker.SaveFileAboutProject(
                 this, "menu.file.exportds", FilePicker.DS);
             if (!string.IsNullOrEmpty(file)) {
@@ -410,39 +428,7 @@ namespace OpenUtau.App.Views {
                     var part = project.parts[i];
                     if (part is UVoicePart voicePart) {
                         var savePath = PathManager.Inst.GetPartSavePath(file, voicePart.DisplayName, i)[..^4] + ".ds";
-                        DiffSingerScript.SavePart(project, voicePart, savePath);
-                        DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"{savePath}."));
-                    }
-                }
-            }
-        }
-
-        async void OnMenuExportDsV2To(object sender, RoutedEventArgs e) {
-            var project = DocManager.Inst.Project;
-            var file = await FilePicker.SaveFileAboutProject(
-                this, "menu.file.exportds.v2", FilePicker.DS);
-            if (!string.IsNullOrEmpty(file)) {
-                for (var i = 0; i < project.parts.Count; i++) {
-                    var part = project.parts[i];
-                    if (part is UVoicePart voicePart) {
-                        var savePath = PathManager.Inst.GetPartSavePath(file, voicePart.DisplayName, i)[..^4] + ".ds";
-                        DiffSingerScript.SavePart(project, voicePart, savePath, true);
-                        DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"{savePath}."));
-                    }
-                }
-            }
-        }
-
-        async void OnMenuExportDsV2WithoutPitchTo(object sender, RoutedEventArgs e) {
-            var project = DocManager.Inst.Project;
-            var file = await FilePicker.SaveFileAboutProject(
-                this, "menu.file.exportds.v2withoutpitch", FilePicker.DS);
-            if (!string.IsNullOrEmpty(file)) {
-                for (var i = 0; i < project.parts.Count; i++) {
-                    var part = project.parts[i];
-                    if (part is UVoicePart voicePart) {
-                        var savePath = PathManager.Inst.GetPartSavePath(file, voicePart.DisplayName, i)[..^4] + ".ds";
-                        DiffSingerScript.SavePart(project, voicePart, savePath, true, false);
+                        DiffSingerScript.SavePart(project, voicePart, savePath, options);
                         DocManager.Inst.ExecuteCmd(new ProgressBarNotification(0, $"{savePath}."));
                     }
                 }

--- a/OpenUtau/Views/MainWindow.axaml.cs
+++ b/OpenUtau/Views/MainWindow.axaml.cs
@@ -405,7 +405,12 @@ namespace OpenUtau.App.Views {
             var project = DocManager.Inst.Project;
             bool allRendered = project.parts
                 .OfType<UVoicePart>()
-                .All(part => part.Mix != null);
+                .All(part => part.renderPhrases.Count > 0 &&
+                    part.renderPhrases.All(phrase => {
+                        var hashStr = $"{phrase.hash:x16}";
+                        return Directory.EnumerateFiles(
+                            PathManager.Inst.CachePath, $"*{hashStr}*.wav").Any();
+                    }));
             if (!allRendered) {
                 await MessageBox.Show(
                     this,


### PR DESCRIPTION
Please merge #2090 first.

1. Drop support for DiffSinger script v1 (without `note_seq`)
2. Support exporting variance expressions to .ds file (require tensor cache to be enabled to ensure reproducible values)
3. Unify all .ds exporting actions into one small dialog
4. Exporting .ds now requires all phrases to finish rendering
<img width="306" height="143" alt="image" src="https://github.com/user-attachments/assets/2075f357-b8de-4226-8fc9-6736867c5eb0" />

