### PR TITLE
Added a snap function for key operations during pitch editing.

### DIFF
--- a/OpenUtau/Views/NoteEditStates.cs
+++ b/OpenUtau/Views/NoteEditStates.cs
@@ -629,6 +629,13 @@ namespace OpenUtau.App.Views {
             } else if (isFirst && note.pitch.snapFirst) {
                 var snapTo = note.Prev == null ? note : note.Prev.End == note.position ? note.Prev : note;
                 deltaY = (snapTo.AdjustedTone - note.AdjustedTone) * 10 - pitchPoint.Y;
+            } else if (ctrlHeld) {
+                var snappedSemitone = Math.Round(notesVm.PointToToneDouble(point) - note.AdjustedTone);
+                deltaY = snappedSemitone * 10 - pitchPoint.Y;
+            } else if (altShiftHeld && note.pitch.data.Count > 2) {
+                deltaY = note.pitch.data[index + 1].Y - pitchPoint.Y;
+            } else if (shiftHeld && note.pitch.data.Count > 2) {
+                deltaY = note.pitch.data[index - 1].Y - pitchPoint.Y;
             } else {
                 deltaY = (notesVm.PointToToneDouble(point) - note.AdjustedTone) * 10 - pitchPoint.Y;
             }

--- a/OpenUtau/Views/NoteEditStates.cs
+++ b/OpenUtau/Views/NoteEditStates.cs
@@ -630,11 +630,11 @@ namespace OpenUtau.App.Views {
                 var snapTo = note.Prev == null ? note : note.Prev.End == note.position ? note.Prev : note;
                 deltaY = (snapTo.AdjustedTone - note.AdjustedTone) * 10 - pitchPoint.Y;
             } else if (ctrlHeld) {
-                var snappedSemitone = Math.Round(notesVm.PointToToneDouble(point) - note.AdjustedTone);
+                var snappedSemitone = Math.Round(notesVm.PointToToneDouble(point) - note.AdjustedTone, MidpointRounding.AwayFromZero);
                 deltaY = snappedSemitone * 10 - pitchPoint.Y;
-            } else if (altShiftHeld && note.pitch.data.Count > 2) {
+            } else if (altShiftHeld && note.pitch.data.Count > 2 && !isLast) {
                 deltaY = note.pitch.data[index + 1].Y - pitchPoint.Y;
-            } else if (shiftHeld && note.pitch.data.Count > 2) {
+            } else if (shiftHeld && note.pitch.data.Count > 2 && !isFirst) {
                 deltaY = note.pitch.data[index - 1].Y - pitchPoint.Y;
             } else {
                 deltaY = (notesVm.PointToToneDouble(point) - note.AdjustedTone) * 10 - pitchPoint.Y;


### PR DESCRIPTION
Improved the operability of pitch point editing by adding conditional branching: use Ctrl for semitone snapping, and Alt+Shift/Shift to snap to adjacent points.
<img width="428" height="434" alt="レコーディング 2026-05-08 202108" src="https://github.com/user-attachments/assets/5d240d49-89f7-4e78-9e05-3f62efd520dc" />
