### PR TITLE
Improved behavior for editing portamento length and start position.

### DIFF
--- a/OpenUtau/Controls/NotePropertiesControl.axaml
+++ b/OpenUtau/Controls/NotePropertiesControl.axaml
@@ -59,14 +59,14 @@
             </Grid>
             <Grid ColumnDefinitions="130,20,50,20,*">
               <Label Content="{DynamicResource notedefaults.portamento.length}"/>
-              <TextBox Grid.Column="2" Text="{Binding PortamentoLength, Mode=OneWay}" Tag="PortamentoLength"/>
+              <TextBox Grid.Column="2" Text="{Binding PortamentoLength, Mode=OneWay}" Tag="PortamentoLength_TextBox"/>
               <Slider Grid.Column="4" Classes="fader" Value="{Binding PortamentoLength}" Minimum="2" Maximum="320"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"
                       Tag="PortamentoLength"/>
             </Grid>
             <Grid ColumnDefinitions="130,20,50,20,*">
               <Label Content="{DynamicResource notedefaults.portamento.start}"/>
-              <TextBox Grid.Column="2" Text="{Binding PortamentoStart, Mode=OneWay}" Tag="PortamentoStart" Margin="0"/>
+              <TextBox Grid.Column="2" Text="{Binding PortamentoStart, Mode=OneWay}" Tag="PortamentoStart_TextBox" Margin="0"/>
               <Slider Grid.Column="4" Classes="fader" Value="{Binding PortamentoStart}" Minimum="-200" Maximum="200"
                       TickPlacement="BottomRight" TickFrequency="1" IsSnapToTickEnabled="true"
                       Tag="PortamentoStart"/>

--- a/OpenUtau/ViewModels/NotePropertiesViewModel.cs
+++ b/OpenUtau/ViewModels/NotePropertiesViewModel.cs
@@ -68,6 +68,7 @@ namespace OpenUtau.App.ViewModels {
 
                         DocManager.Inst.StartUndoGroup("command.pitch.editpoint");
                         PanelControlPressed = true;
+                        SetNoteParams("PortamentoLength", portamentoPreset.PortamentoLength);
                         SetNoteParams("PortamentoStart", portamentoPreset.PortamentoStart);
                         PanelControlPressed = false;
                         DocManager.Inst.EndUndoGroup();
@@ -137,9 +138,9 @@ namespace OpenUtau.App.ViewModels {
                 Tone = MusicMath.GetToneName(note.tone);
                 Tuning = note.tuning;
                 SetTuningFontWeight();
-                if (note.pitch.data.Count == 2) {
-                    PortamentoLength = note.pitch.data[1].X - note.pitch.data[0].X;
-                    PortamentoStart = note.pitch.data[0].X;
+                if (note.pitch.data.Count >= 2) {
+                    PortamentoLength = note.pitch.data.Last().X - note.pitch.data.First().X;
+                    PortamentoStart = note.pitch.data.First().X;
                 } else {
                     PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
                     PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
@@ -302,9 +303,9 @@ namespace OpenUtau.App.ViewModels {
                 }
             } else if (cmd is ExpCommand) {
                 if (cmd is PitchExpCommand) {
-                    if (note.pitch.data.Count == 2) {
-                        PortamentoLength = note.pitch.data[1].X - note.pitch.data[0].X;
-                        PortamentoStart = note.pitch.data[0].X;
+                    if (note.pitch.data.Count >= 2) {
+                        PortamentoLength = note.pitch.data.Last().X - note.pitch.data.First().X;
+                        PortamentoStart = note.pitch.data.First().X;
                     } else {
                         PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
                         PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
@@ -327,6 +328,16 @@ namespace OpenUtau.App.ViewModels {
             } else {
                 TuningFontWeight = FontWeight.Normal;
             }
+        }
+
+        private float ParseValue(object? obj, string tag, float min, float max, float defaultValue) {
+            if (obj != null && (obj is float f || float.TryParse(obj.ToString(), out f))) {
+                if (tag.EndsWith("_TextBox")) {
+                    return f;
+                }
+                return Math.Clamp(f, min, max);
+            }
+            return defaultValue;
         }
 
         // panel -> note
@@ -376,26 +387,38 @@ namespace OpenUtau.App.ViewModels {
                     foreach (UNote note in selectedNotes) {
                         DocManager.Inst.ExecuteCmd(new ChangeNoteTuningCommand(Part, note, value));
                     }
-                } else if (tag == "PortamentoLength") {
-                    if (obj != null && (obj is float value || float.TryParse(obj.ToString(), out value)) && value >= 2 && value <= 320) {
-                        PortamentoLength = value;
-                    } else {
-                        PortamentoLength = NotePresets.Default.DefaultPortamento.PortamentoLength;
+                } else if (tag == "PortamentoLength" || tag == "PortamentoLength_TextBox") {
+                    PortamentoLength = ParseValue(obj, tag, 2, 320, NotePresets.Default.DefaultPortamento.PortamentoLength);
+                    foreach (var note in selectedNotes) {
+                        if (note.pitch.data.Count < 2) {
+                            continue;
+                        }
+                        var firstPoint = note.pitch.data.First();
+                        var oldPortamentoLength = note.pitch.data.Last().X - firstPoint.X;
+                        if (oldPortamentoLength <= 0) {
+                            continue;
+                        }
+                        var scale = PortamentoLength / oldPortamentoLength;
+                        foreach (var pitchPoint in note.pitch.data.Skip(1)) {
+                            var newX = firstPoint.X + (pitchPoint.X - firstPoint.X) * scale;
+                            var deltaX = newX - pitchPoint.X;
+                            if (deltaX != 0) {
+                                DocManager.Inst.ExecuteCmd(new MovePitchPointCommand(Part, pitchPoint, deltaX, 0));
+                            }
+                        }
                     }
-                    var pitch = new UPitch() { snapFirst = true };
-                    pitch.AddPoint(new PitchPoint(PortamentoStart, 0, NotePresets.Default.DefaultPitchShape));
-                    pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0, NotePresets.Default.DefaultPitchShape));
-                    DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, selectedNotes, pitch));
-                } else if (tag == "PortamentoStart") {
-                    if (obj != null && (obj is float value || float.TryParse(obj.ToString(), out value)) && value >= -200 && value <= 200) {
-                        PortamentoStart = value;
-                    } else {
-                        PortamentoStart = NotePresets.Default.DefaultPortamento.PortamentoStart;
+                } else if (tag == "PortamentoStart" || tag == "PortamentoStart_TextBox") {
+                    var oldPortamentoStart = selectedNotes.FirstOrDefault()?.pitch.data.FirstOrDefault()?.X
+                        ?? NotePresets.Default.DefaultPortamento.PortamentoStart;
+                    PortamentoStart = ParseValue(obj, tag, -200, 200, NotePresets.Default.DefaultPortamento.PortamentoStart);
+                    var deltaX = PortamentoStart - oldPortamentoStart;
+                    if (deltaX != 0) {
+                        foreach (var note in selectedNotes) {
+                            foreach (var pitchPoint in note.pitch.data) {
+                                DocManager.Inst.ExecuteCmd(new MovePitchPointCommand(Part, pitchPoint, deltaX, 0));
+                            }
+                        }
                     }
-                    var pitch = new UPitch() { snapFirst = true };
-                    pitch.AddPoint(new PitchPoint(PortamentoStart, 0, NotePresets.Default.DefaultPitchShape));
-                    pitch.AddPoint(new PitchPoint(PortamentoStart + PortamentoLength, 0, NotePresets.Default.DefaultPitchShape));
-                    DocManager.Inst.ExecuteCmd(new SetPitchPointsCommand(Part, selectedNotes, pitch));
                 } else if (tag == "PitchCurveShape") {
                     if (obj != null && (obj is int value || int.TryParse(obj.ToString(), out value)) && Enum.IsDefined(typeof(PitchPointShape), value)) {
                         DocManager.Inst.ExecuteCmd(new SetPitchPointShapeCommand(Part, selectedNotes, (PitchPointShape)value));


### PR DESCRIPTION
The logic for editing portamento length and start position has been revamped to distinguish between slider operations and text box inputs. It now supports scaling and translation when two or more pitch points exist, allowing for intuitive editing while maintaining existing curves.

Value parsing processes have been unified, and behavior for Undo/Redo and multiple note selection has been improved. Additionally, edit history is now correctly preserved even when applying presets.