### PR TITLE
Make phonemizer errors much more informative

### DIFF
--- a/OpenUtau.Core/Api/Phonemizer.cs
+++ b/OpenUtau.Core/Api/Phonemizer.cs
@@ -127,6 +127,11 @@ namespace OpenUtau.Api {
             public int position;
 
             /// <summary>
+            /// Error from the phonemizer, if this phoneme represents an error.
+            /// </summary>
+            public Exception error;
+
+            /// <summary>
             /// Suggested attributes. It may later be overwritten with a user-specified value.
             /// </summary>
             public List<PhonemeExpression> expressions;
@@ -147,6 +152,7 @@ namespace OpenUtau.Api {
         public string Name { get; set; }
         public string Tag { get; set; }
         public string Language { get; set; }
+        internal Exception SetUpException { get; set; }
 
         protected double bpm;
         protected TimeAxis timeAxis;

--- a/OpenUtau.Core/Api/Phonemizer.cs
+++ b/OpenUtau.Core/Api/Phonemizer.cs
@@ -129,7 +129,7 @@ namespace OpenUtau.Api {
             /// <summary>
             /// Error from the phonemizer, if this phoneme represents an error.
             /// </summary>
-            public Exception error;
+            public Exception? error;
 
             /// <summary>
             /// Suggested attributes. It may later be overwritten with a user-specified value.
@@ -152,7 +152,7 @@ namespace OpenUtau.Api {
         public string Name { get; set; }
         public string Tag { get; set; }
         public string Language { get; set; }
-        internal Exception SetUpException { get; set; }
+        internal Exception? SetUpException { get; set; }
 
         protected double bpm;
         protected TimeAxis timeAxis;

--- a/OpenUtau.Core/Api/PhonemizerRunner.cs
+++ b/OpenUtau.Core/Api/PhonemizerRunner.cs
@@ -96,6 +96,7 @@ namespace OpenUtau.Api {
                     timestamp = request.timestamp,
                 };
             }
+            phonemizer.SetUpException = null;
             try {
                 phonemizer.SetSinger(request.singer);
             } catch (Exception e) {

--- a/OpenUtau.Core/Api/PhonemizerRunner.cs
+++ b/OpenUtau.Core/Api/PhonemizerRunner.cs
@@ -102,6 +102,7 @@ namespace OpenUtau.Api {
                 phonemizer.SetUp(notes, DocManager.Inst.Project, DocManager.Inst.Project.tracks[request.part.trackNo]);
             } catch (Exception e) {
                 Log.Error(e, $"phonemizer failed to setup.");
+                phonemizer.SetUpException = e;
             }
 
             var result = new List<Phonemizer.Phoneme[]>();
@@ -142,7 +143,8 @@ namespace OpenUtau.Api {
                     phonemizerResult = new Phonemizer.Result() {
                         phonemes = new Phonemizer.Phoneme[] {
                             new Phonemizer.Phoneme {
-                                phoneme = "error"
+                                phoneme = "error",
+                                error = e
                             }
                         }
                     };

--- a/OpenUtau.Core/Api/PhonemizerRunner.cs
+++ b/OpenUtau.Core/Api/PhonemizerRunner.cs
@@ -96,13 +96,20 @@ namespace OpenUtau.Api {
                     timestamp = request.timestamp,
                 };
             }
-            phonemizer.SetSinger(request.singer);
-            phonemizer.SetTiming(request.timeAxis);
             try {
-                phonemizer.SetUp(notes, DocManager.Inst.Project, DocManager.Inst.Project.tracks[request.part.trackNo]);
+                phonemizer.SetSinger(request.singer);
             } catch (Exception e) {
-                Log.Error(e, $"phonemizer failed to setup.");
+                Log.Error(e, $"phonemizer failed to set singer.");
                 phonemizer.SetUpException = e;
+            }
+            phonemizer.SetTiming(request.timeAxis);
+            if (phonemizer.SetUpException == null) {
+                try {
+                    phonemizer.SetUp(notes, DocManager.Inst.Project, DocManager.Inst.Project.tracks[request.part.trackNo]);
+                } catch (Exception e) {
+                    Log.Error(e, $"phonemizer failed to setup.");
+                    phonemizer.SetUpException = e;
+                }
             }
 
             var result = new List<Phonemizer.Phoneme[]>();

--- a/OpenUtau.Core/Api/PhonemizerRunner.cs
+++ b/OpenUtau.Core/Api/PhonemizerRunner.cs
@@ -114,62 +114,73 @@ namespace OpenUtau.Api {
             }
 
             var result = new List<Phonemizer.Phoneme[]>();
-            for (int i = notes.Length - 1; i >= 0; i--) {
-                Phonemizer.Result phonemizerResult;
-                bool prevIsNeighbour = false;
-                bool nextIsNeighbour = false;
-                Phonemizer.Note[] prevs = null;
-                Phonemizer.Note? prev = null;
-                Phonemizer.Note? next = null;
-                if (i > 0) {
-                    prevs = notes[i - 1];
-                    prev = notes[i - 1][0];
-                    var prevLast = notes[i - 1].Last();
-                    prevIsNeighbour = prevLast.position + prevLast.duration >= notes[i][0].position;
+            if (phonemizer.SetUpException != null) {
+                // Short-circuit: return an error phoneme for each note group
+                for (int i = notes.Length - 1; i >= 0; i--) {
+                    result.Insert(0, new Phonemizer.Phoneme[] {
+                        new Phonemizer.Phoneme {
+                            phoneme = "error",
+                            error = phonemizer.SetUpException
+                        }
+                    });
                 }
-                if (i < notes.Length - 1) {
-                    next = notes[i + 1][0];
-                    var thisLast = notes[i].Last();
-                    nextIsNeighbour = thisLast.position + thisLast.duration >= next.Value.position;
-                }
-
-                if (next != null && result.Count > 0 && result[0].Length > 0) {
-                    var end = notes[i].Last().position + notes[i].Last().duration;
-                    int endPushback = Math.Min(0, result[0][0].position - end);
-                    notes[i][notes[i].Length - 1].duration += endPushback;
-                }
-                try {
-                    phonemizerResult = phonemizer.Process(
-                        notes[i],
-                        prev,
-                        next,
-                        prevIsNeighbour ? prev : null,
-                        nextIsNeighbour ? next : null,
-                        (prevIsNeighbour ? prevs : null) ?? new Phonemizer.Note[0]);
-                } catch (Exception e) {
-                    Log.Error(e, $"phonemizer error {notes[i][0].lyric}");
-                    phonemizerResult = new Phonemizer.Result() {
-                        phonemes = new Phonemizer.Phoneme[] {
-                            new Phonemizer.Phoneme {
-                                phoneme = "error",
-                                error = e
+            } else {
+                for (int i = notes.Length - 1; i >= 0; i--) {
+                    Phonemizer.Result phonemizerResult;
+                    bool prevIsNeighbour = false;
+                    bool nextIsNeighbour = false;
+                    Phonemizer.Note[] prevs = null;
+                    Phonemizer.Note? prev = null;
+                    Phonemizer.Note? next = null;
+                    if (i > 0) {
+                        prevs = notes[i - 1];
+                        prev = notes[i - 1][0];
+                        var prevLast = notes[i - 1].Last();
+                        prevIsNeighbour = prevLast.position + prevLast.duration >= notes[i][0].position;
+                    }
+                    if (i < notes.Length - 1) {
+                        next = notes[i + 1][0];
+                        var thisLast = notes[i].Last();
+                        nextIsNeighbour = thisLast.position + thisLast.duration >= next.Value.position;
+                    }
+                    if (next != null && result.Count > 0 && result[0].Length > 0) {
+                        var end = notes[i].Last().position + notes[i].Last().duration;
+                        int endPushback = Math.Min(0, result[0][0].position - end);
+                        notes[i][notes[i].Length - 1].duration += endPushback;
+                    }
+                    try {
+                        phonemizerResult = phonemizer.Process(
+                            notes[i],
+                            prev,
+                            next,
+                            prevIsNeighbour ? prev : null,
+                            nextIsNeighbour ? next : null,
+                            (prevIsNeighbour ? prevs : null) ?? new Phonemizer.Note[0]);
+                    } catch (Exception e) {
+                        Log.Error(e, $"phonemizer error {notes[i][0].lyric}");
+                        phonemizerResult = new Phonemizer.Result() {
+                            phonemes = new Phonemizer.Phoneme[] {
+                                new Phonemizer.Phoneme {
+                                    phoneme = "error",
+                                    error = e
+                                }
+                            }
+                        };
+                    }
+                    if (phonemizer.LegacyMapping) {
+                        for (var k = 0; k < phonemizerResult.phonemes.Length; k++) {
+                            var phoneme = phonemizerResult.phonemes[k];
+                            if (request.singer.TryGetMappedOto(phoneme.phoneme, notes[i][0].tone, out var oto)) {
+                                phonemizerResult.phonemes[k].phoneme = oto.Alias;
                             }
                         }
-                    };
-                }
-                if (phonemizer.LegacyMapping) {
-                    for (var k = 0; k < phonemizerResult.phonemes.Length; k++) {
-                        var phoneme = phonemizerResult.phonemes[k];
-                        if (request.singer.TryGetMappedOto(phoneme.phoneme, notes[i][0].tone, out var oto)) {
-                            phonemizerResult.phonemes[k].phoneme = oto.Alias;
-                        }
                     }
+                    for (var j = 0; j < phonemizerResult.phonemes.Length; j++) {
+                        phonemizerResult.phonemes[j].position += notes[i][0].position;
+                    }
+                    result.Insert(0, phonemizerResult.phonemes);
                 }
-                for (var j = 0; j < phonemizerResult.phonemes.Length; j++) {
-                    phonemizerResult.phonemes[j].position += notes[i][0].position;
-                }
-                result.Insert(0, phonemizerResult.phonemes);
-            }
+            } // end else (SetUpException == null)
             try {
                 phonemizer.CleanUp();
             } catch (Exception e) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -47,17 +47,12 @@ namespace OpenUtau.Core.DiffSinger
         private bool _executeSetSinger(USinger singer) {
             this.singer = singer;
             if (singer == null) {
-                return false;
+                throw new Exception("Singer is null.");
             }
             if(singer.Location == null){
-                Log.Error("Singer location is null");
-                return false;
+                throw new Exception("Singer location is null.");
             }
-            if (File.Exists(Path.Join(singer.Location, "dsdur", "dsconfig.yaml"))) {
-                rootPath = Path.Combine(singer.Location, "dsdur");
-            } else {
-                rootPath = singer.Location;
-            }
+            rootPath = Path.Combine(singer.Location, "dsdur");
             //Load Config
             var configPath = Path.Join(rootPath, "dsconfig.yaml");
             try {
@@ -70,8 +65,7 @@ namespace OpenUtau.Core.DiffSinger
             //Load language id if needed
             if (dsConfig.use_lang_id) {
                 if (dsConfig.languages == null) {
-                    Log.Error("\"languages\" field is not specified in dsconfig.yaml");
-                    return false;
+                    throw new Exception("\"languages\" field is not specified in dsconfig.yaml");
                 }
                 var langIdPath = Path.Join(rootPath, dsConfig.languages);
                 try {

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -65,7 +65,7 @@ namespace OpenUtau.Core.DiffSinger
                 dsConfig = Yaml.DefaultDeserializer.Deserialize<DsConfig>(configTxt);
             } catch(Exception e) {
                 Log.Error(e, $"failed to load dsconfig from {configPath}");
-                return false;
+                throw;
             }
             //Load language id if needed
             if (dsConfig.use_lang_id) {
@@ -78,7 +78,7 @@ namespace OpenUtau.Core.DiffSinger
                     languageIds = DiffSingerUtils.LoadLanguageIds(langIdPath);
                 } catch (Exception e) {
                     Log.Error(e, $"failed to load language id from {langIdPath}");
-                    return false;
+                    throw;
                 }
             }
             this.frameMs = dsConfig.frameMs();
@@ -95,7 +95,7 @@ namespace OpenUtau.Core.DiffSinger
                 linguisticModel = new InferenceSession(linguisticModelBytes);
             } catch (Exception e) {
                 Log.Error(e, $"failed to load linguistic model from {linguisticModelPath}");
-                return false;
+                throw;
             }
             var durationModelPath = Path.Join(rootPath, dsConfig.dur);
             try {
@@ -104,7 +104,7 @@ namespace OpenUtau.Core.DiffSinger
                 durationModel = new InferenceSession(durationModelBytes);
             } catch (Exception e) {
                 Log.Error(e, $"failed to load duration model from {durationModelPath}");
-                return false;
+                throw;
             }
             return true;
         }
@@ -124,6 +124,7 @@ namespace OpenUtau.Core.DiffSinger
                         g2pBuilder.Load(File.ReadAllText(dictionaryPath)).Build();
                     } catch (Exception e) {
                         Log.Error(e, $"Failed to load {dictionaryPath}");
+                        throw;
                     }
                     break;
                 }
@@ -433,7 +434,8 @@ namespace OpenUtau.Core.DiffSinger
                 Note[] word = phrase[wordIndex];
                 var noteResult = new List<Tuple<string, int>>();
                 if (!wordFound[wordIndex]){
-                    //partResult[word[0].position] = noteResult;
+                    partResult[word[0].position] = noteResult;
+                    unrecognizedLyrics[word[0].position] = word[0].lyric;
                     continue;
                 }
                 if (word[0].lyric.StartsWith("+")) {

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -153,14 +153,21 @@ namespace OpenUtau.Core.DiffSinger
                 .ToArray();
         }
 
-        string[] GetSymbols(Note note) {
+        string[] GetRejectedSymbols(string phoneticHint) {
+            return phoneticHint.Split()
+                .Where(s => String.IsNullOrEmpty(ValidatePhoneme(s)))
+                .ToArray();
+        }
+
+        string[] GetSymbols(Note note, out string[] rejectedSymbols) {
+            rejectedSymbols = Array.Empty<string>();
             //priority:
             //1. phonetic hint
             //2. query from g2p dictionary
             //3. treat lyric as phonetic hint, including single phoneme
             //4. empty
             if (!string.IsNullOrEmpty(note.phoneticHint)) {
-                // Split space-separated symbols into an array.
+                rejectedSymbols = GetRejectedSymbols(note.phoneticHint);
                 return ParsePhoneticHint(note.phoneticHint);
             }
             // User has not provided hint, query g2p dictionary.
@@ -170,6 +177,7 @@ namespace OpenUtau.Core.DiffSinger
                 return g2presult;
             }
             //not found in g2p dictionary, treat lyric as phonetic hint
+            rejectedSymbols = GetRejectedSymbols(note.lyric);
             var lyricSplited = ParsePhoneticHint(note.lyric);
             if (lyricSplited.Length > 0) {
                 return lyricSplited;
@@ -301,8 +309,17 @@ namespace OpenUtau.Core.DiffSinger
             var wordFound = new bool[phrase.Length];
             foreach (int wordIndex in Enumerable.Range(0, phrase.Length)) {
                 Note[] word = phrase[wordIndex];
-                var symbols = GetSymbols(word[0]).Where(s => phonemeTokens.ContainsKey(s)).ToArray();
-                if (symbols == null || symbols.Length == 0) {
+                var rawSymbols = GetSymbols(word[0], out string[] rejectedSymbols);
+                var symbols = rawSymbols.Where(s => phonemeTokens.ContainsKey(s)).ToArray();
+                // Collect symbols that passed GetSymbols but failed phonemeTokens lookup
+                var tokensRejected = rawSymbols.Where(s => !phonemeTokens.ContainsKey(s));
+                rejectedSymbols = rejectedSymbols.Concat(tokensRejected).ToArray();
+                if (rejectedSymbols.Length > 0) {
+                    unrecognizedLyrics[word[0].position] = string.Join(" ", rejectedSymbols);
+                } else if (symbols.Length == 0) {
+                    unrecognizedLyrics[word[0].position] = word[0].lyric ?? string.Empty;
+                }
+                if (symbols.Length == 0) {
                     symbols = new string[] { defaultPause };
                     wordFound[wordIndex] = false;
                 } else {
@@ -429,7 +446,6 @@ namespace OpenUtau.Core.DiffSinger
                 var noteResult = new List<Tuple<string, int>>();
                 if (!wordFound[wordIndex]){
                     partResult[word[0].position] = noteResult;
-                    unrecognizedLyrics[word[0].position] = word[0].lyric;
                     continue;
                 }
                 if (word[0].lyric.StartsWith("+")) {

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRhythmizerPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRhythmizerPhonemizer.cs
@@ -122,11 +122,14 @@ namespace OpenUtau.Core.DiffSinger {
                 Note[] group = phrase[groupIndex];
                 if (group[0].phoneticHint is null) {
                     var lyric = group[0].lyric;
-                    
+
                     if (phoneDict.ContainsKey(lyric)) {
                         notePhonemes = phoneDict[lyric];
-                    } else {
+                    } else if (rhythmizer.phonemes.Contains(lyric)) {
                         notePhonemes = new string[] { lyric };
+                    } else {
+                        notePhonemes = new string[] { "SP" };
+                        unrecognizedLyrics[group[0].position] = lyric;
                     }
                 } else {
                     notePhonemes = group[0].phoneticHint.Split(" ");
@@ -153,8 +156,13 @@ namespace OpenUtau.Core.DiffSinger {
             //error phonemes are replaced with SP
             long defaultToken = rhythmizer.phonemes.IndexOf("SP");
             var tokens = phonemes
-                .Select(x => (long)(rhythmizer.phonemes.IndexOf(x)))
-                .Select(x => x < 0 ? defaultToken : x)
+                .Select(x => {
+                    var idx = rhythmizer.phonemes.IndexOf(x);
+                    if (idx < 0) {
+                        Log.Warning($"Phoneme \"{x}\" not found in rhythmizer, replacing with SP");
+                    }
+                    return (long)(idx < 0 ? defaultToken : idx);
+                })
                 .ToList();
             var inputs = new List<NamedOnnxValue>();
             inputs.Add(NamedOnnxValue.CreateFromTensor("tokens",

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRhythmizerPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRhythmizerPhonemizer.cs
@@ -7,6 +7,7 @@ using OpenUtau.Api;
 using OpenUtau.Core.Ustx;
 using System.Text;
 using System.Linq;
+using Serilog;
 
 namespace OpenUtau.Core.DiffSinger {
 
@@ -97,7 +98,8 @@ namespace OpenUtau.Core.DiffSinger {
                 //Load pinyin to phoneme dictionary from rhythmizer package
                 phoneDict = rhythmizer.phoneDict;
             } catch (Exception ex) {
-                return;
+                Log.Error(ex, "Failed to load rhythmizer");
+                throw;
             }
         }
 

--- a/OpenUtau.Core/Enunu/EnunuKoreanPhonemizer.cs
+++ b/OpenUtau.Core/Enunu/EnunuKoreanPhonemizer.cs
@@ -525,13 +525,10 @@ namespace OpenUtau.Core.Enunu {
                     phonemes = phonemes_,
                 };
             }
-            return new Result {
-                phonemes = new Phoneme[] {
-                    new Phoneme {
-                        phoneme = "error",
-                    }
-                },
-            };
+            if (SetUpException != null) {
+                throw new Exception("Phonemizer failed to process.", SetUpException);
+            }
+            throw new Exception("Part result not found");
         }
 
         public override void CleanUp() {

--- a/OpenUtau.Core/Enunu/EnunuPhonemizer.cs
+++ b/OpenUtau.Core/Enunu/EnunuPhonemizer.cs
@@ -164,13 +164,10 @@ namespace OpenUtau.Core.Enunu {
                     }).ToArray(),
                 };
             }
-            return new Result {
-                phonemes = new Phoneme[] {
-                    new Phoneme {
-                        phoneme = "error",
-                    }
-                },
-            };
+            if (SetUpException != null) {
+                throw new Exception("Phonemizer failed to process.", SetUpException);
+            }
+            throw new Exception("Part result not found");
         }
 
         public override void CleanUp() {

--- a/OpenUtau.Core/MachineLearningPhonemizer.cs
+++ b/OpenUtau.Core/MachineLearningPhonemizer.cs
@@ -60,7 +60,10 @@ namespace OpenUtau.Core {
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevs) {
             if (unrecognizedLyrics.TryGetValue(notes[0].position, out var lyric)) {
-                throw new Exception($"Unrecognized lyric \"{lyric}\"");
+                if (string.IsNullOrEmpty(lyric)) {
+                    throw new Exception("Phoneme not found for this note");
+                }
+                throw new Exception($"Unrecognized phoneme \"{lyric}\"");
             }
             if (!partResult.TryGetValue(notes[0].position, out var phonemes)) {
                 var cause = lastProcessPartException ?? SetUpException;

--- a/OpenUtau.Core/MachineLearningPhonemizer.cs
+++ b/OpenUtau.Core/MachineLearningPhonemizer.cs
@@ -12,11 +12,14 @@ namespace OpenUtau.Core {
         //key: tick position of each note.
         //value: a list of phonemes and their positions in the note
         protected Dictionary<int, List<Tuple<string, int>>> partResult = new Dictionary<int, List<Tuple<string, int>>>();
-
+        protected Dictionary<int, string> unrecognizedLyrics = new Dictionary<int, string>();
+        private Exception lastProcessPartException;
         //Called when the note is changed, and the entire song is passed into the SetUp function as long as the note is changed
         //groups is a two-dimensional array of Note, each Note[] represents a lyrical note and its following slur notes
         //Run phoneme timing model in sections to prevent butterfly effect
         public override void SetUp(Note[][] groups, UProject project, UTrack track) {
+            SetUpException = null;
+            lastProcessPartException = null;
             if (groups.Length == 0) {
                 return;
             }
@@ -34,6 +37,7 @@ namespace OpenUtau.Core {
                     try{
                         ProcessPart(phrase.ToArray());
                     }catch(Exception e){
+                        lastProcessPartException = e;
                         var sentenceLyrics = string.Join(" ", phrase.Select(group => group[0].lyric));
                         Log.Error($"Failed to phonemize sentence {sentenceLyrics}: {e.Message}");
                     }
@@ -42,12 +46,25 @@ namespace OpenUtau.Core {
                 }
             }
             if (phrase.Count > 0) {
-                ProcessPart(phrase.ToArray());
+                try{
+                    ProcessPart(phrase.ToArray());
+                }catch(Exception e){
+                    lastProcessPartException = e;
+                    var sentenceLyrics = string.Join(" ", phrase.Select(group => group[0].lyric));
+                    Log.Error($"Failed to phonemize sentence {sentenceLyrics}: {e.Message}");
+                }
             }
         }
 
         public override Result Process(Note[] notes, Note? prev, Note? next, Note? prevNeighbour, Note? nextNeighbour, Note[] prevs) {
+            if (unrecognizedLyrics.TryGetValue(notes[0].position, out var lyric)) {
+                throw new Exception($"Unrecognized lyric \"{lyric}\"");
+            }
             if (!partResult.TryGetValue(notes[0].position, out var phonemes)) {
+                var cause = lastProcessPartException ?? SetUpException;
+                if (cause != null) {
+                    throw new Exception("Phonemizer failed to process.", cause);
+                }
                 throw new Exception("Part result not found");
             }
             return new Result {
@@ -62,6 +79,7 @@ namespace OpenUtau.Core {
 
         public override void CleanUp() {
             partResult.Clear();
+            unrecognizedLyrics.Clear();
         }
 
         //Run timing model for a sentence, and put the results into partResult

--- a/OpenUtau.Core/MachineLearningPhonemizer.cs
+++ b/OpenUtau.Core/MachineLearningPhonemizer.cs
@@ -13,13 +13,15 @@ namespace OpenUtau.Core {
         //value: a list of phonemes and their positions in the note
         protected Dictionary<int, List<Tuple<string, int>>> partResult = new Dictionary<int, List<Tuple<string, int>>>();
         protected Dictionary<int, string> unrecognizedLyrics = new Dictionary<int, string>();
-        private Exception lastProcessPartException;
+        private Exception? lastProcessPartException;
         //Called when the note is changed, and the entire song is passed into the SetUp function as long as the note is changed
         //groups is a two-dimensional array of Note, each Note[] represents a lyrical note and its following slur notes
         //Run phoneme timing model in sections to prevent butterfly effect
         public override void SetUp(Note[][] groups, UProject project, UTrack track) {
             SetUpException = null;
             lastProcessPartException = null;
+            partResult.Clear();
+            unrecognizedLyrics.Clear();
             if (groups.Length == 0) {
                 return;
             }

--- a/OpenUtau.Core/Ustx/UPart.cs
+++ b/OpenUtau.Core/Ustx/UPart.cs
@@ -159,7 +159,8 @@ namespace OpenUtau.Core.Ustx {
                                     rawPosition = resp.phonemes[i][j].position - position,
                                     rawPhoneme = resp.phonemes[i][j].phoneme,
                                     index = resp.phonemes[i][j].index ?? j,
-                                    Parent = note
+                                    Parent = note,
+                                    ErrorException = resp.phonemes[i][j].error
                                 };
                                 // Check for duplicate indexes
                                 if (phonemes.Any(p => p.Parent == phoneme.Parent && p.index == phoneme.index)) {

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -34,6 +34,7 @@ namespace OpenUtau.Core.Ustx {
         public UPhoneme Prev { get; set; }
         public UPhoneme Next { get; set; }
         public bool Error { get; set; } = false;
+        public Exception ErrorException { get; set; }
 
         public override string ToString() => $"\"{phoneme}\" pos:{position}";
 
@@ -67,6 +68,9 @@ namespace OpenUtau.Core.Ustx {
             PositionMs = project.timeAxis.TickPosToMsPos(part.position + position);
             EndMs = project.timeAxis.TickPosToMsPos(part.position + End);
             Error = Duration <= 0;
+            if (Error) {
+                ErrorException ??= new Exception("Phoneme duration is not positive.");
+            }
         }
 
         void ValidateOto(UTrack track, UNote note) {
@@ -76,6 +80,7 @@ namespace OpenUtau.Core.Ustx {
             }
             if (track.Singer == null || !track.Singer.Found || !track.Singer.Loaded) {
                 Error = true;
+                ErrorException ??= new Exception("Singer is not loaded.");
                 return;
             }
             // Load oto.
@@ -86,6 +91,7 @@ namespace OpenUtau.Core.Ustx {
             } else {
                 this.oto = default;
                 Error = true;
+                ErrorException ??= new Exception($"Oto not found for \"{phoneme}\".");
                 phonemeMapped = string.Empty;
             }
         }

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -34,7 +34,7 @@ namespace OpenUtau.Core.Ustx {
         public UPhoneme Prev { get; set; }
         public UPhoneme Next { get; set; }
         public bool Error { get; set; } = false;
-        public Exception ErrorException { get; set; }
+        public Exception? ErrorException { get; set; }
 
         public override string ToString() => $"\"{phoneme}\" pos:{position}";
 
@@ -46,7 +46,7 @@ namespace OpenUtau.Core.Ustx {
         }
 
         public void Validate(ValidateOptions options, UProject project, UTrack track, UVoicePart part, UNote note) {
-            Error = note.Error;
+            Error = note.Error || ErrorException != null;
             ValidateDuration(project, part);
             ValidateOto(track, note);
             ValidateOverlap(project, track, part, note);

--- a/OpenUtau.Core/Ustx/UPhoneme.cs
+++ b/OpenUtau.Core/Ustx/UPhoneme.cs
@@ -46,8 +46,11 @@ namespace OpenUtau.Core.Ustx {
         }
 
         public void Validate(ValidateOptions options, UProject project, UTrack track, UVoicePart part, UNote note) {
-            Error = note.Error || ErrorException != null;
+            Error = note.Error;
             ValidateDuration(project, part);
+            if (ErrorException != null) {
+                Error = true;
+            }
             ValidateOto(track, note);
             ValidateOverlap(project, track, part, note);
             ValidateEnvelope(project, track, note);

--- a/OpenUtau.Core/Voicevox/Phonemizers/SimpleVoicevoxPhonemizer.cs
+++ b/OpenUtau.Core/Voicevox/Phonemizers/SimpleVoicevoxPhonemizer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using OpenUtau.Api;
 using OpenUtau.Core.Ustx;
 using OpenUtau.Core.Voicevox;
@@ -25,15 +26,15 @@ namespace Voicevox {
                     currentLyric = lyricList[1];
                 }
                 if (!VoicevoxUtils.IsSyllableVowelExtensionNote(notes[i].lyric)) {
-                    string val = "error";
                     if (VoicevoxUtils.TryGetPau(notes[i].lyric, out string pau)) {
-                        val = pau;
+                        phonemes.Add(new Phoneme { phoneme = pau });
                     } else if (VoicevoxUtils.phoneme_List.kanas.ContainsKey(notes[i].lyric)) {
-                        val = currentLyric;
+                        phonemes.Add(new Phoneme { phoneme = currentLyric });
                     } else if (VoicevoxUtils.dic.IsDic(notes[i].lyric)) {
-                        val = VoicevoxUtils.dic.Lyrictodic(notes[i].lyric);
+                        phonemes.Add(new Phoneme { phoneme = VoicevoxUtils.dic.Lyrictodic(notes[i].lyric) });
+                    } else {
+                        throw new Exception($"Unrecognized lyric \"{notes[i].lyric}\"");
                     }
-                    phonemes.Add(new Phoneme { phoneme = val });
                 }
             }
             return new Result { phonemes = phonemes.ToArray() };

--- a/OpenUtau.Core/Voicevox/Phonemizers/SimpleVoicevoxPhonemizer.cs
+++ b/OpenUtau.Core/Voicevox/Phonemizers/SimpleVoicevoxPhonemizer.cs
@@ -25,13 +25,13 @@ namespace Voicevox {
                 if (lyricList.Length > 1) {
                     currentLyric = lyricList[1];
                 }
-                if (!VoicevoxUtils.IsSyllableVowelExtensionNote(notes[i].lyric)) {
-                    if (VoicevoxUtils.TryGetPau(notes[i].lyric, out string pau)) {
+                if (!VoicevoxUtils.IsSyllableVowelExtensionNote(currentLyric)) {
+                    if (VoicevoxUtils.TryGetPau(currentLyric, out string pau)) {
                         phonemes.Add(new Phoneme { phoneme = pau });
-                    } else if (VoicevoxUtils.phoneme_List.kanas.ContainsKey(notes[i].lyric)) {
+                    } else if (VoicevoxUtils.phoneme_List.kanas.ContainsKey(currentLyric)) {
                         phonemes.Add(new Phoneme { phoneme = currentLyric });
-                    } else if (VoicevoxUtils.dic.IsDic(notes[i].lyric)) {
-                        phonemes.Add(new Phoneme { phoneme = VoicevoxUtils.dic.Lyrictodic(notes[i].lyric) });
+                    } else if (VoicevoxUtils.dic.IsDic(currentLyric)) {
+                        phonemes.Add(new Phoneme { phoneme = VoicevoxUtils.dic.Lyrictodic(currentLyric) });
                     } else {
                         throw new Exception($"Unrecognized lyric \"{notes[i].lyric}\"");
                     }

--- a/OpenUtau.Core/Voicevox/Phonemizers/SimpleVoicevoxPhonemizer.cs
+++ b/OpenUtau.Core/Voicevox/Phonemizers/SimpleVoicevoxPhonemizer.cs
@@ -33,7 +33,7 @@ namespace Voicevox {
                     } else if (VoicevoxUtils.dic.IsDic(currentLyric)) {
                         phonemes.Add(new Phoneme { phoneme = VoicevoxUtils.dic.Lyrictodic(currentLyric) });
                     } else {
-                        throw new Exception($"Unrecognized lyric \"{notes[i].lyric}\"");
+                        throw new Exception($"Unrecognized lyric \"{currentLyric}\"");
                     }
                 }
             }

--- a/OpenUtau.Core/Voicevox/Phonemizers/VoicevoxPhonemizer.cs
+++ b/OpenUtau.Core/Voicevox/Phonemizers/VoicevoxPhonemizer.cs
@@ -94,13 +94,10 @@ namespace OpenUtau.Core.Voicevox {
                     }).ToArray(),
                 };
             }
-            return new Result {
-                phonemes = new Phoneme[] {
-                    new Phoneme {
-                        phoneme = "error",
-                    }
-                },
-            };
+            if (SetUpException != null) {
+                throw new Exception("Phonemizer failed to process.", SetUpException);
+            }
+            throw new Exception("Part result not found");
 
         }
 

--- a/OpenUtau/Controls/PhonemeCanvas.cs
+++ b/OpenUtau/Controls/PhonemeCanvas.cs
@@ -11,6 +11,8 @@ using ReactiveUI;
 
 namespace OpenUtau.App.Controls {
     class PhonemeCanvas : Control {
+        private static readonly IPen ErrorPen = new Pen(Brushes.Red, 1);
+
         public static readonly DirectProperty<PhonemeCanvas, IBrush> BackgroundProperty =
             AvaloniaProperty.RegisterDirect<PhonemeCanvas, IBrush>(
                 nameof(Background),
@@ -168,7 +170,7 @@ namespace OpenUtau.App.Controls {
                         = PhonemeUIRender.AliasPosition(viewModel, phoneme, langCode, ref lastTextEndX, ref raiseText);
                         using (var state = context.PushTransform(Matrix.CreateTranslation(textX + 2, textY))) {
                             var pen = mouseoverPhoneme == phoneme ? ThemeManager.AccentPen1Thickness2
-                                : phoneme.Error ? new Pen(Brushes.Red, 1)
+                                : phoneme.Error ? ErrorPen
                                 : ThemeManager.NeutralAccentPenSemi;
                             context.DrawRectangle(ThemeManager.BackgroundBrush, pen, new Rect(new Point(-2, 1.5), size), 4, 4);
                             textLayout.Draw(context, new Point());

--- a/OpenUtau/Controls/PhonemeCanvas.cs
+++ b/OpenUtau/Controls/PhonemeCanvas.cs
@@ -167,7 +167,9 @@ namespace OpenUtau.App.Controls {
                         (double textX, double textY, Size size, TextLayout textLayout) 
                         = PhonemeUIRender.AliasPosition(viewModel, phoneme, langCode, ref lastTextEndX, ref raiseText);
                         using (var state = context.PushTransform(Matrix.CreateTranslation(textX + 2, textY))) {
-                            var pen = mouseoverPhoneme == phoneme ? ThemeManager.AccentPen1Thickness2 : ThemeManager.NeutralAccentPenSemi;
+                            var pen = mouseoverPhoneme == phoneme ? ThemeManager.AccentPen1Thickness2
+                                : phoneme.Error ? new Pen(Brushes.Red, 1)
+                                : ThemeManager.NeutralAccentPenSemi;
                             context.DrawRectangle(ThemeManager.BackgroundBrush, pen, new Rect(new Point(-2, 1.5), size), 4, 4);
                             textLayout.Draw(context, new Point());
                         }

--- a/OpenUtau/Controls/PianoRoll.axaml.cs
+++ b/OpenUtau/Controls/PianoRoll.axaml.cs
@@ -1101,6 +1101,12 @@ namespace OpenUtau.App.Controls {
                         return;
                     }
                 }
+                // Plain click on errored phoneme alias shows error details
+                var clickAliasInfo = ViewModel.NotesViewModel.HitTest.HitTestAlias(args.GetPosition(control));
+                if (clickAliasInfo.hit && clickAliasInfo.phoneme.Error && clickAliasInfo.phoneme.ErrorException != null) {
+                    _ = MessageBox.ShowError(RootWindow, clickAliasInfo.phoneme.ErrorException);
+                    return;
+                }
                 var hitInfo = ViewModel.NotesViewModel.HitTest.HitTestPhoneme(point.Position);
                 if (hitInfo.hit) {
                     var phoneme = hitInfo.phoneme;


### PR DESCRIPTION
The current phonemizers swallow all error messages, just write them to logs, and only show `error` on the phoneme panel. 

This PR adds essential APIs for errored phonemes to carry the exception object, so the root cause can be displayed in a message box with a simple mouse click.

Also, some silent downgrading (dropping/filtering/replacing) for unrecognized symbols in DiffSinger phonemizers are replaced with clear error messages.

<img width="1767" height="1072" alt="E0$_RX6GBII{LOWW1 114I0" src="https://github.com/user-attachments/assets/b024a8d4-e6a3-4ffc-b740-336aeaf2c430" />
