### PR TITLE
Fix silent error handling in DiffSinger rendering pipeline

### DIFF
--- a/OpenUtau.Core/Api/PhonemizerRunner.cs
+++ b/OpenUtau.Core/Api/PhonemizerRunner.cs
@@ -120,6 +120,7 @@ namespace OpenUtau.Api {
                     result.Insert(0, new Phonemizer.Phoneme[] {
                         new Phonemizer.Phoneme {
                             phoneme = "error",
+                            position = notes[i][0].position,
                             error = phonemizer.SetUpException
                         }
                     });

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -60,7 +60,7 @@ namespace OpenUtau.Core.DiffSinger
                 dsConfig = Yaml.DefaultDeserializer.Deserialize<DsConfig>(configTxt);
             } catch(Exception e) {
                 Log.Error(e, $"failed to load dsconfig from {configPath}");
-                throw;
+                throw new Exception($"Failed to load {configPath}", e);
             }
             //Load language id if needed
             if (dsConfig.use_lang_id) {
@@ -72,7 +72,7 @@ namespace OpenUtau.Core.DiffSinger
                     languageIds = DiffSingerUtils.LoadLanguageIds(langIdPath);
                 } catch (Exception e) {
                     Log.Error(e, $"failed to load language id from {langIdPath}");
-                    throw;
+                    throw new Exception($"Failed to load {langIdPath}", e);
                 }
             }
             this.frameMs = dsConfig.frameMs();
@@ -89,7 +89,7 @@ namespace OpenUtau.Core.DiffSinger
                 linguisticModel = new InferenceSession(linguisticModelBytes);
             } catch (Exception e) {
                 Log.Error(e, $"failed to load linguistic model from {linguisticModelPath}");
-                throw;
+                throw new Exception($"Failed to load {linguisticModelPath}", e);
             }
             var durationModelPath = Path.Join(rootPath, dsConfig.dur);
             try {
@@ -98,7 +98,7 @@ namespace OpenUtau.Core.DiffSinger
                 durationModel = new InferenceSession(durationModelBytes);
             } catch (Exception e) {
                 Log.Error(e, $"failed to load duration model from {durationModelPath}");
-                throw;
+                throw new Exception($"Failed to load {durationModelPath}", e);
             }
             return true;
         }
@@ -111,6 +111,7 @@ namespace OpenUtau.Core.DiffSinger
             var dictionaryNames = new string[] {GetDictionaryName(), "dsdict.yaml"};
             // Load dictionary from singer folder.
             G2pDictionary.Builder g2pBuilder = new G2pDictionary.Builder();
+            bool dictFound = false;
             foreach(var dictionaryName in dictionaryNames){
                 string dictionaryPath = Path.Combine(rootPath, dictionaryName);
                 if (File.Exists(dictionaryPath)) {
@@ -120,8 +121,14 @@ namespace OpenUtau.Core.DiffSinger
                         Log.Error(e, $"Failed to load {dictionaryPath}");
                         throw;
                     }
+                    dictFound = true;
                     break;
                 }
+            }
+            if(!dictFound){
+                var triedPaths = string.Join(", ", dictionaryNames.Select(n => Path.Combine(rootPath, n)));
+                throw new FileNotFoundException(
+                    $"No dictionary file found. Tried: {triedPaths}");
             }
             //SP and AP should always be vowel
             g2pBuilder.AddSymbol("SP", true);
@@ -289,7 +296,7 @@ namespace OpenUtau.Core.DiffSinger
         int PhonemeTokenize(string phoneme){
             bool success = phonemeTokens.TryGetValue(phoneme, out int token);
             if(!success){
-                throw new Exception($"Phoneme \"{phoneme}\" isn't supported by timing model. Please check {Path.Combine(rootPath, dsConfig.phonemes)}");
+                throw new Exception($"Phoneme \"{phoneme}\" isn't supported by duration model. Please check {Path.Combine(rootPath, dsConfig.phonemes)}");
             }
             return token;
         }

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -192,13 +192,23 @@ namespace OpenUtau.Core.DiffSinger
             return new string[] { };
         }
 
-        string GetSpeakerAtIndex(Note note, int index){
+        string GetSpeakerAtIndex(Note note, int index) {
             var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == index) ?? default;
             var speaker = singer.Subbanks
-                .Where(subbank => subbank.Color == attr.voiceColor && subbank.toneSet.Contains(note.tone))
-                .FirstOrDefault();
-            if(speaker is null) {
-                return "";
+                .FirstOrDefault(subbank => subbank.Color == attr.voiceColor && subbank.toneSet.Contains(note.tone));
+            if (speaker is null) {
+                //Fall back to the first subbank matching the voice color
+                speaker = singer.Subbanks
+                    .FirstOrDefault(subbank => subbank.Color == attr.voiceColor);
+            }
+            if (speaker is null) {
+                //Fall back to the first defined subbank
+                speaker = singer.Subbanks.FirstOrDefault();
+            }
+            if (speaker is null) {
+                throw new Exception(
+                    $"No subbanks defined for singer \"{singer.Name}\". " +
+                    "Please check the singer's configuration.");
             }
             return speaker.Suffix;
         }

--- a/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerPitch.cs
@@ -30,9 +30,13 @@ namespace OpenUtau.Core.DiffSinger
         public DsPitch(string rootPath)
         {
             this.rootPath = rootPath;
-            dsConfig = Core.Yaml.DefaultDeserializer.Deserialize<DsConfig>(
-                File.ReadAllText(Path.Combine(rootPath, "dsconfig.yaml"),
-                    System.Text.Encoding.UTF8));
+            var dsconfigPath = Path.Combine(rootPath, "dsconfig.yaml");
+            try {
+                dsConfig = Core.Yaml.DefaultDeserializer.Deserialize<DsConfig>(
+                    File.ReadAllText(dsconfigPath, System.Text.Encoding.UTF8));
+            } catch (Exception e) {
+                throw new Exception($"Failed to load {dsconfigPath}", e);
+            }
             if(dsConfig.pitch == null){
                 throw new Exception("This voicebank doesn't contain a pitch model");
             }
@@ -46,7 +50,7 @@ namespace OpenUtau.Core.DiffSinger
                     languageIds = DiffSingerUtils.LoadLanguageIds(langIdPath);
                 } catch (Exception e) {
                     Log.Error(e, $"failed to load language id from {langIdPath}");
-                    return;
+                    throw new Exception($"Failed to load {langIdPath}", e);
                 }
             }
             //Load phonemes list
@@ -76,11 +80,15 @@ namespace OpenUtau.Core.DiffSinger
             if(!File.Exists(file)){
                 throw new Exception($"File not found: {file}");
             }
-            var g2pBuilder = G2pDictionary.NewBuilder().Load(File.ReadAllText(file));
-            //SP and AP should always be vowel
-            g2pBuilder.AddSymbol("SP", true);
-            g2pBuilder.AddSymbol("AP", true);
-            return g2pBuilder.Build();
+            try {
+                var g2pBuilder = G2pDictionary.NewBuilder().Load(File.ReadAllText(file));
+                //SP and AP should always be vowel
+                g2pBuilder.AddSymbol("SP", true);
+                g2pBuilder.AddSymbol("AP", true);
+                return g2pBuilder.Build();
+            } catch (Exception e) {
+                throw new Exception($"Failed to load {file}", e);
+            }
         }
 
         public DiffSingerSpeakerEmbedManager getSpeakerEmbedManager(){

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -110,7 +110,7 @@ namespace OpenUtau.Core.DiffSinger {
                                 result.samples = Wave.GetSamples(waveStream.ToSampleProvider().ToMono(1, 0));
                             }
                         } catch (Exception e) {
-                            Log.Error(e, "Failed to render.");
+                            Log.Error(e, "Failed to read cached render, re-rendering.");
                         }
                     }
                     if (result.samples == null) {
@@ -141,6 +141,9 @@ namespace OpenUtau.Core.DiffSinger {
             if(String.IsNullOrEmpty(singer.dsConfig.vocoder) ||
                 String.IsNullOrEmpty(singer.dsConfig.acoustic) ||
                 String.IsNullOrEmpty(singer.dsConfig.phonemes)){
+                if(singer.Errors.Count > 0) {
+                    throw new Exception(singer.Errors[0]);
+                }
                 throw new Exception("Invalid dsconfig.yaml. Please ensure that dsconfig.yaml contains keys \"vocoder\", \"acoustic\" and \"phonemes\".");
             }
 
@@ -333,6 +336,10 @@ namespace OpenUtau.Core.DiffSinger {
                 || singer.dsConfig.useEnergyEmbed
                 || singer.dsConfig.useVoicingEmbed
                 || singer.dsConfig.useTensionEmbed) {
+                if(!singer.HasVariancePredictor){
+                    throw new Exception(
+                        "This singer has no variance predictor but its acoustic model requires one.");
+                }
                 var variancePredictor = singer.getVariancePredictor();
                 VarianceResult varianceResult;
                 lock(variancePredictor){

--- a/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSinger.cs
@@ -72,7 +72,7 @@ namespace OpenUtau.Core.DiffSinger {
                 }
             } else {
                 avatarData = null;
-                Log.Error("Avatar can't be found");
+                Log.Information("Avatar not found");
             }
 
             subbanks.Clear();
@@ -81,42 +81,54 @@ namespace OpenUtau.Core.DiffSinger {
 
             //Load diffsinger config of a voicebank
             string configPath = Path.Combine(Location, "dsconfig.yaml");
+            bool dsConfigLoaded = false;
             if(configPath != null && File.Exists(configPath)){
                 try {
                     dsConfig = Core.Yaml.DefaultDeserializer.Deserialize<DsConfig>(
                         File.ReadAllText(configPath, Encoding.UTF8));
+                    dsConfigLoaded = true;
                 } catch (Exception e) {
                     Log.Error(e, $"Failed to load dsconfig.yaml for {Name} from {configPath}");
+                    errors.Add($"Failed to load dsconfig.yaml: {e.Message}");
                     dsConfig = new DsConfig();
                 }
             } else {
                 Log.Error($"dsconfig.yaml not found for {Name} at {configPath}");
+                errors.Add($"dsconfig.yaml not found at {configPath}");
                 dsConfig = new DsConfig();
             }
 
-            //Load phoneme list
-            string phonemesPath = Path.Combine(Location, dsConfig.phonemes);
-            if(phonemesPath != null && File.Exists(phonemesPath)){
-                try {
-                    phonemeTokens = DiffSingerUtils.LoadPhonemes(phonemesPath);
-                    phonemes = phonemeTokens.Keys.ToList();
-                } catch (Exception e){
-                    Log.Error(e, $"Failed to load phoneme list for {Name} from {phonemesPath}");
-                }
-            } else {
-                Log.Error($"phonemes file not found for {Name} at {phonemesPath}");
-            }
-
-            //Load language Id if needed
-            if(dsConfig.use_lang_id){
-                if(dsConfig.languages == null){
-                    Log.Error("\"languages\" field is not specified in dsconfig.yaml");
-                } else {
-                var langIdPath = Path.Join(Location, dsConfig.languages);
+            if(dsConfigLoaded) {
+                //Load phoneme tokens for acoustic model (render-time tokenization)
+                string phonemesPath = Path.Combine(Location, dsConfig.phonemes);
+                if(phonemesPath != null && File.Exists(phonemesPath)){
                     try {
-                        languageIds = DiffSingerUtils.LoadLanguageIds(langIdPath);
-                    } catch (Exception e) {
-                        Log.Error(e, $"failed to load language id from {langIdPath}");
+                        phonemeTokens = DiffSingerUtils.LoadPhonemes(phonemesPath);
+                        phonemes = phonemeTokens.Keys.ToList();
+                    } catch (Exception e){
+                        Log.Error(e, $"Failed to load phoneme tokens for {Name} from {phonemesPath}");
+                        errors.Add($"Failed to load phoneme tokens: {e.Message}");
+                        phonemeTokens = new Dictionary<string, int>();
+                    }
+                } else {
+                    Log.Error($"phonemes file not found for {Name} at {phonemesPath}");
+                    errors.Add($"Phonemes file not found at {phonemesPath}");
+                    phonemeTokens = new Dictionary<string, int>();
+                }
+
+                //Load language Id if needed
+                if(dsConfig.use_lang_id){
+                    if(dsConfig.languages == null){
+                        Log.Error("\"languages\" field is not specified in dsconfig.yaml");
+                        errors.Add("\"languages\" field is not specified in dsconfig.yaml but use_lang_id is true");
+                    } else {
+                        var langIdPath = Path.Join(Location, dsConfig.languages);
+                        try {
+                            languageIds = DiffSingerUtils.LoadLanguageIds(langIdPath);
+                        } catch (Exception e) {
+                            Log.Error(e, $"failed to load language id from {langIdPath}");
+                            errors.Add($"Failed to load language IDs: {e.Message}");
+                        }
                     }
                 }
             }
@@ -137,13 +149,11 @@ namespace OpenUtau.Core.DiffSinger {
         }
 
         public override bool TryGetOto(string phoneme, out UOto oto) {
-            var parts = phoneme.Split();
-            if (parts.All(p => phonemes.Contains(p))) {
-                oto = UOto.OfDummy(phoneme);
-                return true;
-            }
-            oto = null;
-            return false;
+            // We always return true here just not to let OTO get in our way.
+            // Phonemizer and acoustic model work independently and both can report missing phonemes by their own,
+            // so do other submodules.
+            oto = UOto.OfDummy(phoneme);
+            return true;
         }
 
         public override IEnumerable<UOto> GetSuggestions(string text) {
@@ -178,7 +188,7 @@ namespace OpenUtau.Core.DiffSinger {
                     vocoder = new DsVocoder(Path.Join(Location, "dsvocoder"));
                     return vocoder;
                 }
-                vocoder = new DsVocoder(dsConfig.vocoder);
+                vocoder = new DsVocoder(Path.Combine(PathManager.Inst.DependencyPath, dsConfig.vocoder));
             }
             return vocoder;
         }
@@ -209,6 +219,11 @@ namespace OpenUtau.Core.DiffSinger {
         }
 
         public int PhonemeTokenize(string phoneme){
+            if(phonemeTokens == null || phonemeTokens.Count == 0){
+                throw new Exception(
+                    $"Phoneme vocabulary is not loaded for singer \"{Name}\". " +
+                    "Please check that dsconfig.yaml and the phonemes file are valid.");
+            }
             bool success = phonemeTokens.TryGetValue(phoneme, out int token);
             if(!success){
                 throw new Exception($"Phoneme \"{phoneme}\" isn't supported by acoustic model. Please check {Path.Combine(Location, dsConfig.phonemes)}");

--- a/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
@@ -57,14 +57,14 @@ namespace OpenUtau.Core.DiffSinger
             }
         }
 
-        public int getSpeakerIndexBySuffix(string suffix){
+        public int getSpeakerIndexBySuffix(string suffix) {
             var speakerIndex = dsConfig.speakers.IndexOf(suffix);
-            if(speakerIndex == -1){
-                throw new Exception(
-                    $"Speaker suffix \"{suffix}\" not found in dsConfig.speakers. " +
-                    "Please check the voice color configuration.");
+            if (speakerIndex >= 0) {
+                return speakerIndex;
             }
-            return speakerIndex;
+            throw new Exception(
+                $"Speaker suffix \"{suffix}\" not found in dsConfig.speakers. " +
+                $"Candidates: {string.Join(',', dsConfig.speakers)}.");
         }
 
         //used by phonemizer (duration model)

--- a/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
@@ -24,7 +24,7 @@ namespace OpenUtau.Core.DiffSinger
         public NDArray loadSpeakerEmbed(string speaker) {
             string path = Path.Join(rootPath, speaker + ".emb");
             if(File.Exists(path)) {
-                var reader = new BinaryReader(File.OpenRead(path));
+                using var reader = new BinaryReader(File.OpenRead(path));
                 return np.array<float>(Enumerable.Range(0, dsConfig.hiddenSize)
                     .Select(i => reader.ReadSingle()));
             } else {
@@ -60,7 +60,9 @@ namespace OpenUtau.Core.DiffSinger
         public int getSpeakerIndexBySuffix(string suffix){
             var speakerIndex = dsConfig.speakers.IndexOf(suffix);
             if(speakerIndex == -1){
-                speakerIndex = 0;
+                throw new Exception(
+                    $"Speaker suffix \"{suffix}\" not found in dsConfig.speakers. " +
+                    "Please check the voice color configuration.");
             }
             return speakerIndex;
         }

--- a/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVariance.cs
@@ -41,9 +41,13 @@ namespace OpenUtau.Core.DiffSinger{
         public DsVariance(string rootPath)
         {
             this.rootPath = rootPath;
-            dsConfig = Yaml.DefaultDeserializer.Deserialize<DsConfig>(
-                File.ReadAllText(Path.Combine(rootPath, "dsconfig.yaml"),
-                    Encoding.UTF8));
+            var dsconfigPath = Path.Combine(rootPath, "dsconfig.yaml");
+            try {
+                dsConfig = Yaml.DefaultDeserializer.Deserialize<DsConfig>(
+                    File.ReadAllText(dsconfigPath, Encoding.UTF8));
+            } catch (Exception e) {
+                throw new Exception($"Failed to load {dsconfigPath}", e);
+            }
             if(dsConfig.variance == null){
                 throw new Exception("This voicebank doesn't contain a variance model");
             }
@@ -57,7 +61,7 @@ namespace OpenUtau.Core.DiffSinger{
                     languageIds = DiffSingerUtils.LoadLanguageIds(langIdPath);
                 } catch (Exception e) {
                     Log.Error(e, $"failed to load language id from {langIdPath}");
-                    return;
+                    throw new Exception($"Failed to load {langIdPath}", e);
                 }
             }
             //Load phonemes list
@@ -89,11 +93,15 @@ namespace OpenUtau.Core.DiffSinger{
             if(!File.Exists(file)){
                 throw new Exception($"File not found: {file}");
             }
-            var g2pBuilder = G2pDictionary.NewBuilder().Load(File.ReadAllText(file));
-            //SP and AP should always be vowel
-            g2pBuilder.AddSymbol("SP", true);
-            g2pBuilder.AddSymbol("AP", true);
-            return g2pBuilder.Build(); 
+            try {
+                var g2pBuilder = G2pDictionary.NewBuilder().Load(File.ReadAllText(file));
+                //SP and AP should always be vowel
+                g2pBuilder.AddSymbol("SP", true);
+                g2pBuilder.AddSymbol("AP", true);
+                return g2pBuilder.Build();
+            } catch (Exception e) {
+                throw new Exception($"Failed to load {file}", e);
+            }
         }
 
         public DiffSingerSpeakerEmbedManager getSpeakerEmbedManager(){

--- a/OpenUtau.Core/DiffSinger/DiffSingerVocoder.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerVocoder.cs
@@ -21,11 +21,10 @@ namespace OpenUtau.Core.DiffSinger {
         public string mel_scale => config.mel_scale;
         public bool pitch_controllable => config.pitch_controllable;
 
-        //Get vocoder by package name
-        public DsVocoder(string name) {
+        public DsVocoder(string location) {
             byte[] model;
             try {
-                Location = Path.Combine(PathManager.Inst.DependencyPath, name);
+                Location = location;
                 config = Core.Yaml.DefaultDeserializer.Deserialize<DsVocoderConfig>(
                     File.ReadAllText(Path.Combine(Location, "vocoder.yaml"),
                         System.Text.Encoding.UTF8));
@@ -33,11 +32,11 @@ namespace OpenUtau.Core.DiffSinger {
             }
             catch (Exception ex) {
                 throw new MessageCustomizableException(
-                    $"Error loading vocoder \"{name}\"",
+                    $"Error loading vocoder from \"{location}\"",
                     $"<translate:errors.diffsinger.downloadvocoder>",
-                    new Exception($"Error loading vocoder \"{name}\""),
+                    ex,
                     true,
-                    new string[] { name, "https://github.com/xunmengshe/OpenUtau/wiki/Vocoders" });
+                    new string[] { Path.GetFileName(location), "https://github.com/xunmengshe/OpenUtau/wiki/Vocoders" });
             }
             hash = XXH64.DigestOf(model);
             session = Onnx.getInferenceSession(model);

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerG2pPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerG2pPhonemizer.cs
@@ -52,6 +52,7 @@ namespace OpenUtau.Core.DiffSinger
             // Load dictionary from singer folder.
             G2pDictionary.Builder g2pBuilder = new G2pDictionary.Builder();
             var replacements = new Dictionary<string,string>();
+            bool dictFound = false;
             foreach(var dictionaryName in dictionaryNames){
                 string dictionaryPath = Path.Combine(rootPath, dictionaryName);
                 if (File.Exists(dictionaryPath)) {
@@ -66,12 +67,19 @@ namespace OpenUtau.Core.DiffSinger
                                 phonemeSymbols[symbol.symbol.Trim()] = true;
                             }
                         }
-                        Log.Error("Loaded symbols: " + string.Join(", ", phonemeSymbols.Keys));
+                        Log.Information("Loaded symbols: " + string.Join(", ", phonemeSymbols.Keys));
                     } catch (Exception e) {
                         Log.Error(e, $"Failed to load {dictionaryPath}");
+                        throw new Exception($"Failed to load {dictionaryPath}", e);
                     }
+                    dictFound = true;
                     break;
                 }
+            }
+            if(!dictFound){
+                var triedPaths = string.Join(", ", dictionaryNames.Select(n => Path.Combine(rootPath, n)));
+                throw new FileNotFoundException(
+                    $"No dictionary file found. Tried: {triedPaths}");
             }
             //SP and AP should always be vowel
             g2pBuilder.AddSymbol("SP", true);

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRhythmizerPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRhythmizerPhonemizer.cs
@@ -99,7 +99,7 @@ namespace OpenUtau.Core.DiffSinger {
                 phoneDict = rhythmizer.phoneDict;
             } catch (Exception ex) {
                 Log.Error(ex, "Failed to load rhythmizer");
-                throw;
+                throw new Exception("Failed to load rhythmizer", ex);
             }
         }
 

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRhythmizerPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRhythmizerPhonemizer.cs
@@ -93,13 +93,13 @@ namespace OpenUtau.Core.DiffSinger {
                     } else {
                         rhythmizerName = DsRhythmizer.DefaultRhythmizer;
                     }
-                        rhythmizer = DsRhythmizer.FromName(rhythmizerName);
+                    rhythmizer = DsRhythmizer.FromName(rhythmizerName);
                 }
                 //Load pinyin to phoneme dictionary from rhythmizer package
                 phoneDict = rhythmizer.phoneDict;
             } catch (Exception ex) {
                 Log.Error(ex, "Failed to load rhythmizer");
-                throw new Exception("Failed to load rhythmizer", ex);
+                throw;
             }
         }
 

--- a/OpenUtau.Core/Render/RenderEngine.cs
+++ b/OpenUtau.Core/Render/RenderEngine.cs
@@ -99,13 +99,17 @@ namespace OpenUtau.Core.Render {
                 if (task.IsFaulted && !wait) {
                     Log.Error(task.Exception.Flatten(), "Failed to render.");
                     PlaybackManager.Inst.StopPlayback();
-                    MessageCustomizableException customEx;
-                    if (task.Exception.Flatten().InnerExceptions.ToList().Any(e => e is DllNotFoundException)) {
-                        customEx = new MessageCustomizableException("Failed to render.", "<translate:errors.failed.render>: <translate:errors.install.cpp>", task.Exception);
+                    var flatEx = task.Exception.Flatten();
+                    var innerEx = flatEx.InnerExceptions.ToList();
+                    if (innerEx.Count == 1 && innerEx[0] is MessageCustomizableException mce) {
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(mce));
+                    } else if (innerEx.Any(e => e is DllNotFoundException)) {
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(
+                            new MessageCustomizableException("Failed to render.", "<translate:errors.failed.render>: <translate:errors.install.cpp>", flatEx)));
                     } else {
-                        customEx = new MessageCustomizableException("Failed to render.", "<translate:errors.failed.render>", task.Exception);
+                        DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(
+                            new MessageCustomizableException("Failed to render.", "<translate:errors.failed.render>", flatEx)));
                     }
-                    DocManager.Inst.ExecuteCmd(new ErrorMessageNotification(customEx));
                 }
             }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, uiScheduler);
             if (wait) {


### PR DESCRIPTION
Silent error handling swallows the error and hides the root cause, making it very difficult to debug. This PR refactors some DiffSinger error handling to throw and show the actual root cause.

It also contains:
- a fix to PhonemizerRunner where "error" phonemes have wrong position
- a fix to RenderEngine to not wrap the exception if it is already `MessageCustomizableException`, so the translatable message can be displayed as expected