### PR TITLE
[EN VCCV] Starlight CC update

### DIFF
--- a/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
@@ -117,7 +117,7 @@ namespace OpenUtau.Plugin.Builtin {
         private readonly string[] ccNoParsing = { "sk", "sm", "sn", "sp", "st", "hy" };
         private readonly string[] stopCs = { "b", "d", "g", "k", "p", "t" };
         private readonly string[] ucvCs = { "r", "l", "w", "y", "f"};
-        private readonly string[] starlightccs = { "rl", "ll", "nn", "mm" };
+        private readonly string[] starlightccs = { "rl", "ll", "nn", "mm", "rf" };
 
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;

--- a/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
+++ b/OpenUtau.Plugin.Builtin/EnglishVCCVPhonemizer.cs
@@ -117,7 +117,7 @@ namespace OpenUtau.Plugin.Builtin {
         private readonly string[] ccNoParsing = { "sk", "sm", "sn", "sp", "st", "hy" };
         private readonly string[] stopCs = { "b", "d", "g", "k", "p", "t" };
         private readonly string[] ucvCs = { "r", "l", "w", "y", "f"};
-        private readonly string[] starlightccs = { "rl", "ll", "nn", "mm", "rf" };
+        private readonly string[] starlightccs = { "rl", "ll", "nn", "mm", "rf", "mf", "lf" };
 
         protected override string[] GetVowels() => vowels;
         protected override string[] GetConsonants() => consonants;


### PR DESCRIPTION
Adds [rf] to the list of starlightCCs so "barefoot" is said as "[-bA][Ar-][r f][f6][6t-]" and not "[bA][A r][rf][f6][6t]", along with two more that might cause issues.