### PR TITLE
Rule-based Filipino phonemizer for DiffSinger

### DIFF
--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using OpenUtau.Api;
+using OpenUtau.Core.G2p;
+
+namespace OpenUtau.Core.G2p {
+    public class RuleBasedFilipinoG2p : IG2p {
+        readonly static Regex kAllPunct = new Regex(@"^[\p{P}]$");
+
+        private string[] validPhonemes =
+            { "m", "n", "ng", "p", "t", "ty", "k", "q", "b", "d", "dy", "g", "s", "sy", "h", "l", "y", "w", "r", "vf", "a", "e", "i", "o", "u" };
+
+        private readonly string[] glides = { "w", "y" };
+
+        private string[] vowels = { "a", "e", "i", "o", "u" };
+
+        public bool IsGlide(string symbol) => glides.Contains(symbol);
+
+        public bool IsValidSymbol(string symbol) => validPhonemes.Contains(symbol);
+
+        public bool IsVowel(string symbol) => vowels.Contains(symbol);
+
+        public string[] UnpackHint(string hint, char separator = ' ') {
+            return hint.Split(separator)
+                .Where(x => validPhonemes.Contains(x))
+                .ToArray();
+        }
+
+        public string[] Query(string grapheme) {
+            if (string.IsNullOrEmpty(grapheme) || kAllPunct.IsMatch(grapheme)) {
+                return null;
+            }
+            return Predict(grapheme);
+        }
+
+        string[]? Predict(string grapheme) {
+            grapheme = grapheme.ToLower(new CultureInfo("fil-PH"));
+            if (grapheme.Equals("mga")) grapheme = "manga";
+            if (grapheme.Equals("ng")) grapheme = "nang";
+            List<string> phonemes = new List<string>();
+            foreach (var c in grapheme) {
+                var prev = phonemes.LastOrDefault("");
+                switch (c) {
+                    case 'a':
+                    case 'o':
+                    case 'u':
+                        if (prev.Equals("c")) phonemes[^1] = "k";
+                        phonemes.Add(c.ToString());
+                        break;
+                    case 'e':
+                        if (prev.Equals("c")) phonemes[^1] = "s";
+                        phonemes.Add("e");
+                        break;
+                    case 'i':
+                        if (prev.Equals("c")) phonemes[^1] = "sy";
+                        else phonemes.Add("i");
+                        break;
+                    case 'f':
+                        phonemes.Add("p");
+                        break;
+                    case 'g':
+                        if (prev.Equals("n")) phonemes[^1] = "ng";
+                        else phonemes.Add("g");
+                        break;
+                    case 'j':
+                        phonemes.Add("dy");
+                        break;
+                    case 'ñ':
+                        phonemes.Add("n");
+                        phonemes.Add("y");
+                        break;
+                    case 'y':
+                        if (prev.Equals("t") || prev.Equals("d") || prev.Equals("s"))
+                            phonemes[^1] = prev + "y";
+                        else phonemes.Add("y");
+                        break;
+                    case 'z':
+                        phonemes.Add("s");
+                        break;
+                    case '-':
+                        phonemes.Add("q");
+                        break;
+                    case '\'':
+                        phonemes.Add("vf");
+                        break;
+                    default:
+                        phonemes.Add(c.ToString());
+                        break;
+                }
+            }
+
+            string[] filteredPhonemes = phonemes.Where(x => validPhonemes.Contains(x)).ToArray();
+
+            return (filteredPhonemes.Length == 0) ? null : filteredPhonemes;
+        }
+    }
+}
+
+namespace OpenUtau.Core.DiffSinger {
+    [Phonemizer("DiffSinger Rule-based Filipino Phonemizer", "DIFFS FIL", "UtaUtaUtau", "FIL")]
+    public class DiffSingerRuleBasedFilipinoPhonemizer : DiffSingerG2pPhonemizer {
+        protected override string GetDictionaryName() => "dsdict-fil.yaml";
+
+        public override string GetLangCode() => "fil";
+
+        protected override IG2p LoadBaseG2p() => new RuleBasedFilipinoG2p();
+
+        protected override string[] GetBaseG2pVowels() => new string[] {
+            "a", "e", "i", "o", "u"
+        };
+
+        protected override string[] GetBaseG2pConsonants() => new string[] {
+            "m", "n", "ng", "p", "t", "ty", "k", "q", "b", "d", "dy", "g", "s", "sy", "h", "l", "y", "w", "r", "vf"
+        };
+    }
+}

--- a/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/Phonemizers/DiffSingerRuleBasedFilipinoPhonemizer.cs
@@ -22,6 +22,8 @@ namespace OpenUtau.Core.G2p {
 
         public bool IsVowel(string symbol) => vowels.Contains(symbol);
 
+        bool IsConsonant(string symbol) => !symbol.Equals("|") && !IsVowel(symbol);
+
         public string[] UnpackHint(string hint, char separator = ' ') {
             return hint.Split(separator)
                 .Where(x => validPhonemes.Contains(x))
@@ -64,12 +66,20 @@ namespace OpenUtau.Core.G2p {
                         if (prev.Equals("n")) phonemes[^1] = "ng";
                         else phonemes.Add("g");
                         break;
+                    case 'h':
+                        if (prev.Equals("c")) phonemes[^1] = "ty";
+                        else phonemes.Add("h");
+                        break;
                     case 'j':
                         phonemes.Add("dy");
                         break;
                     case 'ñ':
                         phonemes.Add("n");
                         phonemes.Add("y");
+                        break;
+                    case 's':
+                        if (prev.Equals("t")) phonemes[^1] = "ty";
+                        else phonemes.Add("s");
                         break;
                     case 'y':
                         if (prev.Equals("t") || prev.Equals("d") || prev.Equals("s"))
@@ -90,6 +100,21 @@ namespace OpenUtau.Core.G2p {
                         break;
                 }
             }
+            
+            // glide pass
+            for (int i = 1; i < phonemes.Count - 1; i++) {
+                string prev = phonemes[i - 1];
+                string curr = phonemes[i];
+                string next = phonemes[i + 1];
+                phonemes[i] = curr switch {
+                    "u" when IsConsonant(prev) && IsVowel(next) => "w",
+                    "i" when IsConsonant(prev) && IsVowel(next) => "y",
+                    _ => phonemes[i]
+                };
+            }
+            
+            // extra palatalization pass
+            
 
             string[] filteredPhonemes = phonemes.Where(x => validPhonemes.Contains(x)).ToArray();
 


### PR DESCRIPTION
## Overview
This PR adds a phonemizer for the Filipino language to use for DiffSinger, along with a rule-based G2P (as `RuleBasedFilipinoG2p`) for Filipino itself for further development. If needed, it can be moved to the proper folder, as I only wrapped it in its corresponding namespace within the phonemizer's .cs file.

## About the G2P
The G2P processes the graphemes directly and translates it into phonemes, as the Filipino language has a more direct relation between orthography and phonology. The phoneme system is mostly based off of Filipino orthography to minimize confusion of the phonemes and make implementation of the G2P easier. There may still be a few edge cases that fail, but editing the spelling is made easy and predictable because of this rule-based system. Other behaviors like inserting vocal fry with ' and glottal stop with - is also implemented in the G2P

## Remarks
I've been thinking of a rule-based phonemizer for Filipino for a long time already because I figured it should be possible. Finally got the push to do it because of my own voicebank.