### PR TITLE
Clamp variance delta outputs for diffsinger acoustics&fix build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,10 +49,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Setup NSIS
-        uses: coolaj86/actions-setup-nsis@v1
-        with:
-          nsis-version: '3.11'
+      - name: Install NSIS via Chocolatey
+        run: choco install nsis --version=3.11 --no-progress
         if: ${{ matrix.arch.os == 'win' }}
       - uses: justalemon/VersionPatcher@v0.7.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: repolevedavaj/install-nsis@v1.0.3
+      - name: Setup NSIS
+        uses: coolaj86/actions-setup-nsis@v1
         with:
           nsis-version: '3.11'
         if: ${{ matrix.arch.os == 'win' }}

--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -361,7 +361,8 @@ namespace OpenUtau.Core.DiffSinger {
                         varianceResult.headFrames, varianceResult.tailFrames,
                         headFrames, tailFrames,
                         varianceResult.frameMs, frameMs);
-                    var energy = predictedEnergy.Zip(userEnergy, varianceDeltaFunctions[ENE]).ToArray();
+                    var energy = predictedEnergy.Zip(userEnergy, varianceDeltaFunctions[ENE])
+                        .Select(x => Math.Clamp(x, -96f, 0f)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("energy",
                         new DenseTensor<float>(energy, new int[] { energy.Length })
                         .Reshape(new int[] { 1, energy.Length })));
@@ -379,7 +380,8 @@ namespace OpenUtau.Core.DiffSinger {
                         varianceResult.headFrames, varianceResult.tailFrames,
                         headFrames, tailFrames,
                         varianceResult.frameMs, frameMs);
-                    var breathiness = predictedBreathiness.Zip(userBreathiness, varianceDeltaFunctions[Format.Ustx.BREC]).ToArray();
+                    var breathiness = predictedBreathiness.Zip(userBreathiness, varianceDeltaFunctions[Format.Ustx.BREC])
+                        .Select(x => Math.Clamp(x, -96f, 0f)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("breathiness",
                         new DenseTensor<float>(breathiness, new int[] { breathiness.Length })
                         .Reshape(new int[] { 1, breathiness.Length })));
@@ -397,7 +399,8 @@ namespace OpenUtau.Core.DiffSinger {
                         varianceResult.headFrames, varianceResult.tailFrames,
                         headFrames, tailFrames,
                         varianceResult.frameMs, frameMs);
-                    var voicing = predictedVoicing.Zip(userVoicing, varianceDeltaFunctions[Format.Ustx.VOIC]).ToArray();
+                    var voicing = predictedVoicing.Zip(userVoicing, varianceDeltaFunctions[Format.Ustx.VOIC])
+                        .Select(x => Math.Clamp(x, -96f, 0f)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("voicing",
                         new DenseTensor<float>(voicing, new int[] { voicing.Length })
                         .Reshape(new int[] { 1, voicing.Length })));
@@ -415,7 +418,8 @@ namespace OpenUtau.Core.DiffSinger {
                         varianceResult.headFrames, varianceResult.tailFrames,
                         headFrames, tailFrames,
                         varianceResult.frameMs, frameMs);
-                    var tension = predictedTension.Zip(userTension, varianceDeltaFunctions[Format.Ustx.TENC]).ToArray();
+                    var tension = predictedTension.Zip(userTension, varianceDeltaFunctions[Format.Ustx.TENC])
+                        .Select(x => Math.Clamp(x, -10f, 10f)).ToArray();
                     acousticInputs.Add(NamedOnnxValue.CreateFromTensor("tension",
                         new DenseTensor<float>(tension, new int[] { tension.Length })
                         .Reshape(new int[] { 1, tension.Length })));


### PR DESCRIPTION
Clamp computed variance delta arrays for acoustic features before creating ONNX input tensors. Energy, breathiness, and voicing are clamped to [-96f, 0f], and tension is clamped to [-10f, 10f]. This prevents extreme/out-of-range values from being passed to the model and helps stabilize rendering in DiffSingerRenderer.cs.