### PR TITLE
Fix speaker embed suffix resolution for subdirectory-organized .emb files

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
@@ -62,9 +62,15 @@ namespace OpenUtau.Core.DiffSinger
             if (speakerIndex >= 0) {
                 return speakerIndex;
             }
-            throw new Exception(
-                $"Speaker suffix \"{suffix}\" not found in dsConfig.speakers. " +
+            speakerIndex = dsConfig.speakers.FindIndex(
+                s => Path.GetFileName(s) == suffix);
+            if (speakerIndex >= 0) {
+                return speakerIndex;
+            }
+            Serilog.Log.Warning(
+                $"Speaker suffix \"{suffix}\" not found in dsConfig.speakers, falling back to first speaker. " +
                 $"Candidates: {string.Join(',', dsConfig.speakers)}.");
+            return 0;
         }
 
         //used by phonemizer (duration model)

--- a/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
@@ -63,8 +63,12 @@ namespace OpenUtau.Core.DiffSinger
             if (speakerIndex >= 0) {
                 return speakerIndex;
             }
-            speakerIndex = dsConfig.speakers.FindIndex(
-                s => Path.GetFileName(s) == suffix);
+            speakerIndex = dsConfig.speakers.FindIndex(s => {
+                var spSegs = s.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var sfSegs = suffix.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                return sfSegs.Length <= spSegs.Length
+                    && spSegs[^sfSegs.Length..].SequenceEqual(sfSegs);
+            });
             if (speakerIndex >= 0) {
                 return speakerIndex;
             }

--- a/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerSpeakerEmbedManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 using Microsoft.ML.OnnxRuntime.Tensors;
 using NumSharp;
+using Serilog;
 
 using OpenUtau.Core.Render;
 
@@ -67,7 +68,11 @@ namespace OpenUtau.Core.DiffSinger
             if (speakerIndex >= 0) {
                 return speakerIndex;
             }
-            Serilog.Log.Warning(
+            if (dsConfig.speakers.Count == 0) {
+                throw new InvalidOperationException(
+                    "Subbanks are defined in character.yaml but \"speakers\" is empty in dsconfig.yaml.");
+            }
+            Log.Warning(
                 $"Speaker suffix \"{suffix}\" not found in dsConfig.speakers, falling back to first speaker. " +
                 $"Candidates: {string.Join(',', dsConfig.speakers)}.");
             return 0;


### PR DESCRIPTION
## Summary

PR #2113 changed `getSpeakerIndexBySuffix` to throw when a suffix isn't found in `dsConfig.speakers`. This breaks voicebanks where `.emb` files are organized in subdirectories — a common pattern when keeping the folder structure clean.

## Root cause

When `.emb` files live in subdirectories, `dsConfig.speakers` contains pathful entries like `embeddings/acoustic/Soft`, but subbank suffixes (from `character.yaml`) are bare names like `Soft`. `IndexOf("Soft")` can't match `"embeddings/acoustic/Soft"`.

Before PR #2113 this silently fell back to speaker 0 — fragile but functional. After PR #2113 it throws, breaking rendering entirely.

This affects all four DiffSinger submodels uniformly since they share `DiffSingerSpeakerEmbedManager`: **acoustic**, **duration (dsdur)**, **pitch (dspitch)**, and **variance (dsvariance)**.

## Fix

Three-tier resolution in `getSpeakerIndexBySuffix`:

1. **Exact match** — `IndexOf(suffix)` against `dsConfig.speakers` (unchanged)
2. **Subpath match** — split both the speaker entry and the suffix into path components, then check if the suffix components form a trailing subpath. This handles bare filenames (`"Soft"` matches `"embeddings/acoustic/Soft"`), subdirectory suffixes (`"acoustic/Soft"` matches `"embeddings/acoustic/Soft"`), and `../`-relative prefixes uniformly.
3. **Fallback** — return 0 with a `Log.Warning`, same as pre-#2113 behavior. If the speakers list is empty, throw with a clear message naming both `character.yaml` subbanks and `dsconfig.yaml` speakers.

## Behavior examples

Voicebank layout: `.emb` files organized under `embeddings/{acoustic,pitch,variance,...}/`

```
my_singer/
├── character.yaml          # subbanks: [{suffix: "Soft"}, {suffix: "Power"}]
├── dsconfig.yaml           # speakers: [embeddings/acoustic/Soft, embeddings/acoustic/Power]
├── embeddings/
│   ├── acoustic/{Soft.emb, Power.emb}
│   ├── pitch/{Soft.emb, Power.emb}
│   └── variance/{Soft.emb, Power.emb}
├── dspitch/
│   └── dsconfig.yaml       # speakers: [../embeddings/pitch/Soft, ../embeddings/pitch/Power]
└── dsvariance/
    └── dsconfig.yaml       # speakers: [../embeddings/variance/Soft, ../embeddings/variance/Power]
```

Subbank suffix: `"Soft"`. Phone gets `suffix = "Soft"`.

### Example 1: Bare filename suffix with subdirectory speakers

suffix `"Soft"`, speakers `["embeddings/acoustic/Soft", "embeddings/acoustic/Power"]`

| Step | Before PR #2113 | After PR #2113 | After fix |
|------|-----------------|----------------|-----------|
| Tier 1: `IndexOf("Soft")` | -1 | -1 | -1 |
| Tier 2: `["Soft"]` suffix of `["embeddings","acoustic","Soft"]` | — | — | **0** ✓ |
| Fallback to 0 | ✓ (accidental) | throw ✗ | — |
| **Result** | speaker 0 ✓ | **render error** | speaker 0 ✓ |

### Example 2: Pathful suffix with subdirectory speakers

suffix `"acoustic/Soft"`, speakers `["embeddings/acoustic/Soft", "embeddings/acoustic/Power"]`

| Step | Before PR #2113 | After PR #2113 | After fix |
|------|-----------------|----------------|-----------|
| Tier 1: `IndexOf("acoustic/Soft")` | -1 | -1 | -1 |
| Tier 2: `["acoustic","Soft"]` suffix of `["embeddings","acoustic","Soft"]` | — | — | **0** ✓ |
| Fallback to 0 | ✓ (accidental) | throw ✗ | — |
| **Result** | speaker 0 ✓ | **render error** | speaker 0 ✓ |

### Example 3: Pitch model with `../`-relative speakers

suffix `"Soft"`, speakers `["../embeddings/pitch/Soft", "../embeddings/pitch/Power"]`

| Step | Before PR #2113 | After PR #2113 | After fix |
|------|-----------------|----------------|-----------|
| Tier 1: `IndexOf("Soft")` | -1 | -1 | -1 |
| Tier 2: `["Soft"]` suffix of `["..","embeddings","pitch","Soft"]` | — | — | **0** ✓ |
| Fallback to 0 | ✓ (accidental) | throw ✗ | — |
| **Result** | speaker 0 ✓ | **render error** | speaker 0 ✓ |

### Example 4: Exact match (unchanged)

suffix `"embeddings/acoustic/Soft"`, speakers `["embeddings/acoustic/Soft", ...]`

| Step | Before PR #2113 | After PR #2113 | After fix |
|------|-----------------|----------------|-----------|
| Tier 1: `IndexOf(...)` | 0 | 0 | 0 |
| **Result** | speaker 0 ✓ | speaker 0 ✓ | speaker 0 ✓ |

### Example 5: Suffix matches nothing (misconfigured)

suffix `"Unmatched"`, speakers `["singer1"]`

| Step | Before PR #2113 | After PR #2113 | After fix |
|------|-----------------|----------------|-----------|
| Tier 1 | -1 | -1 | -1 |
| Tier 2 | — | — | -1 |
| Tier 3 | silent fallback 0 | throw ✗ | **Log.Warning → 0** |
| **Result** | speaker 0 (silent) | **render error** | speaker 0 + warning |
