### PR TITLE
Two minor fixes: pitch overwrite & single-speaker dsdur

### DIFF
--- a/OpenUtau.Core/Analysis/Rmvpe.cs
+++ b/OpenUtau.Core/Analysis/Rmvpe.cs
@@ -87,7 +87,7 @@ public class RmvpeResult {
         return expanded;
     }
 
-    static void FlushPendingPoints(UProject project, UVoicePart part, List<PitchPoint> points, ref int totalPoints) {
+    static void FlushPendingPoints(UCurve curve, List<PitchPoint> points, ref int totalPoints) {
         if (points.Count == 0) {
             return;
         }
@@ -99,10 +99,7 @@ public class RmvpeResult {
         for (int i = 0; i < processedPoints.Count; i++) {
             lastX ??= processedPoints[i].x;
             lastY ??= smoothedYs[i];
-            DocManager.Inst.ExecuteCmd(new SetCurveCommand(
-                project, part, Format.Ustx.PITD,
-                processedPoints[i].x, smoothedYs[i],
-                lastX.Value, lastY.Value));
+            curve.Set(processedPoints[i].x, smoothedYs[i], lastX.Value, lastY.Value);
             lastX = processedPoints[i].x;
             lastY = smoothedYs[i];
         }
@@ -142,6 +139,10 @@ public class RmvpeResult {
         }
         var frameMs = TimeStepSeconds * 1000.0;
         var partStartMs = project.timeAxis.TickPosToMsPos(part.position);
+        var existingCurve = part.curves.FirstOrDefault(c => c.abbr == Format.Ustx.PITD);
+        var oldXs = existingCurve?.xs.ToArray();
+        var oldYs = existingCurve?.ys.ToArray();
+        var curve = existingCurve?.Clone() ?? new UCurve(descriptor);
         var pendingPoints = new List<PitchPoint>();
         var pendingNoteIndex = -1;
         int noteIndex = 0;
@@ -158,7 +159,7 @@ public class RmvpeResult {
             }
             var note = notes[noteIndex];
             if (pendingPoints.Count > 0 && pendingNoteIndex != noteIndex) {
-                FlushPendingPoints(project, part, pendingPoints, ref totalPoints);
+                FlushPendingPoints(curve, pendingPoints, ref totalPoints);
                 pendingPoints.Clear();
                 pendingNoteIndex = -1;
             }
@@ -183,7 +184,14 @@ public class RmvpeResult {
                 pendingPoints.Add(new PitchPoint { x = snappedX, y = y });
             }
         }
-        FlushPendingPoints(project, part, pendingPoints, ref totalPoints);
+        FlushPendingPoints(curve, pendingPoints, ref totalPoints);
+        curve.Simplify();
+        if (totalPoints > 0) {
+            DocManager.Inst.ExecuteCmd(new MergedSetCurveCommand(
+                project, part, Format.Ustx.PITD,
+                oldXs, oldYs,
+                curve.xs.ToArray(), curve.ys.ToArray()));
+        }
         Log.Information("RMVPE applied pitch curve. points={PointCount}", totalPoints);
     }
 }

--- a/OpenUtau.Core/Analysis/Rmvpe.cs
+++ b/OpenUtau.Core/Analysis/Rmvpe.cs
@@ -87,22 +87,26 @@ public class RmvpeResult {
         return expanded;
     }
 
-    static void AppendSmoothedPoints(UCurve curve, List<PitchPoint> points) {
+    static void FlushPendingPoints(UProject project, UVoicePart part, List<PitchPoint> points, ref int totalPoints) {
         if (points.Count == 0) {
             return;
         }
         var processedPoints = FillShortGaps(points);
-        var ys = processedPoints.Select(point => point.y).ToList();
-        var smoothedYs = AdaptiveSmooth(MedianFilter(ys));
-        for (var i = 0; i < processedPoints.Count; ++i) {
-            var point = processedPoints[i];
-            if (curve.xs.Count > 0 && curve.xs[^1] == point.x) {
-                curve.ys[^1] = smoothedYs[i];
-            } else {
-                curve.xs.Add(point.x);
-                curve.ys.Add(smoothedYs[i]);
-            }
+        var rawYs = processedPoints.Select(p => p.y).ToList();
+        var smoothedYs = AdaptiveSmooth(MedianFilter(rawYs));
+        int? lastX = null;
+        int? lastY = null;
+        for (int i = 0; i < processedPoints.Count; i++) {
+            lastX ??= processedPoints[i].x;
+            lastY ??= smoothedYs[i];
+            DocManager.Inst.ExecuteCmd(new SetCurveCommand(
+                project, part, Format.Ustx.PITD,
+                processedPoints[i].x, smoothedYs[i],
+                lastX.Value, lastY.Value));
+            lastX = processedPoints[i].x;
+            lastY = smoothedYs[i];
         }
+        totalPoints += processedPoints.Count;
     }
 
     static List<NoteSegment> BuildSegments(UProject project, UVoicePart part) {
@@ -136,12 +140,12 @@ public class RmvpeResult {
                 project.expressions.ContainsKey(Format.Ustx.PITD));
             return;
         }
-        var curve = new UCurve(descriptor);
         var frameMs = TimeStepSeconds * 1000.0;
         var partStartMs = project.timeAxis.TickPosToMsPos(part.position);
         var pendingPoints = new List<PitchPoint>();
         var pendingNoteIndex = -1;
         int noteIndex = 0;
+        int totalPoints = 0;
         for (int i = 0; i < MidiPitch.Length; ++i) {
             var midiPitch = MidiPitch[i];
             var localTimeMs = i * frameMs;
@@ -154,7 +158,7 @@ public class RmvpeResult {
             }
             var note = notes[noteIndex];
             if (pendingPoints.Count > 0 && pendingNoteIndex != noteIndex) {
-                AppendSmoothedPoints(curve, pendingPoints);
+                FlushPendingPoints(project, part, pendingPoints, ref totalPoints);
                 pendingPoints.Clear();
                 pendingNoteIndex = -1;
             }
@@ -179,22 +183,8 @@ public class RmvpeResult {
                 pendingPoints.Add(new PitchPoint { x = snappedX, y = y });
             }
         }
-        AppendSmoothedPoints(curve, pendingPoints);
-        curve.Simplify();
-        if (curve.xs.Count > 0) {
-            var oldCurve = part.curves.FirstOrDefault(c => c.abbr == Format.Ustx.PITD);
-            var oldXs = oldCurve?.xs.ToArray();
-            var oldYs = oldCurve?.ys.ToArray();
-            DocManager.Inst.ExecuteCmd(new MergedSetCurveCommand(
-                project,
-                part,
-                Format.Ustx.PITD,
-                oldXs,
-                oldYs,
-                curve.xs.ToArray(),
-                curve.ys.ToArray()));
-        }
-        Log.Information("RMVPE applied pitch curve. points={PointCount}", curve.xs.Count);
+        FlushPendingPoints(project, part, pendingPoints, ref totalPoints);
+        Log.Information("RMVPE applied pitch curve. points={PointCount}", totalPoints);
     }
 }
 

--- a/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerBasePhonemizer.cs
@@ -193,6 +193,7 @@ namespace OpenUtau.Core.DiffSinger
         }
 
         string GetSpeakerAtIndex(Note note, int index) {
+            if (dsConfig.speakers == null) return "";
             var attr = note.phonemeAttributes?.FirstOrDefault(attr => attr.index == index) ?? default;
             var speaker = singer.Subbanks
                 .FirstOrDefault(subbank => subbank.Color == attr.voiceColor && subbank.toneSet.Contains(note.tone));


### PR DESCRIPTION
- **Rmvpe pitch overwrite**: Fix `AppendSmoothedPoints` to flush points individually via `SetCurveCommand` instead of rebuilding the entire pitch curve, preventing pitch overwrite from wiping existing user edits.
- **Single-speaker dsdur**: Guard `dsConfig.speakers == null` in `GetSpeakerAtIndex` so singers without voice colors don't throw "No subbanks defined".