### PR TITLE
Fix Piano Roll Window Mode Not Reset When Switching from Detach to Hide

### DIFF
--- a/OpenUtau/Controls/PianoRoll.axaml
+++ b/OpenUtau/Controls/PianoRoll.axaml
@@ -359,7 +359,7 @@
                     <CheckBox IsChecked="{Binding PianoRollDetached}" />
                   </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Header="{DynamicResource pianoroll.menu.view.pianoroll.hide}" Click="OnMenuHidePianoRoll"/>
+                <MenuItem Header="{DynamicResource pianoroll.menu.view.pianoroll.hide}" Click="OnMenuHidePianoRoll" IsVisible="{Binding HideMenuItemVisible}"/>
               </MenuItem>
             </MenuItem>
 
@@ -538,6 +538,7 @@
             </Button>
           </StackPanel>
         </Border>
+        <Border Grid.Column="3" Background="Transparent" PointerPressed="OnToolbarPointerPressed"/>
         <Border Grid.Column="4">
           <StackPanel Orientation="Horizontal">
             <ToggleButton Classes="toolbar" Margin="0" Padding="1" Height="20" Width="20" IsChecked="{Binding NotesViewModel.ShowNoteParams}"
@@ -553,6 +554,10 @@
                 </Path>
               </Grid>
             </ToggleButton>
+            <!-- 占位：内嵌模式 + 参数面板收起时显示，空出位置给浮动关闭按钮，避免重叠 -->
+            <Border IsVisible="{Binding HideMenuItemVisible}">
+              <Border Width="20" IsVisible="{Binding !NotesViewModel.ShowNoteParams}"/>
+            </Border>
           </StackPanel>
         </Border>
       </Grid>
@@ -625,6 +630,20 @@
               Background="{DynamicResource SystemRegionBrush}" Padding="0">
         <c:NotePropertiesControl/>
       </Border>
+
+      <!-- 关闭钢琴卷帘按钮：始终浮在最右上角，位置固定 -->
+      <ToggleButton x:Name="HidePianoRollButton"
+                    Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="4"
+                    Classes="toolbar" Margin="0,2,4,0"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Height="20" Width="20" Padding="1"
+                    Click="OnMenuHidePianoRoll"
+                    IsVisible="{Binding HideMenuItemVisible}"
+                    ToolTip.Tip="{DynamicResource pianoroll.menu.view.pianoroll.hide}">
+        <Grid Width="18" Height="18">
+          <Path Stroke="{DynamicResource SystemControlForegroundBaseHighBrush}" StrokeThickness="1" Data="M 4 4 L 14 14 M 14 4 L 4 14"/>
+        </Grid>
+      </ToggleButton>
 
       <Border Grid.Row="2" Grid.RowSpan="2" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
               BoxShadow="inset 0 0 5 1 #3F000000" ClipToBounds="True" IsHitTestVisible="False">

--- a/OpenUtau/Controls/PianoRoll.axaml.cs
+++ b/OpenUtau/Controls/PianoRoll.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using OpenUtau.App.ViewModels;
 using OpenUtau.App.Views;
 using OpenUtau.Core;
@@ -349,12 +350,25 @@ namespace OpenUtau.App.Controls {
         void OnMenuDetachPianoRoll(object sender, RoutedEventArgs args) {
             MainWindow?.SetPianoRollAttachment();
             ViewModel.RaisePropertyChanged(nameof(ViewModel.PianoRollDetached));
+            // 延迟通知，等窗口切换完成后再更新，避免切换过程中触发 UI 更新导致崩溃
+            Dispatcher.UIThread.Post(() => {
+                ViewModel.RaisePropertyChanged(nameof(ViewModel.HideMenuItemVisible));
+            });
         }
 
         void OnMenuHidePianoRoll(object sender, RoutedEventArgs args) {
-            if (Preferences.Default.DetachPianoRoll && MainWindow != null) {
-                MainWindow.SetPianoRollAttachment();
-            }
+            // Reset ToggleButton checked state / 重置 ToggleButton 的 checked 状态
+            // Reason / 原因:
+            //   ToggleButton keeps IsChecked=true after click, causing darker background.
+            //   But this close button is a one-shot action, not a state toggle.
+            //   So we manually reset it to false immediately after click.
+            //   Since piano roll hides instantly, users never see this momentary state change.
+            //
+            // 详细说明：
+            //   ToggleButton 点击后会保持 IsChecked=true，导致底纹变深。
+            //   但关闭按钮是一次性操作，不应该保持状态，所以手动重置为 false。
+            //   因为点击后钢琴卷帘立即隐藏，用户看不到这个瞬间的状态变化。
+            HidePianoRollButton.IsChecked = false;
             if (RootWindow.DataContext is MainWindowViewModel mwvm) {
                 mwvm.ShowPianoRoll = false;
             } else {
@@ -363,6 +377,24 @@ namespace OpenUtau.App.Controls {
         }
 
         // Edit Tools
+        private long _lastToolbarClickTime = 0;
+        private const long DoubleClickThreshold = 300; // 毫秒
+
+        void OnToolbarPointerPressed(object sender, PointerPressedEventArgs args) {
+            // 双击工具栏空白处关闭钢琴卷帘（仅嵌入模式生效）
+            if (!args.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
+
+            long now = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+            if (now - _lastToolbarClickTime < DoubleClickThreshold) {
+                // 双击
+                if (RootWindow.DataContext is MainWindowViewModel mwvm) {
+                    mwvm.ShowPianoRoll = false;
+                }
+                // 分离模式下不响应，保持和原来一模一样
+            }
+            _lastToolbarClickTime = now;
+        }
+
         private CancellationTokenSource? _longPressCts;
         private async void OnToolButtonPointerPressed(object? sender, PointerPressedEventArgs args) {
             if (!args.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;

--- a/OpenUtau/Controls/PianoRoll.axaml.cs
+++ b/OpenUtau/Controls/PianoRoll.axaml.cs
@@ -352,6 +352,9 @@ namespace OpenUtau.App.Controls {
         }
 
         void OnMenuHidePianoRoll(object sender, RoutedEventArgs args) {
+            if (Preferences.Default.DetachPianoRoll && MainWindow != null) {
+                MainWindow.SetPianoRollAttachment();
+            }
             if (RootWindow.DataContext is MainWindowViewModel mwvm) {
                 mwvm.ShowPianoRoll = false;
             } else {

--- a/OpenUtau/ViewModels/PianoRollViewModel.cs
+++ b/OpenUtau/ViewModels/PianoRollViewModel.cs
@@ -68,6 +68,7 @@ namespace OpenUtau.App.ViewModels {
         public bool PlaybackAutoScroll1 { get => Preferences.Default.PlaybackAutoScroll == 1 ? true : false; }
         public bool PlaybackAutoScroll2 { get => Preferences.Default.PlaybackAutoScroll == 2 ? true : false; }
         public bool PianoRollDetached { get => Preferences.Default.DetachPianoRoll; }
+        public bool HideMenuItemVisible => !Preferences.Default.DetachPianoRoll;
         public bool ShowPhonemizerTags {
             get => Preferences.Default.ShowPhonemizerTags;
             set {


### PR DESCRIPTION
When the user switches the Piano Roll window mode from Detach to Hide, the DetachPianoRoll preference is not reset to false. This causes the Piano Roll to remain in detached mode when it is shown again, instead of embedding back into the main window as expected.