### PR TITLE
Fix to ensure that `Bar` is always rendered

### DIFF
--- a/OpenUtau/Controls/TickBackground.cs
+++ b/OpenUtau/Controls/TickBackground.cs
@@ -151,8 +151,8 @@ namespace OpenUtau.App.Controls {
                     using (var state = context.PushTransform(Matrix.CreateTranslation(x + 3, 10))) {
                         textLayout.Draw(context, new Point());
                     }
-                    context.DrawLine(penBar, new Point(x, y), new Point(x, Bounds.Height + 0.5f));
                 }
+                context.DrawLine(penBar, new Point(x, y), new Point(x, Bounds.Height + 0.5f));
                 // Lines between bars.
                 var timeSig = project.timeAxis.TimeSignatureAtBar(bar);
                 int nextBarTick = project.timeAxis.BarBeatToTickPos(bar + 1, 0);


### PR DESCRIPTION
Before
<img width="720" height="200" alt="image" src="https://github.com/user-attachments/assets/15169445-2bd4-481b-8f73-d69e24fb9b93" />
After
<img width="303" height="184" alt="image" src="https://github.com/user-attachments/assets/512c72c4-c83a-4732-8335-657d7ffe4032" />