### PR TITLE
Change the default of d4c_option.threshold to match conventional synthesis results.

### DIFF
--- a/cpp/worldline/worldline.cpp
+++ b/cpp/worldline/worldline.cpp
@@ -141,7 +141,7 @@ DLL_API void WorldAnalysisF0In(const AnalysisConfig* config, float* samples,
 
   D4COption d4c_option;
   InitializeD4COption(&d4c_option);
-  // d4c_option.threshold = 0;
+  d4c_option.threshold = 0;
   D4C(samples_vec.data(), samples_vec.size(), config->fs, ts_vec.data(), f0_in,
       num_frames, config->fft_size, &d4c_option, ap_2d);
 


### PR DESCRIPTION
Explicitly set the initialization of d4c_option.threshold

In worldline.cpp, the initialization code for d4c_option.threshold has been changed from a comment to active code. This ensures that the behavior remains consistent with previous versions.

There have been reports on Twitter and Discord for some time now that the synthesis results have changed, causing inconvenience. Therefore, I would like to request a fix.

Before
<img width="1698" height="955" alt="image" src="https://github.com/user-attachments/assets/3f52b129-2bf7-4ee9-9c07-c9c0006da860" />
After
<img width="1595" height="1027" alt="image" src="https://github.com/user-attachments/assets/1cf308ba-cecc-4dbf-9763-1166d6e7b07e" />
