### PR TITLE
Fix DiffSinger vocoder output sample rate

### DIFF
--- a/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
+++ b/OpenUtau.Core/DiffSinger/DiffSingerRenderer.cs
@@ -507,6 +507,11 @@ namespace OpenUtau.Core.DiffSinger {
                 throw new Exception($"The shape of vocoder output should be (1, length), but the actual shape is {DiffSingerUtils.ShapeString(samplesTensor)}");
             }
             var samples = samplesTensor.ToArray();
+            if (vocoder.sample_rate != 44100) {
+                var signal = new NWaves.Signals.DiscreteSignal(vocoder.sample_rate, samples);
+                signal = NWaves.Operations.Operation.Resample(signal, 44100);
+                samples = signal.Samples;
+            }
             return samples;
         }
 


### PR DESCRIPTION
Resamples DiffSinger vocoder output to 44.1 kHz before it enters the fixed-rate audio pipeline.

This fixes incorrect pitch and duration with non-44.1 kHz vocoders, such as 48 kHz models.

